### PR TITLE
not sure what just happened here

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
 
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.4.2
+        uses: helm/chart-releaser-action@v1.6.0
         with:
           charts_dir: helm
         env:


### PR DESCRIPTION
two merges later and it's still showing chart-releaser-action 1.4.2 on `main`...

One more time...