### PR TITLE
revert CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @voxel51/aloha-shirts


### PR DESCRIPTION
Removed codeowners that contains an error:

> Unknown owner on line 1: make sure the team @voxel51/aloha-shirts exists, is publicly visible, and has write access to the repository
>   * @voxel51/aloha-shirts

