### PR TITLE
adds nodeport support for NodePort Services

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -128,6 +128,7 @@ You can find a full `values.yaml` with all of the optional values [here](https:/
 | `apiSettings.service.containerPort`                              | 8000                       | Port for FiftyOne Teams API Containers                                    |
 | `apiSettings.service.liveness.initialDelaySeconds`               | 45                         | Delay before Liveness checks for FiftyOne Teams API containers            |
 | `apiSettings.service.name`                                       | teams-api                  | FiftyOne Teams API service name                                           |
+| `apiSettings.service.nodePort`                                   | None                       | `nodePort` for Service Type `NodePort`                                    |
 | `apiSettings.service.port`                                       | 80                         | FiftyOne Teams API service port                                           |
 | `apiSettings.service.readiness.initialDelaySeconds`              | 45                         | Delay before Readiness checks for FiftyOne Teams API containers           |
 | `apiSettings.service.shortname`                                  | teams-api                  | Short name for port definitions (less than 15 characters)                 |
@@ -159,6 +160,7 @@ You can find a full `values.yaml` with all of the optional values [here](https:/
 | `appSettings.service.containerPort`                              | 5151                       | Port for FiftyOne App Containers                                          |
 | `appSettings.service.liveness.initialDelaySeconds`               | 45                         | Delay before Liveness checks for FiftyOne App containers                  |
 | `appSettings.service.name`                                       | fiftyone-app               | FiftyOne App service name                                                 |
+| `appSettings.service.nodePort`                                   | None                       | `nodePort` for Service Type `NodePort`                                    |
 | `appSettings.service.port`                                       | 80                         | FiftyOne App service port                                                 |
 | `appSettings.service.readiness.initialDelaySeconds`              | 45                         | Delay before Readiness checks for FiftyOne App containers                 |
 | `appSettings.service.shortname`                                  | fiftyone-app               | Shirt name for port definitions (less than 15 characters)                 |
@@ -204,6 +206,7 @@ You can find a full `values.yaml` with all of the optional values [here](https:/
 | `teamsAppSettings.service.containerPort`                         | 3000                       | Port for FiftyOne Teams App containers                                    |
 | `teamsAppSettings.service.liveness.initialDelaySeconds`          | 45                         | Delay before Liveness checks for FiftyOne Teams App containers            |
 | `teamsAppSettings.service.name`                                  | teams-app                  | FiftyOne Teams App service name                                           |
+| `teamsAppSettings.service.nodePort`                              | None                       | `nodePort` for Service Type `NodePort`                                    |
 | `teamsAppSettings.service.port`                                  | 80                         | FiftyOne Teams App service port                                           |
 | `teamsAppSettings.service.readiness.initialDelaySeconds`         | 45                         | Delay before Readiness checks for FiftyOne Teams App containers           |
 | `teamsAppSettings.service.shortname`                             | teams-app                  | Short name for port definitions (less than 15 characters)                 |

--- a/helm/fiftyone-teams-app/Chart.yaml
+++ b/helm/fiftyone-teams-app/Chart.yaml
@@ -3,6 +3,6 @@ name: fiftyone-teams-app
 namespace: fiftyone-teams
 description: A FiftyOne Teams Helm Chart
 type: application
-version: 1.1.2-beta1
+version: 1.1.2-beta2
 appVersion: "v1.1.1"
 icon: https://voxel51.com/images/logo/voxel51-logo-horz-color-600dpi.png

--- a/helm/fiftyone-teams-app/templates/api-service.yaml
+++ b/helm/fiftyone-teams-app/templates/api-service.yaml
@@ -12,5 +12,8 @@ spec:
       targetPort: {{ .Values.apiSettings.service.containerPort | default 8000 }}
       protocol: TCP
       name: http
+      {{- if and (eq .Values.apiSettings.service.type "NodePort") (.Values.apiSettings.service.nodePort) }}
+      nodePort: {{ .Values.apiSettings.service.nodePort }}
+      {{- end }}
   selector:
     {{- include "fiftyone-teams-api.selectorLabels" . | nindent 4 }}

--- a/helm/fiftyone-teams-app/templates/app-service.yaml
+++ b/helm/fiftyone-teams-app/templates/app-service.yaml
@@ -12,5 +12,8 @@ spec:
       targetPort: {{ .Values.appSettings.service.containerPort | default 5151 }}
       protocol: TCP
       name: http
+      {{- if and (eq .Values.appSettings.service.type "NodePort") (.Values.appSettings.service.nodePort) }}
+      nodePort: {{ .Values.appSettings.service.nodePort }}
+      {{- end }}
   selector:
     {{- include "fiftyone-app.selectorLabels" . | nindent 4 }}

--- a/helm/fiftyone-teams-app/templates/teams-app-service.yaml
+++ b/helm/fiftyone-teams-app/templates/teams-app-service.yaml
@@ -12,5 +12,8 @@ spec:
       targetPort: {{ .Values.teamsAppSettings.service.containerPort | default 3000 }}
       protocol: TCP
       name: http
+      {{- if and (eq .Values.teamsAppSettings.service.type "NodePort") (.Values.teamsAppSettings.service.nodePort) }}
+      nodePort: {{ .Values.teamsAppSettings.service.nodePort }}
+      {{- end }}
   selector:
     {{- include "fiftyone-teams-app.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
Services of type NodePort allow for a `nodePort` to be set to handle loadbalancing.

This change allows the addition of a `nodePort` parameter when the Service Type is `NodePort`

Rendering with ClusterIP:
```
---
# Source: fiftyone-teams-app/templates/api-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: teams-api
  namespace: staging-fiftyone-ai
  labels:
    helm.sh/chart: fiftyone-teams-app-1.1.2-beta2
    app.kubernetes.io/version: "v1.1.1"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: teams-api
    app.kubernetes.io/instance: fiftyone-teams-app
spec:
  type: ClusterIP
  ports:
    - port: 1234
      targetPort: 8000
      protocol: TCP
      name: http
  selector:
    app.kubernetes.io/name: teams-api
    app.kubernetes.io/instance: fiftyone-teams-app
```

Rendering ClusterIP with `nodePort` set (invalid configuration):
```
❯ grep -B1 -A1 nodePort staging-values.yaml
  service:
    nodePort: 30002
    port: 1234

❯ helm template fiftyone-teams-app ./fiftyone-teams-app-1.1.2-beta2.tgz -f staging-values.yaml -s templates/api-service.yaml

---
# Source: fiftyone-teams-app/templates/api-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: teams-api
  namespace: staging-fiftyone-ai
  labels:
    helm.sh/chart: fiftyone-teams-app-1.1.2-beta2
    app.kubernetes.io/version: "v1.1.1"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: teams-api
    app.kubernetes.io/instance: fiftyone-teams-app
spec:
  type: ClusterIP
  ports:
    - port: 1234
      targetPort: 8000
      protocol: TCP
      name: http
  selector:
    app.kubernetes.io/name: teams-api
    app.kubernetes.io/instance: fiftyone-teams-app
```

Render with Type `NodePort` and no `nodePort` defined:
```
---
# Source: fiftyone-teams-app/templates/api-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: teams-api
  namespace: staging-fiftyone-ai
  labels:
    helm.sh/chart: fiftyone-teams-app-1.1.2-beta2
    app.kubernetes.io/version: "v1.1.1"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: teams-api
    app.kubernetes.io/instance: fiftyone-teams-app
spec:
  type: NodePort
  ports:
    - port: 1234
      targetPort: 8000
      protocol: TCP
      name: http
  selector:
    app.kubernetes.io/name: teams-api
    app.kubernetes.io/instance: fiftyone-teams-app
```

Render with Type `NodePort` and `nodePort` defined:
```
---
# Source: fiftyone-teams-app/templates/api-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: teams-api
  namespace: staging-fiftyone-ai
  labels:
    helm.sh/chart: fiftyone-teams-app-1.1.2-beta2
    app.kubernetes.io/version: "v1.1.1"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: teams-api
    app.kubernetes.io/instance: fiftyone-teams-app
spec:
  type: NodePort
  ports:
    - port: 1234
      targetPort: 8000
      protocol: TCP
      name: http
      nodePort: 30032
  selector:
    app.kubernetes.io/name: teams-api
    app.kubernetes.io/instance: fiftyone-teams-app
```