### PR TITLE
version 1.4.2 is no longer available

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
 
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.4.2
+        uses: helm/chart-releaser-action@v1.6.0
         with:
           charts_dir: helm
         env:


### PR DESCRIPTION
[version 1.4.2](https://github.com/voxel51/fiftyone-teams-app-deploy/actions/runs/6435492179/job/17476869347) of the helm-chart releaser is no longer available.

Bumping to the latest release