### PR TITLE
bump versions in prep for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
 
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.4.1
+        uses: helm/chart-releaser-action@v1.4.2
         with:
           charts_dir: helm
         env:

--- a/docker/README.md
+++ b/docker/README.md
@@ -25,12 +25,49 @@ For Docker Hub credentials, please contact your Voxel51 support team.
 
 ## Initial Installation vs. Upgrades
 
-By default, `FIFTYONE_DATABASE_ADMIN` is set to `false` for FiftyOne Teams version 1.4.2.
+When performing an initial installation, in `compose.yaml` set
+`services.fiftyone-app.environment.FIFTYONE_DATABASE_ADMIN: true`.
+When performing a FiftyOne Teams upgrade, set `services.fiftyone-app.environment.FIFTYONE_DATABASE_ADMIN: false`.
+See [Upgrade Process Recommendations](#upgrade-process-recommendations).
 
-- When performing an initial installation, in `compose.yaml` set
-  `services.fiftyone-app.environment.FIFTYONE_DATABASE_ADMIN: true`
-- When performing an upgrade, please review our
-  [Upgrade Process Recommendations](#upgrade-process-recommendations)
+The environment variable `FIFTYONE_DATABASE_ADMIN` controls whether the database may be migrated.
+This is a safety check to prevent automatic database upgrades that will break other users' SDK connections.
+When false (or unset), either an error will occur
+
+```shell
+$ fiftyone migrate --all
+Traceback (most recent call last):
+...
+OSError: Cannot migrate database from v0.22.1 to v0.22.0 when database_admin=False.
+```
+
+or no action will be taken:
+
+```shell
+$ fiftyone migrate --info
+FiftyOne Teams version: 0.14.2
+
+FiftyOne compatibility version: 0.22.1
+Other compatible versions: >=0.19,<0.23
+
+Database version: 0.22.0
+
+dataset     version
+----------  ---------
+quickstart  0.22.0
+$ fiftyone migrate --all
+$ fiftyone migrate --info
+FiftyOne Teams version: 0.14.2
+
+FiftyOne compatibility version: 0.22.1
+Other compatible versions: >=0.19,<0.23
+
+Database version: 0.22.0
+
+dataset     version
+----------  ---------
+quickstart  0.22.0
+```
 
 ---
 
@@ -60,6 +97,9 @@ There are three modes for plugins
       [./compose.plugins.yaml](./compose.plugins.yaml)
       instead of
       [./compose.yaml](./compose.yaml)
+    - Containers need the following access to plugin storage
+      - `fiftyone-app` requires `read`
+      - `fiftyone-api` requires `read-write`
     - Example `docker compose` command for this mode
 
         ```shell
@@ -74,6 +114,9 @@ There are three modes for plugins
       [./compose.dedicated-plugins.yaml](./compose.dedicated-plugins.yaml)
       instead of the
       [./compose.yaml](./compose.yaml)
+    - Containers need the following access to plugin storage
+      - `teams-plugins` requires `read`
+      - `fiftyone-api` requires `read-write`
     - Example `docker compose` command for this mode
 
         ```shell
@@ -83,21 +126,15 @@ There are three modes for plugins
           up -d
         ```
 
-Both [./compose.plugins.yaml](./compose.plugins.yaml)
+Both
+[./compose.plugins.yaml](./compose.plugins.yaml)
 and
 [./compose.dedicated-plugins.yaml](./compose.dedicated-plugins.yaml)
 create a new Docker Volume shared between FiftyOne Teams services.
 For multi-node deployments, please implement a storage solution allowing the access the deployed plugins.
 
-- If plugins share the `fiftyone-app` deployment
-  - `fiftyone-app` containers require `read` access to plugin storage
-  - `fiftyone-api` containers require `read-write` access to plugin storage
-- If plugins are run in a dedicated `teams-plugins` deployment
-  - `teams-plugins` containers require `read` access to plugin storage
-  - `fiftyone-api` containers require `read-write` access to plugin storage
-
-Deploy plugins using the FiftyOne Teams UI at `/settings/plugins`.
-Any early-adopter plugins installed via manual methods must be redeployed using the FiftyOne Teams UI.
+Use the FiftyOne Teams UI to deploy plugins by navigating to `https://<DEPOY_URL>/settings/plugins`.
+Early-adopter plugins installed manually must be redeployed using the FiftyOne Teams UI.
 
 #### Storage Credentials and `FIFTYONE_ENCRYPTION_KEY`
 
@@ -112,6 +149,7 @@ print(Fernet.generate_key().decode())
 ```
 
 Voxel51 does not have access to this encryption key and cannot reproduce it.
+Please store this key in a safe place.
 If the key is lost, you will need to
 
 1. Schedule an outage window
@@ -119,16 +157,14 @@ If the key is lost, you will need to
     1. Replace the encryption key
     1. Add the storage credentials via the UI again.
 
-Voxel51 strongly recommends storing this key in a safe place.
-
 Storage credentials no longer need to be mounted into containers with appropriate environment variables being set.
-Users with `Admin` permissions may add supported storage credentials using `/settings/cloud_storage_credentials` in the Web UI.
+Users with `Admin` permissions may use the FiftyOne Teams UI to manage storage credentials by navigating to `https://<DEPOY_URL>/settings/cloud_storage_credentials`.
 
-FiftyOne Teams version 1.3+ continues to support the use of environment variables to set storage credentials and is providing an alternate UI-centric configuration path.
+FiftyOne Teams version 1.3+ continues to support the use of environment variables to set storage credentials in the application context and is providing an alternate configuration path for future functionality.
 
 #### Environment Proxies
 
-FiftyOne Teams version 1.1 and higher support routing traffic through proxy servers.
+FiftyOne Teams supports routing traffic through proxy servers.
 To configure this, set following environment variables on
 
 1. All containers
@@ -142,7 +178,7 @@ To configure this, set following environment variables on
     NO_PROXY: ${NO_PROXY_LIST}
     ```
 
-1. All containers based on the `fiftyone-teams-app` image also require
+1. All containers based on the `fiftyone-teams-app` image
 
     ```yaml
     GLOBAL_AGENT_HTTP_PROXY: ${HTTP_PROXY_URL}
@@ -176,10 +212,9 @@ FiftyOne Teams version 1.2 and higher supports using text similarity searches fo
 To use this feature, use a container image containing `torch` (PyTorch) instead of the `fiftyone-app` image.
 Use the Voxel51 provided image `fiftyone-app-torch` or build your own base image including `torch`.
 
-Voxel51 recommends using a `compose.override.yaml` to
-[override the image selection](https://docs.docker.com/compose/extends/).
+To override the default image, update `compose.override.yaml` with the value for image.
 This will allow you to update your `compose.yaml` in future releases without having to port this change forward.
-An example `compose.override.yaml` for this situation might look like:
+For example, `compose.override.yaml` might look like:
 
 ```yaml
 version: '3.8'
@@ -188,12 +223,15 @@ services:
     image: voxel51/fiftyone-app-torch:v1.4.2
 ```
 
+For more information, see the docs for
+[Docker Compose Extend](https://docs.docker.com/compose/extends/).
+
 ## Upgrade Process Recommendations
 
 ### From Early Adopter Versions (Versions less than 1.0)
 
 Please contact your Voxel51 Customer Success team member to coordinate this upgrade.
-You will need to either create a new IdP or modify your existing configuration in order to migrate to a new Auth0 Tenant.
+To migrate to a new Auth0 Tenant, you will need to create a new IdP or modify your existing configuration.
 
 ### From Before FiftyOne Teams Version 1.1.0
 
@@ -201,20 +239,24 @@ The FiftyOne 0.14.2 SDK (database version 0.22.1) is _NOT_ backwards-compatible 
 The FiftyOne 0.10.x SDK is not forwards compatible with current FiftyOne Teams Database Versions.
 If you are using a FiftyOne SDK older than 0.11.0, upgrading the Web server will require upgrading all FiftyOne SDK installations.
 
-Voxel51 recommends the following upgrade process for upgrading from versions prior to FiftyOne Teams version 1.1.0:
+Voxel51 recommends this upgrade process from versions prior to FiftyOne Teams version 1.1.0:
 
 1. Make sure your installation includes the required
    [FIFTYONE_ENCRYPTION_KEY](#fiftyone-teams-upgrade-notes)
    environment variable
 1. [Upgrade to FiftyOne Teams version 1.4.2](#deploying-fiftyone-teams)
    with `FIFTYONE_DATABASE_ADMIN=true`
-   (this is not the default in the `config.yaml` for this release).
+   (this is not the default in the `compose.yaml` for this release).
     - **NOTE:** FiftyOne SDK users will lose access to the
       FiftyOne Teams Database at this step until they upgrade to `fiftyone==0.14.2`
 1. Upgrade your FiftyOne SDKs to version 0.14.2
     - Login to the FiftyOne Teams UI
     - To obtain the CLI command to install the FiftyOne SDK associated with your FiftyOne Teams version, navigate to `Account > Install FiftyOne`
-1. Run `fiftyone migrate --info` to ensure all datasets have been migrated to version 0.22.1.
+1. Check if datasets have been migrated to version 0.22.1.
+
+    ```shell
+    fiftyone migrate --info
+    ```
    - If not all datasets have been upgraded, have an admin run
 
       ```shell
@@ -246,6 +288,12 @@ Voxel51 recommends the following upgrade process for upgrading from FiftyOne Tea
 
     - **NOTE** Any FiftyOne SDK less than 0.14.2 will lose database connectivity at this point. Upgrading to `fiftyone==0.14.2` is required
 
+1. To ensure that all datasets are now at version 0.22.0, run
+
+    ```shell
+    fiftyone migrate --info
+    ```
+
 ---
 
 ## Deploying FiftyOne Teams
@@ -261,8 +309,7 @@ Voxel51 recommends the following upgrade process for upgrading from FiftyOne Tea
     docker-compose up -d
     ```
 
-1. Have the admin run  to upgrade all datasets
-
+1. Have the admin run to upgrade all datasets
 
     ```shell
     FIFTYONE_DATABASE_ADMIN=true fiftyone migrate --all

--- a/docker/README.md
+++ b/docker/README.md
@@ -25,7 +25,7 @@ For Docker Hub credentials, please contact your Voxel51 support team.
 
 ## Initial Installation vs. Upgrades
 
-By default, `FIFTYONE_DATABASE_ADMIN` is set to `false` for FiftyOne Teams version 1.4.1.
+By default, `FIFTYONE_DATABASE_ADMIN` is set to `false` for FiftyOne Teams version 1.4.2.
 
 - When performing an initial installation, in `compose.yaml` set
   `services.fiftyone-app.environment.FIFTYONE_DATABASE_ADMIN: true`
@@ -185,7 +185,7 @@ An example `compose.override.yaml` for this situation might look like:
 version: '3.8'
 services:
   fiftyone-app:
-    image: voxel51/fiftyone-app-torch:v1.4.1
+    image: voxel51/fiftyone-app-torch:v1.4.2
 ```
 
 ## Upgrade Process Recommendations
@@ -197,7 +197,7 @@ You will need to either create a new IdP or modify your existing configuration i
 
 ### From Before FiftyOne Teams Version 1.1.0
 
-The FiftyOne 0.14.1 SDK (database version 0.22.0) is _NOT_ backwards-compatible with FiftyOne Teams Database Versions prior to 0.19.0.
+The FiftyOne 0.14.2 SDK (database version 0.22.1) is _NOT_ backwards-compatible with FiftyOne Teams Database Versions prior to 0.19.0.
 The FiftyOne 0.10.x SDK is not forwards compatible with current FiftyOne Teams Database Versions.
 If you are using a FiftyOne SDK older than 0.11.0, upgrading the Web server will require upgrading all FiftyOne SDK installations.
 
@@ -206,15 +206,15 @@ Voxel51 recommends the following upgrade process for upgrading from versions pri
 1. Make sure your installation includes the required
    [FIFTYONE_ENCRYPTION_KEY](#fiftyone-teams-upgrade-notes)
    environment variable
-1. [Upgrade to FiftyOne Teams version 1.4.1](#deploying-fiftyone-teams)
+1. [Upgrade to FiftyOne Teams version 1.4.2](#deploying-fiftyone-teams)
    with `FIFTYONE_DATABASE_ADMIN=true`
    (this is not the default in the `config.yaml` for this release).
     - **NOTE:** FiftyOne SDK users will lose access to the
-      FiftyOne Teams Database at this step until they upgrade to `fiftyone==0.14.1`
-1. Upgrade your FiftyOne SDKs to version 0.14.1
+      FiftyOne Teams Database at this step until they upgrade to `fiftyone==0.14.2`
+1. Upgrade your FiftyOne SDKs to version 0.14.2
     - Login to the FiftyOne Teams UI
     - To obtain the CLI command to install the FiftyOne SDK associated with your FiftyOne Teams version, navigate to `Account > Install FiftyOne`
-1. Run `fiftyone migrate --info` to ensure all datasets have been migrated to version 0.22.0.
+1. Run `fiftyone migrate --info` to ensure all datasets have been migrated to version 0.22.1.
    - If not all datasets have been upgraded, have an admin run
 
       ```shell
@@ -223,8 +223,8 @@ Voxel51 recommends the following upgrade process for upgrading from versions pri
 
 ### From FiftyOne Teams Version 1.1.0 and later
 
-The FiftyOne 0.14.1 SDK is backwards-compatible with FiftyOne Teams Database Versions 0.19.0 and later.
-You will not be able to connect to a FiftyOne Teams 1.4.1 database (version 0.22.0) with any FiftyOne SDK before 0.14.1.
+The FiftyOne 0.14.2 SDK is backwards-compatible with FiftyOne Teams Database Versions 0.19.0 and later.
+You will not be able to connect to a FiftyOne Teams 1.4.2 database (version 0.22.1) with any FiftyOne SDK before 0.14.2.
 
 Voxel51 always recommends using the latest version of the FiftyOne SDK compatible with your FiftyOne Teams deployment.
 
@@ -234,8 +234,8 @@ Voxel51 recommends the following upgrade process for upgrading from FiftyOne Tea
     - set `FIFTYONE_DATABASE_ADMIN=false`
     - `unset FIFTYONE_DATABASE_ADMIN`
         - This should generally be your default
-1. [Upgrade to FiftyOne Teams version 1.4.1](#deploying-fiftyone-teams)
-1. Upgrade FiftyOne Teams SDK users to FiftyOne Teams version 0.14.1
+1. [Upgrade to FiftyOne Teams version 1.4.2](#deploying-fiftyone-teams)
+1. Upgrade FiftyOne Teams SDK users to FiftyOne Teams version 0.14.2
     - Login to the FiftyOne Teams UI
     - To obtain the CLI command to install the FiftyOne SDK associated with your FiftyOne Teams version, navigate to `Account > Install FiftyOne`
 1. Have the admin run this to upgrade all datasets
@@ -244,7 +244,7 @@ Voxel51 recommends the following upgrade process for upgrading from FiftyOne Tea
     FIFTYONE_DATABASE_ADMIN=true fiftyone migrate --all
     ```
 
-    - **NOTE** Any FiftyOne SDK less than 0.14.1 will lose database connectivity at this point. Upgrading to `fiftyone==0.14.1` is required
+    - **NOTE** Any FiftyOne SDK less than 0.14.2 will lose database connectivity at this point. Upgrading to `fiftyone==0.14.2` is required
 
 ---
 
@@ -268,7 +268,7 @@ Voxel51 recommends the following upgrade process for upgrading from FiftyOne Tea
     FIFTYONE_DATABASE_ADMIN=true fiftyone migrate --all
     ```
 
-1. To ensure that all datasets are now at version 0.22.0, run
+1. To ensure that all datasets are now at version 0.22.1, run
 
     ```shell
     fiftyone migrate --info

--- a/docker/compose.dedicated-plugins.yaml
+++ b/docker/compose.dedicated-plugins.yaml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   teams-api:
-    image: voxel51/fiftyone-teams-api:v1.4.1
+    image: voxel51/fiftyone-teams-api:v1.4.2
     environment:
       AUTH0_CLIENT_ID: ${AUTH0_CLIENT_ID}
       AUTH0_AUDIENCE: ${AUTH0_AUDIENCE}
@@ -32,7 +32,7 @@ services:
     volumes:
       - plugins-vol:/opt/plugins
   teams-app:
-    image: voxel51/fiftyone-teams-app:v1.4.1
+    image: voxel51/fiftyone-teams-app:v1.4.2
     environment:
       API_URL: ${API_URL}
       AUTH0_AUDIENCE: ${AUTH0_AUDIENCE}
@@ -43,7 +43,7 @@ services:
       AUTH0_ORGANIZATION: ${AUTH0_ORGANIZATION}
       AUTH0_SECRET: ${AUTH0_SECRET}
       APP_USE_HTTPS: ${APP_USE_HTTPS:-true}
-      FIFTYONE_APP_TEAMS_SDK_RECOMMENDED_VERSION: 0.14.1
+      FIFTYONE_APP_TEAMS_SDK_RECOMMENDED_VERSION: 0.14.2
       FIFTYONE_SERVER_ADDRESS: ""
       FIFTYONE_SERVER_PATH_PREFIX: /api/proxy/fiftyone-teams
       FIFTYONE_TEAMS_PLUGIN_URL: ${FIFTYONE_TEAMS_PLUGIN_URL}
@@ -66,7 +66,7 @@ services:
       - ${APP_BIND_ADDRESS}:${APP_BIND_PORT}:3000
     restart: always
   fiftyone-app:
-    image: voxel51/fiftyone-app:v1.4.1
+    image: voxel51/fiftyone-app:v1.4.2
     environment:
       API_URL: ${API_URL}
       FIFTYONE_DATABASE_ADMIN: false
@@ -95,7 +95,7 @@ services:
       - ${FIFTYONE_DEFAULT_APP_ADDRESS}:${FIFTYONE_DEFAULT_APP_PORT}:5151
     restart: always
   teams-plugins:
-    image: voxel51/fiftyone-app:v1.4.1
+    image: voxel51/fiftyone-app:v1.4.2
     environment:
       API_URL: ${API_URL}
       FIFTYONE_DATABASE_ADMIN: false

--- a/docker/compose.plugins.yaml
+++ b/docker/compose.plugins.yaml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   teams-api:
-    image: voxel51/fiftyone-teams-api:v1.4.1
+    image: voxel51/fiftyone-teams-api:v1.4.2
     environment:
       AUTH0_CLIENT_ID: ${AUTH0_CLIENT_ID}
       AUTH0_AUDIENCE: ${AUTH0_AUDIENCE}
@@ -32,7 +32,7 @@ services:
     volumes:
       - plugins-vol:/opt/plugins
   teams-app:
-    image: voxel51/fiftyone-teams-app:v1.4.1
+    image: voxel51/fiftyone-teams-app:v1.4.2
     environment:
       API_URL: ${API_URL}
       AUTH0_AUDIENCE: ${AUTH0_AUDIENCE}
@@ -43,7 +43,7 @@ services:
       AUTH0_ORGANIZATION: ${AUTH0_ORGANIZATION}
       AUTH0_SECRET: ${AUTH0_SECRET}
       APP_USE_HTTPS: ${APP_USE_HTTPS:-true}
-      FIFTYONE_APP_TEAMS_SDK_RECOMMENDED_VERSION: 0.14.1
+      FIFTYONE_APP_TEAMS_SDK_RECOMMENDED_VERSION: 0.14.2
       FIFTYONE_SERVER_ADDRESS: ""
       FIFTYONE_SERVER_PATH_PREFIX: /api/proxy/fiftyone-teams
       FIFTYONE_TEAMS_PROXY_URL: ${FIFTYONE_TEAMS_PROXY_URL}
@@ -65,7 +65,7 @@ services:
       - ${APP_BIND_ADDRESS}:${APP_BIND_PORT}:3000
     restart: always
   fiftyone-app:
-    image: voxel51/fiftyone-app:v1.4.1
+    image: voxel51/fiftyone-app:v1.4.2
     environment:
       API_URL: ${API_URL}
       FIFTYONE_DATABASE_ADMIN: false

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   teams-api:
-    image: voxel51/fiftyone-teams-api:v1.4.1
+    image: voxel51/fiftyone-teams-api:v1.4.2
     environment:
       AUTH0_CLIENT_ID: ${AUTH0_CLIENT_ID}
       AUTH0_AUDIENCE: ${AUTH0_AUDIENCE}
@@ -29,7 +29,7 @@ services:
       - ${API_BIND_ADDRESS}:${API_BIND_PORT}:8000
     restart: always
   teams-app:
-    image: voxel51/fiftyone-teams-app:v1.4.1
+    image: voxel51/fiftyone-teams-app:v1.4.2
     environment:
       API_URL: ${API_URL}
       AUTH0_AUDIENCE: ${AUTH0_AUDIENCE}
@@ -40,7 +40,7 @@ services:
       AUTH0_ORGANIZATION: ${AUTH0_ORGANIZATION}
       AUTH0_SECRET: ${AUTH0_SECRET}
       APP_USE_HTTPS: ${APP_USE_HTTPS:-true}
-      FIFTYONE_APP_TEAMS_SDK_RECOMMENDED_VERSION: 0.14.1
+      FIFTYONE_APP_TEAMS_SDK_RECOMMENDED_VERSION: 0.14.2
       FIFTYONE_SERVER_ADDRESS: ""
       FIFTYONE_SERVER_PATH_PREFIX: /api/proxy/fiftyone-teams
       FIFTYONE_TEAMS_PROXY_URL: ${FIFTYONE_TEAMS_PROXY_URL}
@@ -62,7 +62,7 @@ services:
       - ${APP_BIND_ADDRESS}:${APP_BIND_PORT}:3000
     restart: always
   fiftyone-app:
-    image: voxel51/fiftyone-app:v1.4.1
+    image: voxel51/fiftyone-app:v1.4.2
     environment:
       API_URL: ${API_URL}
       FIFTYONE_DATABASE_ADMIN: false

--- a/helm/README.md
+++ b/helm/README.md
@@ -114,8 +114,8 @@ There are three modes for plugins
             - `ReadOnly` permission to the `teams-plugins` deployment
               at the `FIFTYONE_PLUGINS_DIR` path
 
-Deploy plugins using the FiftyOne Teams UI at `/settings/plugins`.
-Any early-adopter plugins installed via manual methods must be redeployed using the FiftyOne Teams UI.
+Use the FiftyOne Teams UI to deploy plugins by navigating to `https://<DEPOY_URL>/settings/plugins`.
+Early-adopter plugins installed manually must be redeployed using the FiftyOne Teams UI.
 
 #### Storage Credentials and `FIFTYONE_ENCRYPTION_KEY`
 
@@ -130,6 +130,7 @@ print(Fernet.generate_key().decode())
 ```
 
 Voxel51 does not have access to this encryption key and cannot reproduce it.
+Please store this key in a safe place.
 If the key is lost, you will need to
 
 1. Schedule an outage window
@@ -137,12 +138,10 @@ If the key is lost, you will need to
     1. Replace the encryption key
     1. Add the storage credentials via the UI again.
 
-Voxel51 strongly recommends storing this key in a safe place.
-
 Storage credentials no longer need to be mounted into pods with appropriate environment variables being set.
-Users with `Admin` permissions may add supported storage credentials using `/settings/cloud_storage_credentials` in the Web UI.
+Users with `Admin` permissions may use the FiftyOne Teams UI to manage storage credentials by navigating to `https://<DEPOY_URL>/settings/cloud_storage_credentials`.
 
-FiftyOne Teams continues to support the use of environment variables to set storage credentials in the application context but is providing an alternate configuration path for future functionality.
+FiftyOne Teams continues to support the use of environment variables to set storage credentials in the application context and is providing an alternate configuration path for future functionality.
 
 #### Environment Proxies
 
@@ -192,7 +191,7 @@ To use this feature, use a container image containing `torch` (PyTorch) instead 
 Use the Voxel51 provided image `fiftyone-app-torch` or build your own base image including `torch`.
 
 To override the default image, add a new `appSettings.image.repository` stanza to the Helm Chart.
-Using the included `values.yaml` this configuration might look like:
+For example, `values.yaml` might look like:
 
 ```yaml
 appSettings:
@@ -386,7 +385,7 @@ The FiftyOne 0.14.2 SDK (database version 0.22.1) is _NOT_ backwards-compatible 
 The FiftyOne 0.10.x SDK is not forwards compatible with current FiftyOne Teams Database Versions.
 If you are using a FiftyOne SDK older than 0.11.0, upgrading the Web server will require upgrading all FiftyOne SDK installations.
 
-Voxel51 recommends the following upgrade process for upgrading from versions prior to FiftyOne Teams version 1.1.0:
+Voxel51 recommends this upgrade process from versions prior to FiftyOne Teams version 1.1.0:
 
 1. Make sure your installation includes the required
    [FIFTYONE_ENCRYPTION_KEY](#fiftyone-teams-upgrade-notes)
@@ -399,11 +398,17 @@ Voxel51 recommends the following upgrade process for upgrading from versions pri
 1. Upgrade your FiftyOne SDKs to version 0.14.2
     - Login to the FiftyOne Teams UI
     - To obtain the CLI command to install the FiftyOne SDK associated with your FiftyOne Teams version, navigate to `Account > Install FiftyOne`
-1. Have an admin run this to upgrade all datasets to version 0.22.1
+1. Check if datasets have been migrated to version 0.22.1.
 
     ```shell
-    FIFTYONE_DATABASE_ADMIN=true fiftyone migrate --all
+    fiftyone migrate --info
     ```
+
+    - If not all datasets have been upgraded, have an admin run
+
+        ```shell
+        FIFTYONE_DATABASE_ADMIN=true fiftyone migrate --all
+        ```
 
 ### From FiftyOne Teams Version 1.1.0 and later
 
@@ -422,11 +427,12 @@ Voxel51 recommends the following upgrade process for upgrading from FiftyOne Tea
 1. Upgrade FiftyOne Teams SDK users to FiftyOne Teams version 0.14.2
     - Login to the FiftyOne Teams UI
     - To obtain the CLI command to install the FiftyOne SDK associated with your FiftyOne Teams version, navigate to `Account > Install FiftyOne`
-1. Have the admin run  to upgrade all datasets
+1. Have the admin run to upgrade all datasets
 
     ```shell
     FIFTYONE_DATABASE_ADMIN=true fiftyone migrate --all
     ```
+    - **NOTE** Any FiftyOne SDK less than 0.14.2 will lose database connectivity at this point. Upgrading to `fiftyone==0.14.2` is required
 
 1. To ensure that all datasets are now at version 0.22.1, run
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -382,7 +382,7 @@ You will need to either create a new IdP or modify your existing configuration i
 
 ### From Before FiftyOne Teams Version 1.1.0
 
-The FiftyOne 0.14.1 SDK (database version 0.22.0) is _NOT_ backwards-compatible with FiftyOne Teams Database Versions prior to 0.19.0.
+The FiftyOne 0.14.2 SDK (database version 0.22.1) is _NOT_ backwards-compatible with FiftyOne Teams Database Versions prior to 0.19.0.
 The FiftyOne 0.10.x SDK is not forwards compatible with current FiftyOne Teams Database Versions.
 If you are using a FiftyOne SDK older than 0.11.0, upgrading the Web server will require upgrading all FiftyOne SDK installations.
 
@@ -391,15 +391,15 @@ Voxel51 recommends the following upgrade process for upgrading from versions pri
 1. Make sure your installation includes the required
    [FIFTYONE_ENCRYPTION_KEY](#fiftyone-teams-upgrade-notes)
    environment variable
-1. [Upgrade to FiftyOne Teams version 1.4.1](#deploying-fiftyone-teams)
+1. [Upgrade to FiftyOne Teams version 1.4.2](#deploying-fiftyone-teams)
    with `appSettings.env.FIFTYONE_DATABASE_ADMIN: true`
    (this is not the default in the Helm Chart for this release).
     - **NOTE:** FiftyOne SDK users will lose access to the
-      FiftyOne Teams Database at this step until they upgrade to `fiftyone==0.14.1`
-1. Upgrade your FiftyOne SDKs to version 0.14.1
+      FiftyOne Teams Database at this step until they upgrade to `fiftyone==0.14.2`
+1. Upgrade your FiftyOne SDKs to version 0.14.2
     - Login to the FiftyOne Teams UI
     - To obtain the CLI command to install the FiftyOne SDK associated with your FiftyOne Teams version, navigate to `Account > Install FiftyOne`
-1. Have an admin run this to upgrade all datasets to version 0.22.0
+1. Have an admin run this to upgrade all datasets to version 0.22.1
 
     ```shell
     FIFTYONE_DATABASE_ADMIN=true fiftyone migrate --all
@@ -407,8 +407,8 @@ Voxel51 recommends the following upgrade process for upgrading from versions pri
 
 ### From FiftyOne Teams Version 1.1.0 and later
 
-The FiftyOne 0.14.1 SDK is backwards-compatible with FiftyOne Teams Database Versions 0.19.0 and later.
-You will not be able to connect to a FiftyOne Teams 1.4.1 database (version 0.22.0) with any FiftyOne SDK before 0.14.1.
+The FiftyOne 0.14.2 SDK is backwards-compatible with FiftyOne Teams Database Versions 0.19.0 and later.
+You will not be able to connect to a FiftyOne Teams 1.4.2 database (version 0.22.1) with any FiftyOne SDK before 0.14.2.
 
 Voxel51 always recommends using the latest version of the FiftyOne SDK compatible with your FiftyOne Teams deployment.
 
@@ -418,8 +418,8 @@ Voxel51 recommends the following upgrade process for upgrading from FiftyOne Tea
     - set `FIFTYONE_DATABASE_ADMIN=false`
     - `unset FIFTYONE_DATABASE_ADMIN`
         - This should generally be your default
-1. [Upgrade to FiftyOne Teams version 1.4.1](#deploying-fiftyone-teams)
-1. Upgrade FiftyOne Teams SDK users to FiftyOne Teams version 0.14.1
+1. [Upgrade to FiftyOne Teams version 1.4.2](#deploying-fiftyone-teams)
+1. Upgrade FiftyOne Teams SDK users to FiftyOne Teams version 0.14.2
     - Login to the FiftyOne Teams UI
     - To obtain the CLI command to install the FiftyOne SDK associated with your FiftyOne Teams version, navigate to `Account > Install FiftyOne`
 1. Have the admin run  to upgrade all datasets
@@ -428,7 +428,7 @@ Voxel51 recommends the following upgrade process for upgrading from FiftyOne Tea
     FIFTYONE_DATABASE_ADMIN=true fiftyone migrate --all
     ```
 
-1. To ensure that all datasets are now at version 0.22.0, run
+1. To ensure that all datasets are now at version 0.22.1, run
 
     ```shell
     fiftyone migrate --info

--- a/helm/fiftyone-teams-app/Chart.yaml
+++ b/helm/fiftyone-teams-app/Chart.yaml
@@ -3,6 +3,6 @@ name: fiftyone-teams-app
 namespace: fiftyone-teams
 description: A FiftyOne Teams Helm Chart
 type: application
-version: 1.4.1
-appVersion: "v1.4.1"
+version: 1.4.2
+appVersion: "v1.4.2"
 icon: https://voxel51.com/images/logo/voxel51-logo-horz-color-600dpi.png

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -200,7 +200,7 @@ teamsAppSettings:
   # dnsName: ""
   env:
     APP_USE_HTTPS: true
-    FIFTYONE_APP_TEAMS_SDK_RECOMMENDED_VERSION: 0.14.1
+    FIFTYONE_APP_TEAMS_SDK_RECOMMENDED_VERSION: 0.14.2
     RECOIL_DUPLICATE_ATOM_KEY_CHECKING_ENABLED: false
   image:
     repository: voxel51/fiftyone-teams-app

--- a/helm/gke-example/values.yaml
+++ b/helm/gke-example/values.yaml
@@ -33,7 +33,7 @@ secret:
 
 # appSettings:
 #   env:
-#     # FIFTYONE_DATABASE_ADMIN is set to `false` by default for v1.4.1 installs
+#     # FIFTYONE_DATABASE_ADMIN is set to `false` by default for v1.4.2 installs
 #     # If you are performing a new install or an upgrade from v1.0 or earlier
 #     # you may want to set this value to `true`.
 #     # Please see https://helm.fiftyone.ai/#initial-installation-vs-upgrades for details

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -41,7 +41,7 @@ secret:
 
 # appSettings:
 #   env:
-#    FIFTYONE_DATABASE_ADMIN is set to `false` by default for v1.4.1 installs
+#    FIFTYONE_DATABASE_ADMIN is set to `false` by default for v1.4.2 installs
 #     If you are performing a new install or an upgrade from v1.0 or earlier you may want to set
 #     this value to `true`.
 #     Please see https://helm.fiftyone.ai/#initial-installation-vs-upgrades for details


### PR DESCRIPTION
FiftyOne Teams 1.4.2 is coming; this change bumps the versions in the docs for that release.