### PR TITLE
In `values.yaml` files, move `dnsName` from `appSettings` to `apiSetti…

### DIFF
--- a/helm/gke-example/values.yaml
+++ b/helm/gke-example/values.yaml
@@ -29,11 +29,12 @@ secret:
     encryptionKey:
 
 
-#apiSettings:
+# apiSettings:
+#   dnsName: your-api.hostname.here
 
-#appSettings:
-#  env:
-#    FIFTYONE_DATABASE_ADMIN: true
+# appSettings:
+#   env:
+#     FIFTYONE_DATABASE_ADMIN: true
 
 teamsAppSettings:
   dnsName: replace.this.dns.name

--- a/helm/gke-example/values.yaml
+++ b/helm/gke-example/values.yaml
@@ -30,7 +30,6 @@ secret:
 
 
 # apiSettings:
-#   dnsName: your-api.hostname.here
 
 # appSettings:
 #   env:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -34,9 +34,9 @@ secret:
 #     See https://github.com/voxel51/fiftyone-teams-app-deploy/tree/main/helm#enabling-fiftyone-teams-plugins
 #   env:
 #     FIFTYONE_PLUGINS_DIR: /opt/plugins
+#   dnsName: your-api.hostname.here
 
 # appSettings:
-#   dnsName: your-api.hostname.here
 #   env:
 #    FIFTYONE_DATABASE_ADMIN is set to `false` by default for v1.4.0 installs
 #     If you are performing a new install or an upgrade from v1.0 or earlier you may want to set

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -29,12 +29,15 @@ secret:
     encryptionKey:
 
 # apiSettings:
+#   Set `dnsName` to expose the API with host-based routing.
+#   See https://helm.fiftyone.ai/docs/expose-teams-api.html for more information.
+#   dnsName: your-api.hostname.here
+#   env:
 #     Set FIFTYONE_PLUGINS_DIR if you are enabling plugins in a dedicated
 #       `teams-plugins` deployment
 #     See https://github.com/voxel51/fiftyone-teams-app-deploy/tree/main/helm#enabling-fiftyone-teams-plugins
-#   env:
 #     FIFTYONE_PLUGINS_DIR: /opt/plugins
-#   dnsName: your-api.hostname.here
+
 
 # appSettings:
 #   env:


### PR DESCRIPTION
…ngs` (where the helm templates reference it).

While asking questions to Topher, he noticed that our `dnsName` should belong to `apiSettings` instead of  `appSettings`.