### PR TITLE
version 1.5.0 not 1.6.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
 
 jobs:
   release:
@@ -30,7 +29,7 @@ jobs:
 
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.6.0
+        uses: helm/chart-releaser-action@v1.5.0
         with:
           charts_dir: helm
         env:


### PR DESCRIPTION
Moving too fast with too many balls in the air...

helm/chart-releaser-action is at version [v1.5.0](https://github.com/helm/chart-releaser-action)

we don't need the manual trigger, it runs when the workflow is actually merged.