### PR TITLE
Snaphot Archive Feature Documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,8 @@ generated using the pre-commit hooks for
 * [https://github.com/norwoodj/helm-docs](https://github.com/norwoodj/helm-docs)
 * [https://github.com/Lucas-C/pre-commit-hooks-nodejs](https://github.com/Lucas-C/pre-commit-hooks-nodejs)
 
+1. Install `helm-docs`: https://github.com/norwoodj/helm-docs#installation
+
 1. Install the pre-commit hooks
 
     ```shell
@@ -67,12 +69,12 @@ generated using the pre-commit hooks for
           2 files changed, 10 insertions(+)
           ```
 
-        * Manually run the pre-commit hooks
+      * Manually run the pre-commit hooks
 
-            ```shell
-            git add helm/fiftyone-teams-app/README.md.gotmpl
-            pre-commit run helm-docs
-            pre-commit run markdown-toc
-            git add helm/fiftyone-teams-app/README.md
-            git commit -m '<COMMIT_MESSAGE>'
-            ```
+          ```shell
+          git add helm/fiftyone-teams-app/README.md.gotmpl
+          pre-commit run helm-docs
+          pre-commit run markdown-toc
+          git add helm/fiftyone-teams-app/README.md
+          git commit -m '<COMMIT_MESSAGE>'
+          ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -79,6 +79,42 @@ quickstart  0.21.2
 
 ### FiftyOne Teams Upgrade Notes
 
+#### Enabling Snapshot Archival
+
+Since version v1.5, FiftyOne Teams supports
+[archiving snapshots](https://docs.voxel51.com/teams/dataset_versioning.html#snapshot-archival)
+to cold storage locations in order to prevent filling up the MongoDB database.
+To enable  this feature, set the `FIFTYONE_SNAPSHOTS_ARCHIVE_PATH` variable to
+the path  of a chosen storage location.
+
+Supported locations are network mounted filesystems and cloud storage folders.
+
+1. Network mounted filesystem
+
+    - Set the environment variable `FIFTYONE_SNAPSHOTS_ARCHIVE_PATH` to the
+      mounted filesystem path in these containers:
+        - `fiftyone-api`
+        - `teams-app`
+
+    - Mount the filesystem to the `fiftyone-api` container (`teams-app` does
+      not need this despite the variable set above). See
+      [./compose.plugins.yaml](./compose.plugins.yaml) for an example to follow.
+
+1. Cloud storage folder
+    - Set the environment variable `FIFTYONE_SNAPSHOTS_ARCHIVE_PATH` to the
+      cloud storage path where archives should go, for example
+      `gs://my-voxel51-bucket/dev-deployment-snapshot-archives/`, in these
+      containers:
+        - `fiftyone-api`
+        - `teams-app`
+
+    - Ensure the [cloud credentials](https://docs.voxel51.com/teams/installation.html#cloud-credentials)
+      loaded in the `fiftyone-api` container have full edit capabilities to
+      this bucket.
+
+See the [configuration documentation](https://docs.voxel51.com/teams/dataset_versioning.html#dataset-versioning-configuration)
+for other configuration values that control the behavior of automatic snapshot archival.
+
 #### Enabling FiftyOne Teams Authenticated API
 
 FiftyOne Teams v1.3 introduces the capability to connect FiftyOne Teams SDK
@@ -223,7 +259,7 @@ To reduce the logging verbosity, add this environment variable to your `teamsApp
 ROARR_LOG: false
 ```
 
-### Text Similarity
+#### Text Similarity
 
 FiftyOne Teams version 1.2 and higher supports using text
 similarity searches for images that are indexed with a model that
@@ -247,42 +283,6 @@ services:
 
 For more information, see the docs for
 [Docker Compose Extend](https://docs.docker.com/compose/extends/).
-
-### Snapshot Archival
-
-Since version v1.5, FiftyOne Teams supports
-[archiving snapshots](https://docs.voxel51.com/teams/dataset_versioning.html#snapshot-archival)
-to cold storage locations in order to prevent filling up the MongoDB database. To enable
-this feature, set the `FIFTYONE_SNAPSHOTS_ARCHIVE_PATH` variable to the path
-of a chosen storage location.
-
-Supported locations are network mounted filesystems and cloud storage folders.
-
-1. Network mounted filesystem
-
-    - Set the environment variable `FIFTYONE_SNAPSHOTS_ARCHIVE_PATH` to the
-      mounted filesystem path in these containers:
-        - `fiftyone-api`
-        - `teams-app`
-
-    - Mount the filesystem to the `fiftyone-api` container (`teams-app` does
-      not need this despite the variable set above). See
-      [./compose.plugins.yaml](./compose.plugins.yaml) for an example to follow.
-
-1. Cloud storage folder
-    - Set the environment variable `FIFTYONE_SNAPSHOTS_ARCHIVE_PATH` to the
-      cloud storage path where archives should go, for example
-      `gs://my-voxel51-bucket/dev-deployment-snapshot-archives/`, in these
-      containers:
-        - `fiftyone-api`
-        - `teams-app`
-
-    - Ensure the [cloud credentials](https://docs.voxel51.com/teams/installation.html#cloud-credentials)
-      loaded in the `fiftyone-api` container have full edit capabilities to
-      this bucket.
-
-See the [configuration documentation](https://docs.voxel51.com/teams/dataset_versioning.html#dataset-versioning-configuration)
-for other configuration values that control the behavior of automatic snapshot archival.
 
 ## Upgrade Process Recommendations
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -252,7 +252,7 @@ For more information, see the docs for
 
 Since version v1.5, FiftyOne Teams supports
 [archiving snapshots](https://docs.voxel51.com/teams/dataset_versioning.html#snapshot-archival)
-to cold storage locations to prevent filling up the MongoDB database. To enable
+to cold storage locations in order to prevent filling up the MongoDB database. To enable
 this feature, set the `FIFTYONE_SNAPSHOTS_ARCHIVE_PATH` variable to the path
 of a chosen storage location.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -223,7 +223,7 @@ To reduce the logging verbosity, add this environment variable to your `teamsApp
 ROARR_LOG: false
 ```
 
-#### Text Similarity
+### Text Similarity
 
 FiftyOne Teams version 1.2 and higher supports using text
 similarity searches for images that are indexed with a model that
@@ -247,6 +247,42 @@ services:
 
 For more information, see the docs for
 [Docker Compose Extend](https://docs.docker.com/compose/extends/).
+
+### Snapshot Archival
+
+Since version v1.5, FiftyOne Teams supports
+[archiving snapshots](https://docs.voxel51.com/teams/dataset_versioning.html#snapshot-archival)
+to cold storage locations to prevent filling up the MongoDB database. To enable
+this feature, set the `FIFTYONE_SNAPSHOTS_ARCHIVE_PATH` variable to the path
+of a chosen storage location.
+
+Supported locations are network mounted filesystems and cloud storage folders.
+
+1. Network mounted filesystem
+
+    - Set the environment variable `FIFTYONE_SNAPSHOTS_ARCHIVE_PATH` to the
+      mounted filesystem path in these containers:
+        - `fiftyone-api`
+        - `teams-app`
+
+    - Mount the filesystem to the `fiftyone-api` container (`teams-app` does
+      not need this despite the variable set above). See
+      [./compose.plugins.yaml](./compose.plugins.yaml) for an example to follow.
+
+1. Cloud storage folder
+    - Set the environment variable `FIFTYONE_SNAPSHOTS_ARCHIVE_PATH` to the
+      cloud storage path where archives should go, for example
+      `gs://my-voxel51-bucket/dev-deployment-snapshot-archives/`, in these
+      containers:
+        - `fiftyone-api`
+        - `teams-app`
+
+    - Ensure the [cloud credentials](https://docs.voxel51.com/teams/installation.html#cloud-credentials)
+      loaded in the `fiftyone-api` container have full edit capabilities to
+      this bucket.
+
+See the [configuration documentation](https://docs.voxel51.com/teams/dataset_versioning.html#dataset-versioning-configuration)
+for other configuration values that control the behavior of automatic snapshot archival.
 
 ## Upgrade Process Recommendations
 
@@ -398,6 +434,10 @@ See
 | `FIFTYONE_ENCRYPTION_KEY`                    | Used to encrypt storage credentials in MongoDB                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | Yes      |
 | `FIFTYONE_ENV`                               | GraphQL verbosity for the `fiftyone-teams-api` service; `production` will not log every GraphQL query, any other value will                                                                                                                                                                                                                                                                                                                                                                                                                     | No       |
 | `FIFTYONE_PLUGINS_DIR`                       | Persistent directory for plugins to be stored in. `teams-api` must have write access to this directory, all plugin nodes must have read access to this directory.                                                                                                                                                                                                                                                                                                                                                                               | No       |
+| `FIFTYONE_SNAPSHOTS_ARCHIVE_PATH`            |  Full path to network-mounted file system or a cloud storage path to use for snapshot archive storage. The default `None` means archival is disabled.                                                                                                                                                                                                                                                                                                                                                                                           | No       |
+| `FIFTYONE_SNAPSHOTS_MAX_IN_DB`               | The max total number of Snapshots allowed at once. -1 for no limit. If this limit is exceeded then automatic archival is triggered if enabled, otherwise an error is raised.                                                                                                                                                                                                                                                                                                                                                                    | No       |
+| `FIFTYONE_SNAPSHOTS_MAX_PER_DATASET`         | The max number of Snapshots allowed per dataset. -1 for no limit. If this limit is exceeded then automatic archival is triggered if enabled, otherwise an error is raised.                                                                                                                                                                                                                                                                                                                                                                      | No       |
+| `FIFTYONE_SNAPSHOTS_MIN_LAST_LOADED_SEC`     | The minimum last-loaded age in seconds (as defined by `now-last_loaded_at`) a snapshot must meet to be considered for automatic archival. This limit is intended to help curtail automatic archival of a snapshot a user is actively working with. The default value is 1 day.                                                                                                                                                                                                                                                                  | No       |
 | `FIFTYONE_TEAMS_PROXY_URL`                   | The URL that `fiftyone-teams-app` will use to proxy requests to `fiftyone-app`                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | Yes      |
 | `GRAPHQL_DEFAULT_LIMIT`                      | Default GraphQL limit for results                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | No       |
 | `HTTP_PROXY_URL`                             | The URL for your environment http proxy                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | No       |

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -31,6 +31,7 @@ Please contact Voxel51 for more information regarding Fiftyone Teams.
   - [Storage Credentials and `FIFTYONE_ENCRYPTION_KEY`](#storage-credentials-and-fiftyone_encryption_key)
   - [Proxies](#proxies)
   - [Text Similarity](#text-similarity)
+  - [Snapshot Archival](#snapshot-archival)
 - [Upgrading From Previous Versions](#upgrading-from-previous-versions)
   - [From Early Adopter Versions (Versions less than 1.0)](#from-early-adopter-versions-versions-less-than-10)
   - [From Before FiftyOne Teams Version 1.1.0](#from-before-fiftyone-teams-version-110)
@@ -224,6 +225,42 @@ appSettings:
   image:
     repository: voxel51/fiftyone-app-torch
 ```
+
+### Snapshot Archival
+
+Since version v1.5, FiftyOne Teams supports
+[archiving snapshots](https://docs.voxel51.com/teams/dataset_versioning.html#snapshot-archival)
+to cold storage locations to prevent filling up the MongoDB database. To enable
+this feature, set the `FIFTYONE_SNAPSHOTS_ARCHIVE_PATH` variable to the path
+of a chosen storage location.
+
+Supported locations are network mounted filesystems and cloud storage folders.
+
+1. Network mounted filesystem
+
+    - In `values.yaml`, set the path for a Persistent Volume Claim mounted to the
+      `teams-api` deployment (not necessary to mount to other deployments) in both
+        - `appSettings.env.FIFTYONE_SNAPSHOTS_ARCHIVE_PATH`
+        - `teamsAppSettings.env.FIFTYONE_SNAPSHOTS_ARCHIVE_PATH`
+
+    - Mount a Persistent Volume Claim that provides `ReadWrite` permissions to
+      the `teams-api` deployment at the `FIFTYONE_SNAPSHOTS_ARCHIVE_PATH` path
+      See [Plugins Storage](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/plugins-storage.md)
+      for an example to follow.
+
+1. Cloud storage folder
+
+    - In `values.yaml`, set the cloud storage path where snapshot archives
+      should go, for example
+      `gs://my-voxel51-bucket/dev-deployment-snapshot-archives/`:
+        - `appSettings.env.FIFTYONE_SNAPSHOTS_ARCHIVE_PATH`
+        - `apiSettings.env.FIFTYONE_SNAPSHOTS_ARCHIVE_PATH`
+
+    - Ensure the [cloud credentials](https://docs.voxel51.com/teams/installation.html#cloud-credentials)
+      loaded in the `teams-api` deployment has full edit capabilities to this bucket.
+
+See the [configuration documentation](https://docs.voxel51.com/teams/dataset_versioning.html#dataset-versioning-configuration)
+for other configuration values that control the behavior of automatic snapshot archival.
 
 ## Values
 

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -257,7 +257,7 @@ Supported locations are network mounted filesystems and cloud storage folders.
         - `apiSettings.env.FIFTYONE_SNAPSHOTS_ARCHIVE_PATH`
 
     - Ensure the [cloud credentials](https://docs.voxel51.com/teams/installation.html#cloud-credentials)
-      loaded in the `teams-api` deployment has full edit capabilities to this bucket.
+      loaded in the `teams-api` deployment have full edit capabilities to this bucket.
 
 See the [configuration documentation](https://docs.voxel51.com/teams/dataset_versioning.html#dataset-versioning-configuration)
 for other configuration values that control the behavior of automatic snapshot archival.

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -26,12 +26,12 @@ Please contact Voxel51 for more information regarding Fiftyone Teams.
 
 - [Initial Installation vs. Upgrades](#initial-installation-vs-upgrades)
 - [FiftyOne Features](#fiftyone-features)
+  - [Snapshot Archival](#snapshot-archival)
   - [FiftyOne Teams Authenticated API](#fiftyone-teams-authenticated-api)
   - [FiftyOne Teams Plugins](#fiftyone-teams-plugins)
   - [Storage Credentials and `FIFTYONE_ENCRYPTION_KEY`](#storage-credentials-and-fiftyone_encryption_key)
   - [Proxies](#proxies)
   - [Text Similarity](#text-similarity)
-  - [Snapshot Archival](#snapshot-archival)
 - [Upgrading From Previous Versions](#upgrading-from-previous-versions)
   - [From Early Adopter Versions (Versions less than 1.0)](#from-early-adopter-versions-versions-less-than-10)
   - [From Before FiftyOne Teams Version 1.1.0](#from-before-fiftyone-teams-version-110)
@@ -80,6 +80,42 @@ When performing an upgrade, please review
 ## FiftyOne Features
 
 Consider if you will require these settings for your deployment.
+
+### Snapshot Archival
+
+Since version v1.5, FiftyOne Teams supports
+[archiving snapshots](https://docs.voxel51.com/teams/dataset_versioning.html#snapshot-archival)
+to cold storage locations in order to prevent filling up the MongoDB database.
+To enable this feature, set the `FIFTYONE_SNAPSHOTS_ARCHIVE_PATH` variable to
+the path of a chosen storage location.
+
+Supported locations are network mounted filesystems and cloud storage folders.
+
+1. Network mounted filesystem
+
+    - In `values.yaml`, set the path for a Persistent Volume Claim mounted to the
+      `teams-api` deployment (not necessary to mount to other deployments) in both
+        - `appSettings.env.FIFTYONE_SNAPSHOTS_ARCHIVE_PATH`
+        - `teamsAppSettings.env.FIFTYONE_SNAPSHOTS_ARCHIVE_PATH`
+
+    - Mount a Persistent Volume Claim that provides `ReadWrite` permissions to
+      the `teams-api` deployment at the `FIFTYONE_SNAPSHOTS_ARCHIVE_PATH` path
+      See [Plugins Storage](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/plugins-storage.md)
+      for an example to follow.
+
+1. Cloud storage folder
+
+    - In `values.yaml`, set the cloud storage path where snapshot archives
+      should go, for example
+      `gs://my-voxel51-bucket/dev-deployment-snapshot-archives/`:
+        - `appSettings.env.FIFTYONE_SNAPSHOTS_ARCHIVE_PATH`
+        - `apiSettings.env.FIFTYONE_SNAPSHOTS_ARCHIVE_PATH`
+
+    - Ensure the [cloud credentials](https://docs.voxel51.com/teams/installation.html#cloud-credentials)
+      loaded in the `teams-api` deployment have full edit capabilities to this bucket.
+
+See the [configuration documentation](https://docs.voxel51.com/teams/dataset_versioning.html#dataset-versioning-configuration)
+for other configuration values that control the behavior of automatic snapshot archival.
 
 ### FiftyOne Teams Authenticated API
 
@@ -225,42 +261,6 @@ appSettings:
   image:
     repository: voxel51/fiftyone-app-torch
 ```
-
-### Snapshot Archival
-
-Since version v1.5, FiftyOne Teams supports
-[archiving snapshots](https://docs.voxel51.com/teams/dataset_versioning.html#snapshot-archival)
-to cold storage locations to prevent filling up the MongoDB database. To enable
-this feature, set the `FIFTYONE_SNAPSHOTS_ARCHIVE_PATH` variable to the path
-of a chosen storage location.
-
-Supported locations are network mounted filesystems and cloud storage folders.
-
-1. Network mounted filesystem
-
-    - In `values.yaml`, set the path for a Persistent Volume Claim mounted to the
-      `teams-api` deployment (not necessary to mount to other deployments) in both
-        - `appSettings.env.FIFTYONE_SNAPSHOTS_ARCHIVE_PATH`
-        - `teamsAppSettings.env.FIFTYONE_SNAPSHOTS_ARCHIVE_PATH`
-
-    - Mount a Persistent Volume Claim that provides `ReadWrite` permissions to
-      the `teams-api` deployment at the `FIFTYONE_SNAPSHOTS_ARCHIVE_PATH` path
-      See [Plugins Storage](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/plugins-storage.md)
-      for an example to follow.
-
-1. Cloud storage folder
-
-    - In `values.yaml`, set the cloud storage path where snapshot archives
-      should go, for example
-      `gs://my-voxel51-bucket/dev-deployment-snapshot-archives/`:
-        - `appSettings.env.FIFTYONE_SNAPSHOTS_ARCHIVE_PATH`
-        - `apiSettings.env.FIFTYONE_SNAPSHOTS_ARCHIVE_PATH`
-
-    - Ensure the [cloud credentials](https://docs.voxel51.com/teams/installation.html#cloud-credentials)
-      loaded in the `teams-api` deployment have full edit capabilities to this bucket.
-
-See the [configuration documentation](https://docs.voxel51.com/teams/dataset_versioning.html#dataset-versioning-configuration)
-for other configuration values that control the behavior of automatic snapshot archival.
 
 ## Values
 

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -259,7 +259,7 @@ Supported locations are network mounted filesystems and cloud storage folders.
         - `apiSettings.env.FIFTYONE_SNAPSHOTS_ARCHIVE_PATH`
 
     - Ensure the [cloud credentials](https://docs.voxel51.com/teams/installation.html#cloud-credentials)
-      loaded in the `teams-api` deployment has full edit capabilities to this bucket.
+      loaded in the `teams-api` deployment have full edit capabilities to this bucket.
 
 See the [configuration documentation](https://docs.voxel51.com/teams/dataset_versioning.html#dataset-versioning-configuration)
 for other configuration values that control the behavior of automatic snapshot archival.

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -232,7 +232,7 @@ appSettings:
 
 Since version v1.5, FiftyOne Teams supports
 [archiving snapshots](https://docs.voxel51.com/teams/dataset_versioning.html#snapshot-archival)
-to cold storage locations to prevent filling up the MongoDB database. To enable
+to cold storage locations in order to prevent filling up the MongoDB database. To enable
 this feature, set the `FIFTYONE_SNAPSHOTS_ARCHIVE_PATH` variable to the path
 of a chosen storage location.
 

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -28,12 +28,12 @@ Please contact Voxel51 for more information regarding Fiftyone Teams.
 
 - [Initial Installation vs. Upgrades](#initial-installation-vs-upgrades)
 - [FiftyOne Features](#fiftyone-features)
+  - [Snapshot Archival](#snapshot-archival)
   - [FiftyOne Teams Authenticated API](#fiftyone-teams-authenticated-api)
   - [FiftyOne Teams Plugins](#fiftyone-teams-plugins)
   - [Storage Credentials and `FIFTYONE_ENCRYPTION_KEY`](#storage-credentials-and-fiftyone_encryption_key)
   - [Proxies](#proxies)
   - [Text Similarity](#text-similarity)
-  - [Snapshot Archival](#snapshot-archival)
 - [Upgrading From Previous Versions](#upgrading-from-previous-versions)
   - [From Early Adopter Versions (Versions less than 1.0)](#from-early-adopter-versions-versions-less-than-10)
   - [From Before FiftyOne Teams Version 1.1.0](#from-before-fiftyone-teams-version-110)
@@ -82,6 +82,42 @@ When performing an upgrade, please review
 ## FiftyOne Features
 
 Consider if you will require these settings for your deployment.
+
+### Snapshot Archival
+
+Since version v1.5, FiftyOne Teams supports
+[archiving snapshots](https://docs.voxel51.com/teams/dataset_versioning.html#snapshot-archival)
+to cold storage locations in order to prevent filling up the MongoDB database.
+To enable this feature, set the `FIFTYONE_SNAPSHOTS_ARCHIVE_PATH` variable to
+the path of a chosen storage location.
+
+Supported locations are network mounted filesystems and cloud storage folders.
+
+1. Network mounted filesystem
+
+    - In `values.yaml`, set the path for a Persistent Volume Claim mounted to the
+      `teams-api` deployment (not necessary to mount to other deployments) in both
+        - `appSettings.env.FIFTYONE_SNAPSHOTS_ARCHIVE_PATH`
+        - `teamsAppSettings.env.FIFTYONE_SNAPSHOTS_ARCHIVE_PATH`
+
+    - Mount a Persistent Volume Claim that provides `ReadWrite` permissions to
+      the `teams-api` deployment at the `FIFTYONE_SNAPSHOTS_ARCHIVE_PATH` path
+      See [Plugins Storage](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/plugins-storage.md)
+      for an example to follow.
+
+1. Cloud storage folder
+
+    - In `values.yaml`, set the cloud storage path where snapshot archives
+      should go, for example
+      `gs://my-voxel51-bucket/dev-deployment-snapshot-archives/`:
+        - `appSettings.env.FIFTYONE_SNAPSHOTS_ARCHIVE_PATH`
+        - `apiSettings.env.FIFTYONE_SNAPSHOTS_ARCHIVE_PATH`
+
+    - Ensure the [cloud credentials](https://docs.voxel51.com/teams/installation.html#cloud-credentials)
+      loaded in the `teams-api` deployment have full edit capabilities to this bucket.
+
+See the [configuration documentation](https://docs.voxel51.com/teams/dataset_versioning.html#dataset-versioning-configuration)
+for other configuration values that control the behavior of automatic snapshot archival.
 
 ### FiftyOne Teams Authenticated API
 
@@ -227,42 +263,6 @@ appSettings:
   image:
     repository: voxel51/fiftyone-app-torch
 ```
-
-### Snapshot Archival
-
-Since version v1.5, FiftyOne Teams supports
-[archiving snapshots](https://docs.voxel51.com/teams/dataset_versioning.html#snapshot-archival)
-to cold storage locations in order to prevent filling up the MongoDB database. To enable
-this feature, set the `FIFTYONE_SNAPSHOTS_ARCHIVE_PATH` variable to the path
-of a chosen storage location.
-
-Supported locations are network mounted filesystems and cloud storage folders.
-
-1. Network mounted filesystem
-
-    - In `values.yaml`, set the path for a Persistent Volume Claim mounted to the
-      `teams-api` deployment (not necessary to mount to other deployments) in both
-        - `appSettings.env.FIFTYONE_SNAPSHOTS_ARCHIVE_PATH`
-        - `teamsAppSettings.env.FIFTYONE_SNAPSHOTS_ARCHIVE_PATH`
-
-    - Mount a Persistent Volume Claim that provides `ReadWrite` permissions to
-      the `teams-api` deployment at the `FIFTYONE_SNAPSHOTS_ARCHIVE_PATH` path
-      See [Plugins Storage](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/plugins-storage.md)
-      for an example to follow.
-
-1. Cloud storage folder
-
-    - In `values.yaml`, set the cloud storage path where snapshot archives
-      should go, for example
-      `gs://my-voxel51-bucket/dev-deployment-snapshot-archives/`:
-        - `appSettings.env.FIFTYONE_SNAPSHOTS_ARCHIVE_PATH`
-        - `apiSettings.env.FIFTYONE_SNAPSHOTS_ARCHIVE_PATH`
-
-    - Ensure the [cloud credentials](https://docs.voxel51.com/teams/installation.html#cloud-credentials)
-      loaded in the `teams-api` deployment have full edit capabilities to this bucket.
-
-See the [configuration documentation](https://docs.voxel51.com/teams/dataset_versioning.html#dataset-versioning-configuration)
-for other configuration values that control the behavior of automatic snapshot archival.
 
 {{ template "chart.homepageLine" . }}
 

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -33,6 +33,7 @@ Please contact Voxel51 for more information regarding Fiftyone Teams.
   - [Storage Credentials and `FIFTYONE_ENCRYPTION_KEY`](#storage-credentials-and-fiftyone_encryption_key)
   - [Proxies](#proxies)
   - [Text Similarity](#text-similarity)
+  - [Snapshot Archival](#snapshot-archival)
 - [Upgrading From Previous Versions](#upgrading-from-previous-versions)
   - [From Early Adopter Versions (Versions less than 1.0)](#from-early-adopter-versions-versions-less-than-10)
   - [From Before FiftyOne Teams Version 1.1.0](#from-before-fiftyone-teams-version-110)
@@ -226,6 +227,42 @@ appSettings:
   image:
     repository: voxel51/fiftyone-app-torch
 ```
+
+### Snapshot Archival
+
+Since version v1.5, FiftyOne Teams supports
+[archiving snapshots](https://docs.voxel51.com/teams/dataset_versioning.html#snapshot-archival)
+to cold storage locations to prevent filling up the MongoDB database. To enable
+this feature, set the `FIFTYONE_SNAPSHOTS_ARCHIVE_PATH` variable to the path
+of a chosen storage location.
+
+Supported locations are network mounted filesystems and cloud storage folders.
+
+1. Network mounted filesystem
+
+    - In `values.yaml`, set the path for a Persistent Volume Claim mounted to the
+      `teams-api` deployment (not necessary to mount to other deployments) in both
+        - `appSettings.env.FIFTYONE_SNAPSHOTS_ARCHIVE_PATH`
+        - `teamsAppSettings.env.FIFTYONE_SNAPSHOTS_ARCHIVE_PATH`
+
+    - Mount a Persistent Volume Claim that provides `ReadWrite` permissions to
+      the `teams-api` deployment at the `FIFTYONE_SNAPSHOTS_ARCHIVE_PATH` path
+      See [Plugins Storage](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/plugins-storage.md)
+      for an example to follow.
+
+1. Cloud storage folder
+
+    - In `values.yaml`, set the cloud storage path where snapshot archives
+      should go, for example
+      `gs://my-voxel51-bucket/dev-deployment-snapshot-archives/`:
+        - `appSettings.env.FIFTYONE_SNAPSHOTS_ARCHIVE_PATH`
+        - `apiSettings.env.FIFTYONE_SNAPSHOTS_ARCHIVE_PATH`
+
+    - Ensure the [cloud credentials](https://docs.voxel51.com/teams/installation.html#cloud-credentials)
+      loaded in the `teams-api` deployment has full edit capabilities to this bucket.
+
+See the [configuration documentation](https://docs.voxel51.com/teams/dataset_versioning.html#dataset-versioning-configuration)
+for other configuration values that control the behavior of automatic snapshot archival.
 
 {{ template "chart.homepageLine" . }}
 


### PR DESCRIPTION
Adds documentation for snapshot archive feature.

Mostly points to the official documentation [here](https://docs.voxel51.com/teams/dataset_versioning.html#dataset-versioning-configuration), however goes into a little bit more technical detail given the audience specifically needs to deploy these variables.

So I based the text off of the plugins section and tried to adapt it as best I could.

