### PR TITLE
trigger manually

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   release:


### PR DESCRIPTION
The action doesn't trigger on a change to the workflow; this will allow us to trigger it manually when necessary.  The job won't update the release if there haven't been changes.