### PR TITLE
Adds an option for adding the API service to the Ingress Controller

### DIFF
--- a/helm/fiftyone-teams-app/Chart.yaml
+++ b/helm/fiftyone-teams-app/Chart.yaml
@@ -3,6 +3,6 @@ name: fiftyone-teams-app
 namespace: fiftyone-teams
 description: A FiftyOne Teams Helm Chart
 type: application
-version: 1.1.2-beta2
+version: 1.1.2-beta3
 appVersion: "v1.1.1"
 icon: https://voxel51.com/images/logo/voxel51-logo-horz-color-600dpi.png

--- a/helm/fiftyone-teams-app/templates/_helpers.tpl
+++ b/helm/fiftyone-teams-app/templates/_helpers.tpl
@@ -37,7 +37,7 @@ Create a default name for the fiftyone app service
 {{/*
 Create a default name for the teams api service
 */}}
-{{- define "fiftyone-teams-api.name" -}}
+{{- define "teams-api.name" -}}
 {{- if .Values.apiSettings.service.name }}
 {{- .Values.apiSettings.service.name | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -78,7 +78,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 API Selector labels
 */}}
 {{- define "fiftyone-teams-api.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "fiftyone-teams-api.name" . }}
+app.kubernetes.io/name: {{ include "teams-api.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 

--- a/helm/fiftyone-teams-app/templates/api-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/api-deployment.yaml
@@ -1,16 +1,16 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "fiftyone-teams-api.name" . }}
+  name: {{ include "teams-api.name" . }}
   namespace: {{ .Values.namespace.name }}
   labels:
-    app: {{ include "fiftyone-teams-api.name" . }}
+    app: {{ include "teams-api.name" . }}
     {{- include "fiftyone-teams-api.labels" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ include "fiftyone-teams-api.name" . }}
+      app: {{ include "teams-api.name" . }}
       {{- include "fiftyone-teams-api.selectorLabels" . | nindent 6 }}
   template:
     metadata:
@@ -19,7 +19,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        app: {{ include "fiftyone-teams-api.name" . }}
+        app: {{ include "teams-api.name" . }}
         {{- include "fiftyone-teams-api.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
@@ -30,7 +30,7 @@ spec:
       securityContext:
         {{- toYaml .Values.apiSettings.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ include "fiftyone-teams-api.name" . }}
+        - name: {{ include "teams-api.name" . }}
           securityContext:
             {{- toYaml .Values.apiSettings.securityContext | nindent 12 }}
           image: "{{ .Values.apiSettings.image.repository }}:{{ .Values.apiSettings.image.tag | default .Chart.AppVersion }}"

--- a/helm/fiftyone-teams-app/templates/api-service.yaml
+++ b/helm/fiftyone-teams-app/templates/api-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "fiftyone-teams-api.name" . }}
+  name: {{ include "teams-api.name" . }}
   namespace: {{ .Values.namespace.name }}
   labels:
     {{- include "fiftyone-teams-api.labels" . | nindent 4 }}

--- a/helm/fiftyone-teams-app/templates/ingress.yaml
+++ b/helm/fiftyone-teams-app/templates/ingress.yaml
@@ -44,15 +44,15 @@ spec:
             {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: {{ .pathType }}
             {{- end }}
-          {{- end }}
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
-                name: {{ include "teams-app.name" . }}
+                name: {{ include "teams-app.name" $ }}
                 port:
-                  number: {{ .Values.teamsAppSettings.service.port }}
+                  number: {{ $.Values.teamsAppSettings.service.port }}
               {{- else }}
-              serviceName: {{ include "teams-app.name" . }}
-              servicePort: {{ .Values.teamsAppSettings.service.port }}
+              serviceName: {{ include "teams-app.name" $ }}
+              servicePort: {{ $.Values.teamsAppSettings.service.port }}
               {{- end }}
+          {{- end }}
 {{- end }}

--- a/helm/fiftyone-teams-app/templates/ingress.yaml
+++ b/helm/fiftyone-teams-app/templates/ingress.yaml
@@ -33,12 +33,16 @@ spec:
   tls:
     - hosts:
         - {{ .Values.teamsAppSettings.dnsName | quote }}
+        {{- if .Values.apiSettings.dnsName }}
+        - {{ .Values.apiSettings.dnsName | quote }}
+        {{- end }}
       secretName: {{ .Values.ingress.tlsSecretName }}
   {{- end }}
   rules:
     - host: {{ .Values.teamsAppSettings.dnsName | quote }}
       http:
         paths:
+          {{- if .Values.ingress.paths }}
           {{- range .Values.ingress.paths }}
           - path: {{ .path }}
             {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
@@ -55,4 +59,39 @@ spec:
               servicePort: {{ $.Values.teamsAppSettings.service.port }}
               {{- end }}
           {{- end }}
+          {{- else }}
+          - path: {{ .Values.ingress.teamsApp.path }}
+            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
+            pathType: {{ .Values.ingress.teamsApp.pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ include "teams-app.name" . }}
+                port:
+                  number: {{ .Values.teamsAppSettings.service.port }}
+              {{- else }}
+              serviceName: {{ include "teams-app.name" . }}
+              servicePort: {{ .Values.teamsAppSettings.service.port }}
+              {{- end }}
+          {{- end }}
+    {{- if .Values.apiSettings.dnsName }}
+    - host: {{ .Values.apiSettings.dnsName | quote }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.api.path }}
+            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
+            pathType: {{ .Values.ingress.api.pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ include "teams-api.name" . }}
+                port:
+                  number: {{ .Values.apiSettings.service.port }}
+              {{- else }}
+              serviceName: {{ include "teams-api.name" . }}
+              servicePort: {{ .Values.apiSettings.service.port }}
+              {{- end }}
+    {{- end }}
 {{- end }}

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -195,10 +195,13 @@ serviceAccount:
 ingress:
   # If you are configuring your own ingress controller, set this to 'false'
   annotations: {}
+  # api:
+  #   path: /*
+  #   pathType: ImplementationSpecific
   className: ""
   enabled: true
-  paths:
-    - path: /*
-      pathType: ImplementationSpecific
+  teamsApp:
+    path: /*
+    pathType: ImplementationSpecific
   tlsEnabled: true
   tlsSecretName: fiftyone-teams-tls-secret


### PR DESCRIPTION
We need to expose the API service in the future for SDK access; this provides an opportunity for that.

Existing values.yaml files render with a null diff.
values.yaml files with `ingress.paths` defined render using the old mechanism for backwards compatibility.

