### PR TITLE
Reduces fiftyone-teams-app image from 2.0GB to 1.6GB

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,76 +41,42 @@
 # voxel51.com
 #
 
-# The base image to build from; must be Debian-based (eg Ubuntu)
-ARG BASE_IMAGE=ubuntu:20.04
-FROM $BASE_IMAGE
+ARG PYTHON_VERSION=3.10
 
-# The Python version to install. Must be >= 3.9
-ARG PYTHON_VERSION=3.9
+FROM python:${PYTHON_VERSION}-buster as builder
 
-#
-# Install system packages
-#
-
-RUN apt -y update \
-    && apt -y --no-install-recommends install software-properties-common \
-    && add-apt-repository -y ppa:deadsnakes/ppa \
-    && apt -y update \
-    && apt -y upgrade \
-    && apt -y --no-install-recommends install tzdata \
-    && TZ=Etc/UTC \
-    && apt -y --no-install-recommends install \
-        build-essential \
-        ca-certificates \
-        cmake \
-        cmake-data \
-        pkg-config \
-        libcurl4 \
-        libsm6 \
-        libxext6 \
-        libssl-dev \
-        libffi-dev \
-        libxml2-dev \
-        libxslt1-dev \
-        zlib1g-dev \
-        unzip \
-        curl \
-        wget \
-        python${PYTHON_VERSION} \
-        python${PYTHON_VERSION}-dev \
-        python${PYTHON_VERSION}-distutils \
-        ffmpeg \
-    && ln -s /usr/bin/python${PYTHON_VERSION} /usr/local/bin/python \
-    && ln -s /usr/local/lib/python${PYTHON_VERSION} /usr/local/lib/python \
-    && curl https://bootstrap.pypa.io/get-pip.py | python \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN pip --no-cache-dir install --upgrade pip setuptools wheel ipython
-
-#
-# Install FiftyOne Teams
-#
-
-# Your install token
+ARG TEAMS_APP_VERSION
 ARG TOKEN
+ARG INDEX_URL=https://${TOKEN}@pypi.fiftyone.ai
 
-# The Teams App version to install, or "latest"
-ARG TEAMS_APP_VERSION=0.2.2
+RUN pip --no-cache-dir install --upgrade pip setuptools wheel ipython \
+    && pip wheel --wheel-dir=/tmp/wheels --index-url ${INDEX_URL} fiftyone-teams-app==${TEAMS_APP_VERSION}
 
-RUN if [ "${TEAMS_APP_VERSION}" = "latest" ]; then \
-        pip --no-cache-dir install --index-url https://${TOKEN}@pypi.fiftyone.ai fiftyone-teams-app; \
-    else \
-        pip --no-cache-dir install --index-url https://${TOKEN}@pypi.fiftyone.ai fiftyone-teams-app==${TEAMS_APP_VERSION}; \
-    fi
 
-#
-# Configure shared storage
-#
+FROM python:${PYTHON_VERSION}-slim-buster as release
 
-ENV FIFTYONE_MEDIA_CACHE_SIZE_BYTES=-1 \
+WORKDIR /opt
+
+ENV FIFTYONE_DATABASE_ADMIN=false \
+    FIFTYONE_DATABASE_NAME=fiftyone \
     FIFTYONE_MEDIA_CACHE_APP_IMAGES=false \
-    FIFTYONE_DATABASE_ADMIN=false \
-    FIFTYONE_DATABASE_NAME=fiftyone
+    FIFTYONE_MEDIA_CACHE_SIZE_BYTES=-1 \
+    VIRTUAL_ENV=/opt/fiftyone-teams-app \
+    PATH="${VIRTUAL_ENV}/bin:${PATH}" \
+    TZ=Etc/UTC
+
+# Update the base image, install ffmpeg, create the voxel51 user, install fiftyone-teams-app
+RUN --mount=type=cache,from=builder,target=/builder,ro \
+    apt -y update && apt -y upgrade \
+    && apt install -y --no-install-recommends ffmpeg \
+    && apt clean && rm -rf /var/lib/apt/lists/* \
+    && useradd -l -U -d /opt voxel51 \
+    && python3 -m venv "${VIRTUAL_ENV}" \
+    && pip --no-cache-dir install --no-index --find-links=/builder/tmp/wheels fiftyone-teams-app \
+    && chown --changes --silent --no-dereference --recursive voxel51:voxel51 /opt
+
+# run as the voxel51 user
+USER voxel51
 
 #
 # Serve the app

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,22 +7,24 @@
 #
 # OPTIONAL BUILD ARGs::
 #
-#   BASE_IMAGE (ubuntu:20.04): The Debian-based image to build from
-#   PYTHON_VERSION (3.9): The Python version to install. Must be >= 3.9
-#   ROOT_DIR (/fiftyone): The name of the directory within the container that
-#       should be mounted when running
+#   PYTHON_VERSION (3.10): The Python version to install. Must be >= 3.9
+#   TEAMS_APP_VERSION (0.2.2): The version of fiftyone-teams-app to install.
+#   INDEX_URL (https://${TOKEN}@pypi.fiftyone.ai): The URL to install fiftyone-teams-app from
 #
 # REQUIRED RUNTIME ENV VARS::
 #
 #   FIFTYONE_DATABASE_URI: your MongoDB database URI
 #   FIFTYONE_TEAMS_CLIENT_ID: your application client ID
 #   FIFTYONE_TEAMS_ORGANIZATION: your organization's authentication ID
+#
+# OPTIONAL RUNTIME ENV VARS::
+#
 #   (your cloud storage credentials)
 #
 # Example usage::
 #
 #   # Build
-#   docker build \
+#   DOCKER_BUILDKIT=1 docker build \
 #       --build-arg TOKEN=${TOKEN} \
 #       -t voxel51/fiftyone-teams-app .
 #
@@ -33,7 +35,7 @@
 #       -e FIFTYONE_TEAMS_CLIENT_ID=... \
 #       -e FIFTYONE_TEAMS_ORGANIZATION=... \
 #       -e AWS_CONFIG_FILE=/fiftyone/aws-credentials.ini \
-#       -v ${SHARED_DIR}:/fiftyone \
+#       -v /path/to/aws-credentials.ini:/fiftyone/aws-credentials.ini \
 #       -p 5151:5151 \
 #       -it voxel51/fiftyone-teams-app
 #
@@ -45,7 +47,7 @@ ARG PYTHON_VERSION=3.10
 
 FROM python:${PYTHON_VERSION}-buster as builder
 
-ARG TEAMS_APP_VERSION
+ARG TEAMS_APP_VERSION=0.2.2
 ARG TOKEN
 ARG INDEX_URL=https://${TOKEN}@pypi.fiftyone.ai
 
@@ -61,18 +63,22 @@ ENV FIFTYONE_DATABASE_ADMIN=false \
     FIFTYONE_DATABASE_NAME=fiftyone \
     FIFTYONE_MEDIA_CACHE_APP_IMAGES=false \
     FIFTYONE_MEDIA_CACHE_SIZE_BYTES=-1 \
-    VIRTUAL_ENV=/opt/fiftyone-teams-app \
-    PATH="${VIRTUAL_ENV}/bin:${PATH}" \
-    TZ=Etc/UTC
+    TZ=Etc/UTC \
+    VIRTUAL_ENV=/opt/fiftyone-teams-app
 
-# Update the base image, install ffmpeg, create the voxel51 user, install fiftyone-teams-app
-RUN --mount=type=cache,from=builder,target=/builder,ro \
-    apt -y update && apt -y upgrade \
+# Update the base image, install ffmpeg, create the voxel51 user
+RUN apt -y update && apt -y upgrade \
     && apt install -y --no-install-recommends ffmpeg \
     && apt clean && rm -rf /var/lib/apt/lists/* \
     && useradd -l -U -d /opt voxel51 \
-    && python3 -m venv "${VIRTUAL_ENV}" \
-    && pip --no-cache-dir install --no-index --find-links=/builder/tmp/wheels fiftyone-teams-app \
+    && python3 -m venv "${VIRTUAL_ENV}"
+
+# Activate the virtual env
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+
+# Install fiftyone-teams-app and chown everything to voxel51
+RUN --mount=type=cache,from=builder,target=/builder,ro \
+    pip --no-cache-dir install --no-index --find-links=/builder/tmp/wheels fiftyone-teams-app \
     && chown --changes --silent --no-dereference --recursive voxel51:voxel51 /opt
 
 # run as the voxel51 user
@@ -81,5 +87,4 @@ USER voxel51
 #
 # Serve the app
 #
-
 CMD hypercorn fiftyone.teams.app:app --bind "${FIFTYONE_DEFAULT_APP_ADDRESS:-0.0.0.0}":"${FIFTYONE_DEFAULT_APP_PORT:-5151}"


### PR DESCRIPTION
I know, it really doesn't seem like a lot, but it's almost 20%

-The recommended Dockerfile now uses a multi-build approach and uses the python:3.10-slim-buster image as the base image.
- New build time is 106s compared to 160.1s using the old Dockerfile.
- New container installs fiftyone-teams-app in a virtual-environment.
- New container runs fiftyone-teams-app as the `voxel51` users instead of running as root.

The container built with this image has been deployed to voxel51.dev.fiftyone.ai running fiftyone-teams-app v0.2.2.