### PR TITLE
updates for Teams v1.3.3

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -17,7 +17,7 @@ The `fiftyone-teams-app`, `fiftyone-teams-api`, and `fiftyone-app` images are av
 
 ## Initial Installation vs. Upgrades
 
-`FIFTYONE_DATABASE_ADMIN` is set to `false` by default for FiftyOne Teams version 1.3.2. This is because FiftyOne Teams version 1.3.2 is backwards compatible with FiftyOne Teams database schema version 0.19 (Teams Version 1.1) and newer.
+`FIFTYONE_DATABASE_ADMIN` is set to `false` by default for FiftyOne Teams version 1.3.3. This is because FiftyOne Teams version 1.3.3 is backwards compatible with FiftyOne Teams database schema version 0.19 (Teams Version 1.1) and newer.
 
 - If you are performing an initial install, you will either want to set `FIFTYONE_DATABASE_ADMIN: true` in the `environment` section of the `fiftyone-app` service definition.
 
@@ -110,7 +110,7 @@ Voxel51 recommends using a `compose.override.yaml` to [override the image select
 version: '3.8'
 services:
   fiftyone-app:
-    image: voxel51/fiftyone-app-torch:v1.3.2
+    image: voxel51/fiftyone-app-torch:v1.3.3
 ```
 
 ## Upgrade Process Recommendations
@@ -121,37 +121,37 @@ Please contact your Voxel51 Customer Success team member to coordinate this upgr
 
 ### Upgrade Process Recommendations From Before FiftyOne Teams Version 1.1.0
 
-The FiftyOne 0.13.2 SDK (database version 0.21.2) is _NOT_ backwards-compatible with FiftyOne Teams Database Versions prior to 0.19.0, and the FiftyOne 0.10.x SDK is not forwards compatible with current FiftyOne Teams Database Versions. If you are using a FiftyOne SDK older than 0.11.0, upgrading the Web server will require upgrading all FiftyOne SDK installations.
+The FiftyOne 0.13.3 SDK (database version 0.21.3) is _NOT_ backwards-compatible with FiftyOne Teams Database Versions prior to 0.19.0, and the FiftyOne 0.10.x SDK is not forwards compatible with current FiftyOne Teams Database Versions. If you are using a FiftyOne SDK older than 0.11.0, upgrading the Web server will require upgrading all FiftyOne SDK installations.
 
 Voxel51 recommends the following upgrade process for upgrading from versions prior to FiftyOne Teams version 1.1.0:
 
 1. Make sure your installation includes the required [FIFTYONE_ENCRYPTION_KEY](#fiftyone-teams-upgrade-notes) environment variable
 1. If you are using a proxy server, make sure you have configured the appropriate [proxy environment variables](#environment-proxies)
 
-1. [Upgrade to FiftyOne Teams version 1.3.2](#deploying-fiftyone-teams) with `FIFTYONE_DATABASE_ADMIN=true` (this is not the default in the `config.yaml` for this release).<br>
-   **NOTE:** FiftyOne SDK users will lose access to the FiftyOne Teams Database at this step until they upgrade to `fiftyone==0.13.2`
-1. Upgrade your FiftyOne SDKs to version 0.13.2<br>
+1. [Upgrade to FiftyOne Teams version 1.3.3](#deploying-fiftyone-teams) with `FIFTYONE_DATABASE_ADMIN=true` (this is not the default in the `config.yaml` for this release).<br>
+   **NOTE:** FiftyOne SDK users will lose access to the FiftyOne Teams Database at this step until they upgrade to `fiftyone==0.13.3`
+1. Upgrade your FiftyOne SDKs to version 0.13.3<br>
    The command line for installing the FiftyOne SDK associated with your FiftyOne Teams version is available in the FiftyOne Teams UI under `Account > Install FiftyOne` after a user has logged in.
-1. Use `fiftyone migrate --info` to make sure that all datasets have been migrated to version 0.21.2.
+1. Use `fiftyone migrate --info` to make sure that all datasets have been migrated to version 0.21.3.
    - If not all datasets have been upgraded, an admin can run `FIFTYONE_DATABASE_ADMIN=true fiftyone migrate
    --all` in their local environment
 
 
 ### Upgrade Process Recommendations From FiftyOne Teams Version 1.1.0 and later
 
-The FiftyOne 0.13.2 SDK (database version 0.21.2) is backwards-compatible with FiftyOne Teams Database Versions 0.19.0 and later, but the FiftyOne 0.11.0 SDK is _NOT_ forward compatible with FiftyOne Teams Database Version 0.21.2.
+The FiftyOne 0.13.3 SDK (database version 0.21.3) is backwards-compatible with FiftyOne Teams Database Versions 0.19.0 and later, but the FiftyOne 0.11.0 SDK is _NOT_ forward compatible with FiftyOne Teams Database Version 0.21.3.
 
 Voxel51 always recommends using the latest version of the FiftyOne SDK compatible with your FiftyOne Teams deployment.
 
 Voxel51 recommends the following upgrade process for upgrading from FiftyOne Teams version 1.1.0 or later:
 
 1. Ensure all FiftyOne SDK users set `FIFTYONE_DATABASE_ADMIN=false` or `unset FIFTYONE_DATABASE_ADMIN` (this should generally be your default)
-1. [Upgrade to FiftyOne Teams version 1.3.2](#deploying-fiftyone-teams)
-1. Upgrade FiftyOne Teams SDK users to FiftyOne Teams version 0.13.2<br>
+1. [Upgrade to FiftyOne Teams version 1.3.3](#deploying-fiftyone-teams)
+1. Upgrade FiftyOne Teams SDK users to FiftyOne Teams version 0.13.3<br>
    The command line for installing the FiftyOne SDK associated with your FiftyOne Teams version is available in the FiftyOne Teams UI under `Account > Install FiftyOne` after a user has logged in.
 1. Have the admin run `FIFTYONE_DATABASE_ADMIN=true fiftyone migrate --all` to upgrade all datasets<br>
-   **NOTE** Any FiftyOne SDK less than 0.13.2 will lose database connectivity at this point; upgrading to `fiftyone==0.13.2` is required
-1. Use `fiftyone migrate --info` to ensure that all datasets are now at version 0.21.2.
+   **NOTE** Any FiftyOne SDK less than 0.13.3 will lose database connectivity at this point; upgrading to `fiftyone==0.13.3` is required
+1. Use `fiftyone migrate --info` to ensure that all datasets are now at version 0.21.3.
 
 ---
 

--- a/docker/compose.dedicated-plugins.yaml
+++ b/docker/compose.dedicated-plugins.yaml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   teams-api:
-    image: voxel51/fiftyone-teams-api:v1.3.2
+    image: voxel51/fiftyone-teams-api:v1.3.3
     environment:
       AUTH0_CLIENT_ID: ${AUTH0_CLIENT_ID}
       AUTH0_AUDIENCE: ${AUTH0_AUDIENCE}
@@ -32,7 +32,7 @@ services:
     volumes:
       - plugins-vol:/opt/plugins
   teams-app:
-    image: voxel51/fiftyone-teams-app:v1.3.2
+    image: voxel51/fiftyone-teams-app:v1.3.3
     environment:
       API_URL: ${API_URL}
       AUTH0_AUDIENCE: ${AUTH0_AUDIENCE}
@@ -43,7 +43,7 @@ services:
       AUTH0_ORGANIZATION: ${AUTH0_ORGANIZATION}
       AUTH0_SECRET: ${AUTH0_SECRET}
       APP_USE_HTTPS: ${APP_USE_HTTPS:-true}
-      FIFTYONE_APP_TEAMS_SDK_RECOMMENDED_VERSION: 0.13.2
+      FIFTYONE_APP_TEAMS_SDK_RECOMMENDED_VERSION: 0.13.3
       FIFTYONE_SERVER_ADDRESS: ""
       FIFTYONE_SERVER_PATH_PREFIX: /api/proxy/fiftyone-teams
       FIFTYONE_TEAMS_PLUGIN_URL: ${FIFTYONE_TEAMS_PLUGIN_URL}
@@ -66,7 +66,7 @@ services:
       - ${APP_BIND_ADDRESS}:${APP_BIND_PORT}:3000
     restart: always
   fiftyone-app:
-    image: voxel51/fiftyone-app:v1.3.2
+    image: voxel51/fiftyone-app:v1.3.3
     environment:
       API_URL: ${API_URL}
       FIFTYONE_DATABASE_ADMIN: false
@@ -95,7 +95,7 @@ services:
       - ${FIFTYONE_DEFAULT_APP_ADDRESS}:${FIFTYONE_DEFAULT_APP_PORT}:5151
     restart: always
   teams-plugins:
-    image: voxel51/fiftyone-app:v1.3.2
+    image: voxel51/fiftyone-app:v1.3.3
     environment:
       API_URL: ${API_URL}
       FIFTYONE_DATABASE_ADMIN: false

--- a/docker/compose.plugins.yaml
+++ b/docker/compose.plugins.yaml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   teams-api:
-    image: voxel51/fiftyone-teams-api:v1.3.2
+    image: voxel51/fiftyone-teams-api:v1.3.3
     environment:
       AUTH0_CLIENT_ID: ${AUTH0_CLIENT_ID}
       AUTH0_AUDIENCE: ${AUTH0_AUDIENCE}
@@ -32,7 +32,7 @@ services:
     volumes:
       - plugins-vol:/opt/plugins
   teams-app:
-    image: voxel51/fiftyone-teams-app:v1.3.2
+    image: voxel51/fiftyone-teams-app:v1.3.3
     environment:
       API_URL: ${API_URL}
       AUTH0_AUDIENCE: ${AUTH0_AUDIENCE}
@@ -43,7 +43,7 @@ services:
       AUTH0_ORGANIZATION: ${AUTH0_ORGANIZATION}
       AUTH0_SECRET: ${AUTH0_SECRET}
       APP_USE_HTTPS: ${APP_USE_HTTPS:-true}
-      FIFTYONE_APP_TEAMS_SDK_RECOMMENDED_VERSION: 0.13.2
+      FIFTYONE_APP_TEAMS_SDK_RECOMMENDED_VERSION: 0.13.3
       FIFTYONE_SERVER_ADDRESS: ""
       FIFTYONE_SERVER_PATH_PREFIX: /api/proxy/fiftyone-teams
       FIFTYONE_TEAMS_PROXY_URL: ${FIFTYONE_TEAMS_PROXY_URL}
@@ -65,7 +65,7 @@ services:
       - ${APP_BIND_ADDRESS}:${APP_BIND_PORT}:3000
     restart: always
   fiftyone-app:
-    image: voxel51/fiftyone-app:v1.3.2
+    image: voxel51/fiftyone-app:v1.3.3
     environment:
       API_URL: ${API_URL}
       FIFTYONE_DATABASE_ADMIN: false

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   teams-api:
-    image: voxel51/fiftyone-teams-api:v1.3.2
+    image: voxel51/fiftyone-teams-api:v1.3.3
     environment:
       AUTH0_CLIENT_ID: ${AUTH0_CLIENT_ID}
       AUTH0_AUDIENCE: ${AUTH0_AUDIENCE}
@@ -29,7 +29,7 @@ services:
       - ${API_BIND_ADDRESS}:${API_BIND_PORT}:8000
     restart: always
   teams-app:
-    image: voxel51/fiftyone-teams-app:v1.3.2
+    image: voxel51/fiftyone-teams-app:v1.3.3
     environment:
       API_URL: ${API_URL}
       AUTH0_AUDIENCE: ${AUTH0_AUDIENCE}
@@ -40,7 +40,7 @@ services:
       AUTH0_ORGANIZATION: ${AUTH0_ORGANIZATION}
       AUTH0_SECRET: ${AUTH0_SECRET}
       APP_USE_HTTPS: ${APP_USE_HTTPS:-true}
-      FIFTYONE_APP_TEAMS_SDK_RECOMMENDED_VERSION: 0.13.2
+      FIFTYONE_APP_TEAMS_SDK_RECOMMENDED_VERSION: 0.13.3
       FIFTYONE_SERVER_ADDRESS: ""
       FIFTYONE_SERVER_PATH_PREFIX: /api/proxy/fiftyone-teams
       FIFTYONE_TEAMS_PROXY_URL: ${FIFTYONE_TEAMS_PROXY_URL}
@@ -62,7 +62,7 @@ services:
       - ${APP_BIND_ADDRESS}:${APP_BIND_PORT}:3000
     restart: always
   fiftyone-app:
-    image: voxel51/fiftyone-app:v1.3.2
+    image: voxel51/fiftyone-app:v1.3.3
     environment:
       API_URL: ${API_URL}
       FIFTYONE_DATABASE_ADMIN: false

--- a/helm/README.md
+++ b/helm/README.md
@@ -21,7 +21,7 @@ The `fiftyone-teams-app`, `fiftyone-teams-api`, and `fiftyone-app` images are av
 
 ## Initial Installation vs. Upgrades
 
-`FIFTYONE_DATABASE_ADMIN` is set to `false` by default for FiftyOne Teams version 1.3.2. This is because FiftyOne Teams version 1.3.2 is backwards compatible with FiftyOne Teams database schema 0.19 (Teams Version 1.1) and newer.
+`FIFTYONE_DATABASE_ADMIN` is set to `false` by default for FiftyOne Teams version 1.3.3. This is because FiftyOne Teams version 1.3.3 is backwards compatible with FiftyOne Teams database schema 0.19 (Teams Version 1.1) and newer.
 
 - If you are performing an initial install, you will either want to add `FIFTYONE_DATABASE_ADMIN: true` in the `env` section of the `appSettings` configuration.
 
@@ -306,31 +306,31 @@ Please contact your Voxel51 Customer Success team member to coordinate this upgr
 
 ### Upgrade Process Recommendations From Before FiftyOne Teams Version 1.1.0
 
-The FiftyOne 0.13.2 SDK (database version 0.21.2) is _NOT_ backwards-compatible with FiftyOne Teams Database Versions prior to 0.19.0, and the FiftyOne 0.10 SDK is not forwards compatible with current FiftyOne Teams Database Versions. If you are using a FiftyOne SDK older than 0.11.0, upgrading the Web server will require upgrading all FiftyOne SDK installations before the SDK can interact with the database.
+The FiftyOne 0.13.3 SDK (database version 0.21.3) is _NOT_ backwards-compatible with FiftyOne Teams Database Versions prior to 0.19.0, and the FiftyOne 0.10 SDK is not forwards compatible with current FiftyOne Teams Database Versions. If you are using a FiftyOne SDK older than 0.11.0, upgrading the Web server will require upgrading all FiftyOne SDK installations before the SDK can interact with the database.
 
 Voxel51 recommends the following upgrade process for upgrading from versions prior to FiftyOne Teams version 1.1.0:
 
 1. Make sure your installation includes the required [FIFTYONE_ENCRYPTION_KEY](#fiftyone-teams-upgrade-notes) environment variable
-1. [Upgrade to FiftyOne Teams version 1.3.2](#deploying-fiftyone-teams) with `appSettings.env.FIFTYONE_DATABASE_ADMIN: true` (this is not the default in the Helm Chart for this release).<br>
-   **NOTE:** FiftyOne SDK users will lose access to the FiftyOne Teams Database at this step until they upgrade to `fiftyone==0.13.2`
-1. Upgrade your FiftyOne SDKs to version 0.13.2<br>
+1. [Upgrade to FiftyOne Teams version 1.3.3](#deploying-fiftyone-teams) with `appSettings.env.FIFTYONE_DATABASE_ADMIN: true` (this is not the default in the Helm Chart for this release).<br>
+   **NOTE:** FiftyOne SDK users will lose access to the FiftyOne Teams Database at this step until they upgrade to `fiftyone==0.13.3`
+1. Upgrade your FiftyOne SDKs to version 0.13.3<br>
    The command line for installing the FiftyOne SDK associated with your FiftyOne Teams version is available in the FiftyOne Teams UI under `Account > Install FiftyOne` after a user has logged in.
-1. Have an admin run `FIFTYONE_DATABASE_ADMIN=true fiftyone migrate --all` in their local environment to upgrade all datasets to version 0.21.2
+1. Have an admin run `FIFTYONE_DATABASE_ADMIN=true fiftyone migrate --all` in their local environment to upgrade all datasets to version 0.21.3
 
 ### Upgrade Process Recommendations From FiftyOne Teams Version 1.1.0 and later
 
-The FiftyOne 0.13.2 SDK (database version 0.21.2) is backwards-compatible with FiftyOne Teams Database Versions after-and-including 0.19.0, but FiftyOne SDKs before version 0.13.2 are _not_ forwards-compatible with FiftyOne Database Version 0.21.2.
+The FiftyOne 0.13.3 SDK (database version 0.21.3) is backwards-compatible with FiftyOne Teams Database Versions after-and-including 0.19.0, but FiftyOne SDKs before version 0.13.3 are _not_ forwards-compatible with FiftyOne Database Version 0.21.3.
 
 Voxel51 always recommends using the latest version of the FiftyOne SDK compatible with your FiftyOne Teams deployment.
 
 Voxel51 recommends the following upgrade process for upgrading from FiftyOne Teams version 1.1.0 or later:
 
 1. Ensure all FiftyOne SDK users set `FIFTYONE_DATABASE_ADMIN=false` or `unset FIFTYONE_DATABASE_ADMIN` (this should generally be your default)
-1. [Upgrade to FiftyOne Teams version 1.3.2](#deploying-fiftyone-teams)
-1. Upgrade FiftyOne Teams SDK users to FiftyOne Teams version 0.13.2<br>
+1. [Upgrade to FiftyOne Teams version 1.3.3](#deploying-fiftyone-teams)
+1. Upgrade FiftyOne Teams SDK users to FiftyOne Teams version 0.13.3<br>
    The command line for installing the FiftyOne SDK associated with your FiftyOne Teams version is available in the FiftyOne Teams UI under `Account > Install FiftyOne` after a user has logged in.
 1. Have the admin run `FIFTYONE_DATABASE_ADMIN=true fiftyone migrate --all` to upgrade all datasets
-1. Use `fiftyone migrate --info` to ensure that all datasets are now at version 0.21.2
+1. Use `fiftyone migrate --info` to ensure that all datasets are now at version 0.21.3
 
 ---
 

--- a/helm/docs/expose-teams-api.md
+++ b/helm/docs/expose-teams-api.md
@@ -22,7 +22,7 @@ You can expose your `teams-api` service in any manner that suits your deployment
 ## Adding a second host to the Ingress Controller (host-based routing)
 
 1. set `apiSettings.dnsName` to the hostname to route API requests to (e.g. demo-api.fiftyone.ai)
-1. upgrade your deployment using the v1.3.2 Helm chart:
+1. upgrade your deployment using the latest Helm chart:
     ```
 	helm repo update voxel51
     helm upgrade fiftyone-teams-app voxel51/fiftyone-teams-app -f ./values.yaml

--- a/helm/fiftyone-teams-app/Chart.yaml
+++ b/helm/fiftyone-teams-app/Chart.yaml
@@ -3,6 +3,6 @@ name: fiftyone-teams-app
 namespace: fiftyone-teams
 description: A FiftyOne Teams Helm Chart
 type: application
-version: 1.3.2
-appVersion: "v1.3.2"
+version: 1.3.3
+appVersion: "v1.3.3"
 icon: https://voxel51.com/images/logo/voxel51-logo-horz-color-600dpi.png

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -199,7 +199,7 @@ teamsAppSettings:
     targetMemoryUtilizationPercentage: 80
   env:
     APP_USE_HTTPS: true
-    FIFTYONE_APP_TEAMS_SDK_RECOMMENDED_VERSION: 0.13.2
+    FIFTYONE_APP_TEAMS_SDK_RECOMMENDED_VERSION: 0.13.3
     RECOIL_DUPLICATE_ATOM_KEY_CHECKING_ENABLED: false
   image:
     repository: voxel51/fiftyone-teams-app

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -35,7 +35,7 @@ secret:
 # appSettings:
 #   dnsName: your-api.hostname.here
 #   env:
-#    FIFTYONE_DATABASE_ADMIN is set to `false` by default for v1.3.2 installs
+#    FIFTYONE_DATABASE_ADMIN is set to `false` by default for v1.3.3 installs
 #     If you are performing a new install or an upgrade from v1.0 or earlier you may want to set
 #     this value to `true`.
 #     Please see https://helm.fiftyone.ai/#initial-installation-vs-upgrades for details


### PR DESCRIPTION
bumping helm and docker compose versions, bumping versions in documentation

```
❯ ack -l '0.13.2'
❯ ack -l '1.3.2'
❯ ack -l '0.21.2'
❯
```