### PR TITLE
fix the yamllint findings (that can be resolved).

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,4 @@
+---
 name: Release Charts
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 ---
 name: Release Charts
 
+# yamllint disable-line rule:truthy
 on:
   push:
     branches:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,8 @@ repos:
       - id: check-case-conflict
       - id: check-shebang-scripts-are-executable
       - id: check-yaml
+        # We exclude helm template files since in raw form, they are not valid yaml
+        exclude: helm/fiftyone-teams-app/templates
       - id: detect-aws-credentials
         args:
           - --allow-missing-credentials
@@ -32,6 +34,8 @@ repos:
     hooks:
       - id: yamllint
         entry: yamllint --config-file .yamllint.yaml
+        # We exclude helm template files since in raw form, they are not valid yaml
+        exclude: helm/fiftyone-teams-app/templates
   - repo: https://github.com/norwoodj/helm-docs
     rev: v1.11.3
     hooks:

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,6 +1,12 @@
 ---
 extends: default
 rules:
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 1
+  brackets:
+    min-spaces-inside: 0
+    max-spaces-inside: 1
   indentation:
     spaces: 2
   line-length: disable

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,12 +67,12 @@ generated using the pre-commit hooks for
           2 files changed, 10 insertions(+)
           ```
 
-        * Manually run the pre-commit hooks
+      * Manually run the pre-commit hooks
 
-            ```shell
-            git add helm/fiftyone-teams-app/README.md.gotmpl
-            pre-commit run helm-docs
-            pre-commit run markdown-toc
-            git add helm/fiftyone-teams-app/README.md
-            git commit -m '<COMMIT_MESSAGE>'
-            ```
+          ```shell
+          git add helm/fiftyone-teams-app/README.md.gotmpl
+          pre-commit run helm-docs
+          pre-commit run markdown-toc
+          git add helm/fiftyone-teams-app/README.md
+          git commit -m '<COMMIT_MESSAGE>'
+          ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <!-- prettier-ignore -->
 <img src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
 <img src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
-helm/gke-example/values.yaml<!-- markdownlint-enable no-inline-html line-length -->
+<!-- markdownlint-enable no-inline-html line-length -->
 
 ## Fiftyone Teams Deployment Assets
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable no-inline-html line-length -->
+<!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
 
@@ -6,6 +8,7 @@
 
 </p>
 </div>
+<!-- markdownlint-enable no-inline-html line-length -->
 
 ---
 
@@ -27,11 +30,14 @@ For Docker Hub credentials, please contact your Voxel51 support team.
 
 When performing an initial installation, in `compose.yaml` set
 `services.fiftyone-app.environment.FIFTYONE_DATABASE_ADMIN: true`.
-When performing a FiftyOne Teams upgrade, set `services.fiftyone-app.environment.FIFTYONE_DATABASE_ADMIN: false`.
+When performing a FiftyOne Teams upgrade, set
+`services.fiftyone-app.environment.FIFTYONE_DATABASE_ADMIN: false`.
 See [Upgrade Process Recommendations](#upgrade-process-recommendations).
 
-The environment variable `FIFTYONE_DATABASE_ADMIN` controls whether the database may be migrated.
-This is a safety check to prevent automatic database upgrades that will break other users' SDK connections.
+The environment variable `FIFTYONE_DATABASE_ADMIN`
+controls whether the database may be migrated.
+This is a safety check to prevent automatic database
+upgrades that will break other users' SDK connections.
 When false (or unset), either an error will occur
 
 ```shell
@@ -75,7 +81,8 @@ quickstart  0.21.2
 
 #### Enabling FiftyOne Teams Authenticated API
 
-FiftyOne Teams v1.3 introduces the capability to connect FiftyOne Teams SDKs through the FiftyOne Teams API (instead of creating a direct connection to MongoDB).
+FiftyOne Teams v1.3 introduces the capability to connect FiftyOne Teams SDK
+through the FiftyOne Teams API (instead of creating a direct connection to MongoDB).
 
 To enable the FiftyOne Teams Authenticated API you will need to
 [expose the FiftyOne Teams API endpoint](docs/expose-teams-api.md)
@@ -131,14 +138,17 @@ Both
 and
 [./compose.dedicated-plugins.yaml](./compose.dedicated-plugins.yaml)
 create a new Docker Volume shared between FiftyOne Teams services.
-For multi-node deployments, please implement a storage solution allowing the access the deployed plugins.
+For multi-node deployments, please implement a storage
+solution allowing the access the deployed plugins.
 
 Use the FiftyOne Teams UI to deploy plugins by navigating to `https://<DEPOY_URL>/settings/plugins`.
-Early-adopter plugins installed manually must be redeployed using the FiftyOne Teams UI.
+Early-adopter plugins installed manually must
+be redeployed using the FiftyOne Teams UI.
 
 #### Storage Credentials and `FIFTYONE_ENCRYPTION_KEY`
 
-As of FiftyOne Teams 1.1, containers based on the `fiftyone-teams-api` and `fiftyone-app` images must include the `FIFTYONE_ENCRYPTION_KEY` variable.
+As of FiftyOne Teams 1.1, containers based on the `fiftyone-teams-api` and
+`fiftyone-app` images must include the `FIFTYONE_ENCRYPTION_KEY` variable.
 This key is used to encrypt storage credentials in the MongoDB database.
 
 To  generate `FIFTYONE_ENCRYPTION_KEY`, run this Python code
@@ -157,10 +167,15 @@ If the key is lost, you will need to
     1. Replace the encryption key
     1. Add the storage credentials via the UI again.
 
-Storage credentials no longer need to be mounted into containers with appropriate environment variables being set.
-Users with `Admin` permissions may use the FiftyOne Teams UI to manage storage credentials by navigating to `https://<DEPOY_URL>/settings/cloud_storage_credentials`.
+Storage credentials no longer need to be mounted into
+containers with appropriate environment variables being set.
+Users with `Admin` permissions may use the FiftyOne Teams UI
+to manage storage credentials by navigating to
+`https://<DEPOY_URL>/settings/cloud_storage_credentials`.
 
-FiftyOne Teams version 1.3+ continues to support the use of environment variables to set storage credentials in the application context and is providing an alternate configuration path for future functionality.
+FiftyOne Teams version 1.3+ continues to support the use of environment
+variables to set storage credentials in the application context and is
+providing an alternate configuration path for future functionality.
 
 #### Environment Proxies
 
@@ -186,7 +201,8 @@ To configure this, set following environment variables on
     GLOBAL_AGENT_NO_PROXY: ${NO_PROXY_LIST}
     ```
 
-The environment variable `NO_PROXY_LIST` value should be a comma-separated list of Docker Compose services that may communicate without going through a proxy server.
+The environment variable `NO_PROXY_LIST` value should be a comma-separated list
+of Docker Compose services that may communicate without going through a proxy server.
 By default these service names are
 
 - `fiftyone-app`
@@ -199,7 +215,8 @@ Examples of these settings are included in the FiftyOne Teams configuration file
 - [common-services.yaml](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/docker/common-services.yaml)
 - [env.template](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/docker/env.template)
 
-By default, the Global Agent Proxy will log all outbound connections and identify which connections are routed through the proxy.
+By default, the Global Agent Proxy will log all outbound connections
+and identify which connections are routed through the proxy.
 To reduce the logging verbosity, add this environment variable to your `teamsAppSettings.env`
 
 ```ini
@@ -208,13 +225,18 @@ ROARR_LOG: false
 
 #### Text Similarity
 
-FiftyOne Teams version 1.2 and higher supports using text similarity searches for images that are indexed with a model that
+FiftyOne Teams version 1.2 and higher supports using text
+similarity searches for images that are indexed with a model that
 [supports text queries](https://docs.voxel51.com/user_guide/brain.html#brain-similarity-text).
-To use this feature, use a container image containing `torch` (PyTorch) instead of the `fiftyone-app` image.
-Use the Voxel51 provided image `fiftyone-app-torch` or build your own base image including `torch`.
+To use this feature, use a container image containing
+`torch` (PyTorch) instead of the `fiftyone-app` image.
+Use the Voxel51 provided image `fiftyone-app-torch` or
+build your own base image including `torch`.
 
-To override the default image, update `compose.override.yaml` with the value for image.
-This will allow you to update your `compose.yaml` in future releases without having to port this change forward.
+To override the default image, update
+`compose.override.yaml` with the value for image.
+This will allow you to update your `compose.yaml` in future
+releases without having to port this change forward.
 For example, `compose.override.yaml` might look like:
 
 ```yaml
@@ -231,15 +253,20 @@ For more information, see the docs for
 ### From Early Adopter Versions (Versions less than 1.0)
 
 Please contact your Voxel51 Customer Success team member to coordinate this upgrade.
-To migrate to a new Auth0 Tenant, you will need to create a new IdP or modify your existing configuration.
+To migrate to a new Auth0 Tenant, you will need to
+create a new IdP or modify your existing configuration.
 
 ### From Before FiftyOne Teams Version 1.1.0
 
-The FiftyOne 0.14.1 SDK (database version 0.23.0) is _NOT_ backwards-compatible with FiftyOne Teams Database Versions prior to 0.19.0.
-The FiftyOne 0.10.x SDK is not forwards compatible with current FiftyOne Teams Database Versions.
-If you are using a FiftyOne SDK older than 0.11.0, upgrading the Web server will require upgrading all FiftyOne SDK installations.
+The FiftyOne 0.14.1 SDK (database version 0.23.0) is _NOT_ backwards-compatible
+with FiftyOne Teams Database Versions prior to 0.19.0.
+The FiftyOne 0.10.x SDK is not forwards compatible
+with current FiftyOne Teams Database Versions.
+If you are using a FiftyOne SDK older than 0.11.0, upgrading the
+Web server will require upgrading all FiftyOne SDK installations.
 
-Voxel51 recommends this upgrade process from versions prior to FiftyOne Teams version 1.1.0:
+Voxel51 recommends this upgrade process from
+versions prior to FiftyOne Teams version 1.1.0:
 
 1. Make sure your installation includes the required
    [FIFTYONE_ENCRYPTION_KEY](#fiftyone-teams-upgrade-notes)
@@ -251,7 +278,8 @@ Voxel51 recommends this upgrade process from versions prior to FiftyOne Teams ve
       FiftyOne Teams Database at this step until they upgrade to `fiftyone==0.14.1`
 1. Upgrade your FiftyOne SDKs to version 0.14.1
     - Login to the FiftyOne Teams UI
-    - To obtain the CLI command to install the FiftyOne SDK associated with your FiftyOne Teams version, navigate to `Account > Install FiftyOne`
+    - To obtain the CLI command to install the FiftyOne SDK associated with
+      your FiftyOne Teams version, navigate to `Account > Install FiftyOne`
 1. Check if datasets have been migrated to version 0.23.0.
 
     ```shell
@@ -266,12 +294,16 @@ Voxel51 recommends this upgrade process from versions prior to FiftyOne Teams ve
 
 ### From FiftyOne Teams Version 1.1.0 and later
 
-The FiftyOne 0.14.1 SDK is backwards-compatible with FiftyOne Teams Database Versions 0.19.0 and later.
-You will not be able to connect to a FiftyOne Teams 1.4.1 database (version 0.23.0) with any FiftyOne SDK before 0.14.1.
+The FiftyOne 0.14.1 SDK is backwards-compatible with
+FiftyOne Teams Database Versions 0.19.0 and later.
+You will not be able to connect to a FiftyOne Teams 1.4.1
+database (version 0.23.0) with any FiftyOne SDK before 0.14.1.
 
-Voxel51 always recommends using the latest version of the FiftyOne SDK compatible with your FiftyOne Teams deployment.
+Voxel51 always recommends using the latest version of the
+FiftyOne SDK compatible with your FiftyOne Teams deployment.
 
-Voxel51 recommends the following upgrade process for upgrading from FiftyOne Teams version 1.1.0 or later:
+Voxel51 recommends the following upgrade process for
+upgrading from FiftyOne Teams version 1.1.0 or later:
 
 1. Ensure all FiftyOne SDK users either
     - set `FIFTYONE_DATABASE_ADMIN=false`
@@ -280,14 +312,16 @@ Voxel51 recommends the following upgrade process for upgrading from FiftyOne Tea
 1. [Upgrade to FiftyOne Teams version 1.4.1](#deploying-fiftyone-teams)
 1. Upgrade FiftyOne Teams SDK users to FiftyOne Teams version 0.14.1
     - Login to the FiftyOne Teams UI
-    - To obtain the CLI command to install the FiftyOne SDK associated with your FiftyOne Teams version, navigate to `Account > Install FiftyOne`
+    - To obtain the CLI command to install the FiftyOne SDK associated with
+      your FiftyOne Teams version, navigate to `Account > Install FiftyOne`
 1. Have the admin run this to upgrade all datasets
 
     ```shell
     FIFTYONE_DATABASE_ADMIN=true fiftyone migrate --all
     ```
 
-    - **NOTE** Any FiftyOne SDK less than 0.14.1 will lose database connectivity at this point. Upgrading to `fiftyone==0.14.1` is required
+    - **NOTE** Any FiftyOne SDK less than 0.14.1 will lose database connectivity
+      at this point. Upgrading to `fiftyone==0.14.1` is required
 
 1. To ensure that all datasets are now at version 0.23.0, run
 
@@ -300,7 +334,8 @@ Voxel51 recommends the following upgrade process for upgrading from FiftyOne Tea
 ## Deploying FiftyOne Teams
 
 1. Install docker-compose
-1. From a directory containing the files `compose.yaml` and `env.template` files (included in this repository),
+1. From a directory containing the files `compose.yaml` and `env.template`
+   files (included in this repository),
     1. Rename the `env.template` file to `.env`
     1. Edit the `.env` file, setting the parameters required for this deployment.
        [See table below](#fiftyone-teams-environment-variables).
@@ -323,9 +358,12 @@ Voxel51 recommends the following upgrade process for upgrading from FiftyOne Tea
     ```
 
 The FiftyOne Teams App is now exposed on port 3000.
-An SSL endpoint (Load Balancer or Nginx Proxy or something similar) will need to be configured to route traffic from the SSL endpoint to port 3000 on the host running the FiftyOne Teams App.
+An SSL endpoint (Load Balancer or Nginx Proxy or something similar)
+will need to be configured to route traffic from the SSL endpoint
+to port 3000 on the host running the FiftyOne Teams App.
 
-An example nginx site configuration that forwards http traffic to https, and https traffic for `your.server.name` to port 3000.
+An example nginx site configuration that forwards http traffic to
+https, and https traffic for `your.server.name` to port 3000.
 See
 [./example-nginx-site.conf](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/docker/example-nginx-site.conf).
 
@@ -353,7 +391,7 @@ See
 | `AUTH0_SECRET`                               | A random string used to encrypt cookies; use something like `openssl rand -hex 32` to generate this string                                                                                                                                                                                                                                                                                                                                                                                                                                      | Yes      |
 | `FIFTYONE_APP_ALLOW_MEDIA_EXPORT`            | Set this to `"false"` if you want to disable media export options                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | No       |
 | `FIFTYONE_APP_TEAMS_SDK_RECOMMENDED_VERSION` | The recommended fiftyone SDK version. This will be displayed in install modal (i.e. `pip install ... fiftyone==0.11.0`)                                                                                                                                                                                                                                                                                                                                                                                                                         | No       |
-| `FIFTYONE_APP_THEME`                         | The default theme configuration for your FiftyOne Teams application:<br>&ensp;- `dark`: Application will default to dark theme when user visits for the first time<br>&ensp;- `light`: Application will default to light theme when user visits for the first time<br>&ensp;- `always-dark`: Application will default to dark theme on each refresh (even if user changes theme to light within the app)<br>&ensp;- `always-light`: Application will default to light theme on each refresh (even if user changes theme to dark within the app) | No       |
+| `FIFTYONE_APP_THEME`                         | The default theme configuration for your FiftyOne Teams application:<br>&ensp;- `dark`: Application will default to dark theme when user visits for the first time<br>&ensp;- `light`: Application will default to light theme when user visits for the first time<br>&ensp;- `always-dark`: Application will default to dark theme on each refresh (even if user changes theme to light within the app)<br>&ensp;- `always-light`: Application will default to light theme on each refresh (even if user changes theme to dark within the app) | No       | <!-- markdownlint-disable-line no-inline-html -->
 | `FIFTYONE_BASE_DIR`                          | This will be mounted as `/fiftyone` in the `fiftyone-teams-app` container and can be used to pass cloud storage credentials into the environment                                                                                                                                                                                                                                                                                                                                                                                                | No       |
 | `FIFTYONE_DEFAULT_APP_ADDRESS`               | The host address that `fiftyone-app` should bind to; `127.0.0.1` is appropriate for this in most cases                                                                                                                                                                                                                                                                                                                                                                                                                                          | Yes      |
 | `FIFTYONE_DEFAULT_APP_PORT`                  | The host port that `fiftyone-app` should bind to; the default is `5151`                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | Yes      |

--- a/docker/compose.dedicated-plugins.yaml
+++ b/docker/compose.dedicated-plugins.yaml
@@ -1,3 +1,4 @@
+---
 # For Proxy Server instructions please see
 #  https://github.com/voxel51/fiftyone-teams-app-deploy/tree/main/docker#environment-proxies
 services:

--- a/docker/compose.plugins.yaml
+++ b/docker/compose.plugins.yaml
@@ -1,3 +1,4 @@
+---
 # For Proxy Server instructions please see
 #  https://github.com/voxel51/fiftyone-teams-app-deploy/tree/main/docker#environment-proxies
 services:

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -1,3 +1,4 @@
+---
 # For Proxy Server instructions please see
 #  https://github.com/voxel51/fiftyone-teams-app-deploy/tree/main/docker#environment-proxies
 services:

--- a/docker/docs/expose-teams-api.md
+++ b/docker/docs/expose-teams-api.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable no-inline-html line-length -->
+<!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
 
@@ -6,6 +8,7 @@
 
 </p>
 </div>
+<!-- markdownlint-enable no-inline-html line-length -->
 
 ---
 
@@ -13,31 +16,51 @@
 
 You may wish to expose your FiftyOne Teams API for SDK access.
 
-You may expose your `teams-api` service in any manner that suits your deployment strategy.
-The following are two possible solutions but do not represent the entirety of possible solutions.
-Any solution allowing the FiftyOne Teams SDK to use websockets to access the `teams-api` container on port 8000 should work.
+You may expose your `teams-api` service in any
+manner that suits your deployment strategy.
+The following are two possible solutions but
+do not represent the entirety of possible solutions.
+Any solution allowing the FiftyOne Teams SDK to use websockets
+to access the `teams-api` container on port 8000 should work.
 
-**NOTE**: The `teams-api` service uses websockets to maintain connections and allow for long-running processes to complete.
-Please ensure your Infrastructure supports websockets before attempting to expose the `teams-api` service.
-(e.g. You will have to migrate from AWS Classic Load Balancers to AWS Application Load Balancers to provide websockets support.)
+**NOTE**: The `teams-api` service uses websockets to maintain connections
+and allow for long-running processes to complete.
+Please ensure your Infrastructure supports websockets
+before attempting to expose the `teams-api` service.
+(e.g. You will have to migrate from AWS Classic Load Balancers
+to AWS Application Load Balancers to provide websockets support.)
 
-**NOTE**: If you are using file-based storage credentials, or setting environment variables, the same credentials must be shared with the `fiftyone-app` and `teams-api` containers.
-Voxel51 recommends the use of Database Cloud Storage Credentials, which can be configured at `/settings/cloud_storage_credentials`.
+**NOTE**: If you are using file-based storage credentials,
+or setting environment variables, the same credentials must
+be shared with the `fiftyone-app` and `teams-api` containers.
+Voxel51 recommends the use of Database Cloud Storage Credentials,
+which can be configured at `/settings/cloud_storage_credentials`.
 
 ## Expose `teams-api` Directly
 
-**NOTE**: This method does not protect your API endpoint with TLS and will send API Keys in clear text.
-While it is the simplest mechanism, consider the security implications before using this method.
+**NOTE**: This method does not protect your API
+endpoint with TLS and will send API Keys in clear text.
+While it is the simplest mechanism, consider the
+security implications before using this method.
 
 1. Edit your `.env` file setting `API_BIND_ADDRESS` to `0.0.0.0`
 1. Recreate your environment using the
-   [plugin specific](./README.md#enabling-fiftyone-teams-plugins) `docker compose` command
-1. Access your FiftyOne Teams API using the same hostname as your FiftyOne Teams App using port 8000
+   [plugin specific](./README.md#enabling-fiftyone-teams-plugins) command
+
+   ```shell
+   docker compose
+   ```
+
+1. Access your FiftyOne Teams API using the same hostname
+   as your FiftyOne Teams App using port 8000
 
 ## Expose `teams-api` using Nginx and a unique hostname
 
-1. Create a second hostname for your API (e.g. demo-api.fiftyone.ai) and create SSL certificates for that hostname
-1. Using [example-nginx-api.conf](../example-nginx-api.conf) as a template, create a second service for your nginx reverse proxy
+1. Create a second hostname for your API (e.g. demo-api.fiftyone.ai)
+   and create SSL certificates for that hostname
+1. Using
+   [example-nginx-api.conf](../example-nginx-api.conf)
+   as a template, create a second service for your nginx reverse proxy
 1. Reload your nginx configuration
 1. Access your FiftyOne Teams API using the new hostname
 

--- a/helm/docs/plugins-storage.md
+++ b/helm/docs/plugins-storage.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable no-inline-html line-length -->
+<!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
 
@@ -6,19 +8,21 @@
 
 </p>
 </div>
+<!-- markdownlint-enable no-inline-html line-length -->
 
 ---
 
 # Adding Shared Storage for FiftyOne Teams Plugins
 
-This document will provide guidance for adding shared storage for FiftyOne Teams Plugins using
+This document will provide guidance for adding shared
+storage for FiftyOne Teams Plugins using
 
 * Persistent Volumes (PVs)
 * Persistent Volume Claims (PVCs)
 * NFS
 
 Alternate storage solutions vary based on cloud providers and infrastructure services.
-PVCs may be configured using provider specfic services
+PVCs may be configured using provider specific services
 
 * Google Cloud [Filestore](https://cloud.google.com/filestore/docs)
 * Amazon [EFS](https://aws.amazon.com/efs/)
@@ -26,8 +30,10 @@ PVCs may be configured using provider specfic services
 
 ## NFS Share
 
-Configured NFS server with an exported share that grants permission to the kubernetes cluster.
-One such configuration would be to share the `/exports/deployment_name/plugins` directory using a configuration like
+Configured NFS server with an exported share that
+grants permission to the kubernetes cluster.
+One such configuration would be to share the `/exports/deployment_name/plugins`
+directory using a configuration like
 
 ```shell
 $ cat /etc/exports
@@ -36,12 +42,14 @@ $ cat /etc/exports
 /exports/fiftyone_teams_app/plugins 10.202.15.0/24(rw,insecure,no_root_squash,anonuid=1000,anongid=1000,no_subtree_check)
 ```
 
-We recommend that you test this export to make sure the NFS configuration is accurate before proceeding.
+We recommend that you test this export to make sure
+the NFS configuration is accurate before proceeding.
 Testing now will save frustration later.
 
 ## PV and PVC Creation
 
-The following yaml configuration will create a PV and PVC designed to access the NFS share established above
+The following yaml configuration will create a PV and
+PVC designed to access the NFS share established above
 
 ```yaml
 # nfs-pv-pvc.yaml
@@ -93,7 +101,8 @@ To run plugins in a dedicated `teams-plugins` deployment, provide
 * `ReadOnly` access to the `teams-plugins` deployment
 * `ReadWrite` access to the `teams-api` deployment
 
-Add the appropriate `volumes` and `volumeMounts` configurations to the `apiSettings` section of your `values.yaml`
+Add the appropriate `volumes` and `volumeMounts` configurations
+to the `apiSettings` section of your `values.yaml`
 
 ```yaml
 # values.yaml
@@ -109,7 +118,8 @@ apiSettings:
   [...existing config...]
 ```
 
-Add the `volumes` and `volumeMounts` configurations to either the `pluginsSettings` or `appSettings` section of your `values.yaml`
+Add the `volumes` and `volumeMounts` configurations to either
+the `pluginsSettings` or `appSettings` section of your `values.yaml`
 
 ```yaml
 # values.yaml

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -230,6 +230,12 @@ appSettings:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | apiSettings.affinity | object | `{}` | Affinity and anti-affinity for teams-api. [Reference][affinity]. |
+| apiSettings.autoscaling | object | `{"enabled":false,"maxReplicas":20,"minReplicas":2,"targetCPUUtilizationPercentage":80,"targetMemoryUtilizationPercentage":80}` | Configuration settings for teams-api autoscaling Requires `secret.redisConnectionString` to be set |
+| apiSettings.autoscaling.enabled | bool | `false` | Controls horizontal pod autoscaling for teams-api. [Reference][autoscaling]. |
+| apiSettings.autoscaling.maxReplicas | int | `20` | Maximum replicas for horizontal pod autoscaling for teams-api. |
+| apiSettings.autoscaling.minReplicas | int | `2` | Minimum Replicas for horizontal pod autoscaling for teams-api. |
+| apiSettings.autoscaling.targetCPUUtilizationPercentage | int | `80` | Percent CPU utilization for autoscaling for teams-api. |
+| apiSettings.autoscaling.targetMemoryUtilizationPercentage | int | `80` | Percent memory utilization for autoscaling for teams-api. |
 | apiSettings.dnsName | string | `""` | Controls whether teams-api is added to the chart's ingress. When an empty string, a rule for teams-api is not added to the chart managed ingress. When not an empty string, becomes the value to the `host` in the ingress' rule and set `ingress.api` too. |
 | apiSettings.env.FIFTYONE_ENV | string | `"production"` | Controls FiftyOne GraphQL verbosity. When "production", debug mode is disabled and the default logging level is "INFO". When "development", debug mode is enabled and the default logging level is "DEBUG". Can be overridden by setting `apiSettings.env.LOGGING_LEVEL`. |
 | apiSettings.env.FIFTYONE_INTERNAL_SERVICE | bool | `true` | Whether the SDK is running in an internal service context. When running in FiftyOne Teams, set to `true`. |
@@ -241,6 +247,7 @@ appSettings:
 | apiSettings.nodeSelector | object | `{}` | nodeSelector for teams-api. [Reference][node-selector]. |
 | apiSettings.podAnnotations | object | `{}` | Annotations for pods for teams-api. [Reference][annotations]. |
 | apiSettings.podSecurityContext | object | `{}` | Pod-level security attributes and common container settings for teams-api. [Reference][security-context]. |
+| apiSettings.replicaCount | int | `1` | Number of pods in the teams-api deployment's ReplicaSet. Ignored when `apiSettings.autoscaling.enabled: true`. [Reference][deployment]. Requires `secret.redisConnectionURI` to be set |
 | apiSettings.resources | object | `{"limits":{},"requests":{}}` | Container resource requests and limits for teams-api. [Reference][resources]. |
 | apiSettings.securityContext | object | `{}` | Container security configuration for teams-api. [Reference][container-security-context]. |
 | apiSettings.service.annotations | object | `{}` | Service annotations for teams-api. [Reference][annotations]. |
@@ -284,6 +291,7 @@ appSettings:
 | appSettings.service.shortname | string | `"fiftyone-app"` | Port name (maximum length is 15 characters) for fiftyone-app. [Reference][ports]. |
 | appSettings.service.type | string | `"ClusterIP"` | Service type for fiftyone-app. [Reference][service-type]. |
 | appSettings.tolerations | list | `[]` | Allow the k8s scheduler to schedule fiftyone-app pods with matching taints. [Reference][taints-and-tolerations]. |
+| appSettings.useRedisCache | bool | `false` | Controls the use of a Redis cache when multiple API pods are deployed. |
 | appSettings.volumeMounts | list | `[]` | Volume mounts for fiftyone-app. [Reference][volumes]. |
 | appSettings.volumes | list | `[]` | Volumes for fiftyone-app. [Reference][volumes]. |
 | imagePullSecrets | list | `[]` | Container image registry keys. [Reference][image-pull-secrets]. |
@@ -342,6 +350,7 @@ appSettings:
 | secret.fiftyone.fiftyoneDatabaseName | string | `""` | MongoDB Database Name for FiftyOne Teams. |
 | secret.fiftyone.mongodbConnectionString | string | `""` | MongoDB Connection String. [Reference][mongodb-connection-string]. |
 | secret.fiftyone.organizationId | string | `""` | Voxel51-provided Auth0 Organization ID. |
+| secret.fiftyone.redisConnectionURI | string | `""` | Redis Connection URI. [Reference][redis-command-line-usage] |
 | secret.name | string | `"fiftyone-teams-secrets"` | Name of the secret (existing or to be created) in the namespace `namespace.name`. |
 | serviceAccount.annotations | object | `{}` | Service Account annotations. [Reference][annotations]. |
 | serviceAccount.create | bool | `true` | Controls whether to create the service account named `serviceAccount.name`. |
@@ -521,6 +530,8 @@ A minimal example `values.yaml` may be found
 [mongodb-connection-string]: https://www.mongodb.com/docs/manual/reference/connection-string/
 
 [recoil-env]: https://recoiljs.org/docs/api-reference/core/RecoilEnv/
+
+[redis-command-line-usage]: https://redis.io/docs/connect/cli/#command-line-usage
 
 [fiftyone-encryption-key]: https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/README.md#storage-credentials-and-fiftyone_encryption_key
 [fiftyone-config]: https://docs.voxel51.com/user_guide/config.html

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -378,5 +378,7 @@ A minimal example `values.yaml` may be found
 
 [recoil-env]: https://recoiljs.org/docs/api-reference/core/RecoilEnv/
 
+[redis-command-line-usage]: https://redis.io/docs/connect/cli/#command-line-usage
+
 [fiftyone-encryption-key]: https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/README.md#storage-credentials-and-fiftyone_encryption_key
 [fiftyone-config]: https://docs.voxel51.com/user_guide/config.html

--- a/helm/fiftyone-teams-app/templates/_helpers.tpl
+++ b/helm/fiftyone-teams-app/templates/_helpers.tpl
@@ -201,6 +201,13 @@ Create a merged list of environment variables for fiftyone-teams-api
     secretKeyRef:
       name: {{ $secretName }}
       key: encryptionKey
+{{- if or (gt (int .Values.apiSettings.replicaCount) 1) (eq .Values.apiSettings.autoscaling.enabled true) }}
+- name: FIFTYONE_REDIS_URL
+  valueFrom:
+    secretKeyRef:
+      name: {{ $secretName }}
+      key: redisConnectionURI
+{{- end }}
 - name: MONGO_DEFAULT_DB
   valueFrom:
     secretKeyRef:

--- a/helm/fiftyone-teams-app/templates/api-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/api-deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -7,7 +8,9 @@ metadata:
     app: {{ include "teams-api.name" . }}
     {{- include "fiftyone-teams-api.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  {{- if not .Values.apiSettings.autoscaling.enabled }}
+  replicas: {{ .Values.apiSettings.replicaCount | default 1 }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ include "teams-api.name" . }}

--- a/helm/fiftyone-teams-app/templates/api-hpa.yaml
+++ b/helm/fiftyone-teams-app/templates/api-hpa.yaml
@@ -1,0 +1,34 @@
+---
+{{- if .Values.apiSettings.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "fiftyone-app.name" . }}
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    {{- include "fiftyone-app.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "fiftyone-app.name" . }}
+  minReplicas: {{ .Values.apiSettings.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.apiSettings.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.apiSettings.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.apiSettings.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.apiSettings.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.apiSettings.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/helm/fiftyone-teams-app/templates/api-service.yaml
+++ b/helm/fiftyone-teams-app/templates/api-service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/fiftyone-teams-app/templates/app-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/app-deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/fiftyone-teams-app/templates/app-hpa.yaml
+++ b/helm/fiftyone-teams-app/templates/app-hpa.yaml
@@ -1,3 +1,4 @@
+---
 {{- if .Values.appSettings.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler

--- a/helm/fiftyone-teams-app/templates/app-service.yaml
+++ b/helm/fiftyone-teams-app/templates/app-service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/fiftyone-teams-app/templates/ingress.yaml
+++ b/helm/fiftyone-teams-app/templates/ingress.yaml
@@ -1,3 +1,4 @@
+---
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "fiftyone-teams-app.fullname" . -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}

--- a/helm/fiftyone-teams-app/templates/namespace.yaml
+++ b/helm/fiftyone-teams-app/templates/namespace.yaml
@@ -1,3 +1,4 @@
+---
 {{- if .Values.namespace.create -}}
 apiVersion: v1
 kind: Namespace

--- a/helm/fiftyone-teams-app/templates/plugins-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/plugins-deployment.yaml
@@ -1,3 +1,4 @@
+---
 {{- if .Values.pluginsSettings.enabled }}
 apiVersion: apps/v1
 kind: Deployment

--- a/helm/fiftyone-teams-app/templates/plugins-hpa.yaml
+++ b/helm/fiftyone-teams-app/templates/plugins-hpa.yaml
@@ -1,3 +1,4 @@
+---
 {{- if .Values.pluginsSettings.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler

--- a/helm/fiftyone-teams-app/templates/plugins-service.yaml
+++ b/helm/fiftyone-teams-app/templates/plugins-service.yaml
@@ -1,3 +1,4 @@
+---
 {{- if .Values.pluginsSettings.enabled }}
 apiVersion: v1
 kind: Service

--- a/helm/fiftyone-teams-app/templates/secrets.yaml
+++ b/helm/fiftyone-teams-app/templates/secrets.yaml
@@ -1,3 +1,4 @@
+---
 {{- if .Values.secret.create -}}
 apiVersion: v1
 kind: Secret

--- a/helm/fiftyone-teams-app/templates/serviceaccount.yaml
+++ b/helm/fiftyone-teams-app/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+---
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount

--- a/helm/fiftyone-teams-app/templates/teams-app-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/teams-app-deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/fiftyone-teams-app/templates/teams-app-hpa.yaml
+++ b/helm/fiftyone-teams-app/templates/teams-app-hpa.yaml
@@ -1,3 +1,4 @@
+---
 {{- if .Values.teamsAppSettings.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler

--- a/helm/fiftyone-teams-app/templates/teams-app-service.yaml
+++ b/helm/fiftyone-teams-app/templates/teams-app-service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -6,6 +6,19 @@ apiSettings:
   # When not an empty string, becomes the value to the `host` in the ingress' rule and
   # set `ingress.api` too.
   dnsName: ""
+  # -- Configuration settings for teams-api autoscaling
+  # Requires `secret.redisConnectionString` to be set
+  autoscaling:
+    # -- Controls horizontal pod autoscaling for teams-api. [Reference][autoscaling].
+    enabled: false
+    # -- Maximum replicas for horizontal pod autoscaling for teams-api.
+    maxReplicas: 20
+    # -- Minimum Replicas for horizontal pod autoscaling for teams-api.
+    minReplicas: 2
+    # -- Percent CPU utilization for autoscaling for teams-api.
+    targetCPUUtilizationPercentage: 80
+    # -- Percent memory utilization for autoscaling for teams-api.
+    targetMemoryUtilizationPercentage: 80
   # Environment Variables are passed to the teams-api containers
   env:
     # -- Controls FiftyOne GraphQL verbosity.
@@ -31,6 +44,10 @@ apiSettings:
     repository: voxel51/fiftyone-teams-api
     # -- Image tag for teams-api. Defaults to the chart version.
     tag: ""
+  # -- Number of pods in the teams-api deployment's ReplicaSet.
+  # Ignored when `apiSettings.autoscaling.enabled: true`. [Reference][deployment].
+  # Requires `secret.redisConnectionURI` to be set
+  replicaCount: 1
 
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
@@ -165,6 +182,8 @@ appSettings:
     shortname: fiftyone-app
     # -- Service type for fiftyone-app. [Reference][service-type].
     type: ClusterIP
+  # -- Controls the use of a Redis cache when multiple API pods are deployed.
+  useRedisCache: false
 
   # -- Affinity and anti-affinity for fiftyone-app. [Reference][affinity].
   affinity: {}
@@ -346,24 +365,23 @@ secret:
     apiClientSecret: ""
     # -- Voxel51-provided Auth0 Domain.
     auth0Domain: ""
-
     # -- Voxel51-provided Auth0 Client ID.
     clientId: ""
     # -- Voxel51-provided Auth0 Client Secret.
     clientSecret: ""
-    # -- Voxel51-provided Auth0 Organization ID.
-    organizationId: ""
-
-    # -- MongoDB Database Name for FiftyOne Teams.
-    fiftyoneDatabaseName: ""
-    # -- MongoDB Connection String. [Reference][mongodb-connection-string].
-    mongodbConnectionString: ""
-
     # -- A randomly generated string for cookie encryption.
     # To generate, run `openssl rand -hex 32`.
     cookieSecret: ""
     # -- Encryption key for storage credentials. [Reference][fiftyone-encryption-key].
     encryptionKey: ""
+    # -- MongoDB Database Name for FiftyOne Teams.
+    fiftyoneDatabaseName: ""
+    # -- MongoDB Connection String. [Reference][mongodb-connection-string].
+    mongodbConnectionString: ""
+    # -- Voxel51-provided Auth0 Organization ID.
+    organizationId: ""
+    # -- Redis Connection URI. [Reference][redis-command-line-usage]
+    redisConnectionURI: ""
 
 serviceAccount:
   # -- Service Account annotations. [Reference][annotations].

--- a/helm/gke-example/cluster-issuer.yaml
+++ b/helm/gke-example/cluster-issuer.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
@@ -7,12 +8,12 @@ spec:
     # The ACME server URL
     server: https://acme-v02.api.letsencrypt.org/directory
     # Email address used for ACME registration
-    email: topher@voxel51.com # Update to yours
+    email: topher@voxel51.com  # Update to yours
     # Name of a secret used to store the ACME account private key
     privateKeySecretRef:
       name: letsencrypt-prod
     # Enable the HTTP-01 challenge provider
     solvers:
-    - http01:
-        ingress:
+      - http01:
+          ingress:
             class: ingress-gce

--- a/helm/gke-example/frontend-config.yaml
+++ b/helm/gke-example/frontend-config.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: networking.gke.io/v1beta1
 kind: FrontendConfig
 metadata:

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -6,14 +6,20 @@ Module for deploying FiftyOne Teams Infrastructure
 
 ### Simple Two-Node Deploy
 
-**NOTE** This deploys a simple two-node infrastructure that does not provide High Availability.
-If High Availability is a requirement in your environment you should consider modifying this deployment to include multiple MongoDB nodes and multiple app nodes.
+**NOTE** This deploys a simple two-node infrastructure
+that does not provide High Availability.
+If High Availability is a requirement in your environment, consider modifying
+this deployment to include multiple MongoDB nodes and multiple app nodes.
 
-This terraform does not deploy the application - it only deploys two systems; you will still need to use another mechanism to deploy the application itself.
+This terraform does not deploy the application - it only deploys two systems;
+you will still need to use another mechanism to deploy the application itself.
 
-Edit `simple-two-node-deploy/google/terraform.tfvars` to include your Google Compute project name as the `google_project`.
+Edit `simple-two-node-deploy/google/terraform.tfvars` setting
+your Google Compute project name as the `google_project`.
 
-Edit `simple-two-node-deploy/google/public-ssh-keys` to include any SSH keys that will be provisioned for the nodes that are created.  (format `username:contents of public ssh keyfile`)
+Edit `simple-two-node-deploy/google/public-ssh-keys` setting any
+SSH keys that will be provisioned for the nodes that are created.
+(format `username:contents of public ssh keyfile`)
 
 ```shell
 gcloud auth login
@@ -22,9 +28,10 @@ terraform init
 terraform apply
 ```
 
-The terraform apply will output the IP address of each node, the users defined in the `public-ssh-keys` file will have ssh access to the system.
+The terraform apply will output the IP address of each node, the users
+defined in the `public-ssh-keys` file will have ssh access to the system.
 
-**TODO**
+## TODO
 
 - Add a dedicated data drive for MongoDB
 - Make the MongoDB Data Drive XFS formatted

--- a/terraform/simple-two-node-deploy/google/provider.tf
+++ b/terraform/simple-two-node-deploy/google/provider.tf
@@ -3,5 +3,3 @@ provider "google" {
   region  = var.google_region
   zone    = var.google_zone
 }
-
-


### PR DESCRIPTION
# Rationale

In the last few days, there have been a couple of questions about our pre-commit hooks in this repo.

These changes fix all of the errors in the pre-commit checks.


Part of the problem is that helm templates (yaml files containing go template language constructs) aren't valid yaml. It seems like there's a preference to not validate them.  So I excluded them from the checks:

* check-yaml
* yamllint

If we'd rather have some failing checks (that we manually override when making commits) we can remove these lines from `.pre-commit-config.yaml`

```yaml
exclude: helm/fiftyone-teams-app/templates
```


## Testing


<details>
<summary> All passing after excluding the helm template directory </summary>
<details>
```
[fiftyone-teams-app-deploy]$ git commit -m 'Exclude helm/template directory from yaml syntax checking and linting. Fixed markdownlint violations (with ignore comments for markdown, line length, headings, etc)'
check for added large files..........................................................Passed
check for case conflicts.............................................................Passed
check that scripts with shebangs are executable......................................Passed
check yaml...........................................................................Passed
detect aws credentials...............................................................Passed
fix end of files.....................................................................Passed
mixed line ending....................................................................Passed
pretty format json...............................................(no files to check)Skipped
trim trailing whitespace.............................................................Passed
No-tabs checker......................................................................Passed
markdownlint.........................................................................Passed
markdownlint-fix.....................................................................Passed
codespell............................................................................Passed
yamllint.............................................................................Passed
Helm Docs........................................................(no files to check)Skipped
Insert a table of contents in Markdown files, like a README.md...(no files to check)Skipped
[fix-yamllint-findings e94c574] Exclude helm/template directory from yaml syntax checking and linting. Fixed markdownlint violations (with ignore comments for markdown, line length, headings, etc)
 8 files changed, 147 insertions(+), 66 deletions(-)
[fiftyone-teams-app-deploy]$
```

</details>

