### PR TITLE
Increase client_max_body_size in nginx example

### DIFF
--- a/docker/example-nginx-api.conf
+++ b/docker/example-nginx-api.conf
@@ -10,6 +10,7 @@ server {
   proxy_buffer_size   256k;
 
   location / {
+    client_max_body_size 100M;
     proxy_set_header Host $host;
     # if you are using a port other than 443 set:
     # proxy_set_header Host $host:$server_port;

--- a/docker/example-nginx-api.conf
+++ b/docker/example-nginx-api.conf
@@ -10,6 +10,7 @@ server {
   proxy_buffer_size   256k;
 
   location / {
+    # default is 1M; api needs higher for large mongo requests, file import
     client_max_body_size 100M;
     proxy_set_header Host $host;
     # if you are using a port other than 443 set:

--- a/docker/example-nginx-path-routing.conf
+++ b/docker/example-nginx-path-routing.conf
@@ -14,6 +14,8 @@ server {
   proxy_buffer_size   256k;
 
   location /_pymongo {
+    # default is 1M; api needs higher for large mongo requests
+    client_max_body_size 100M;
     proxy_pass http://teams-api;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "Upgrade";
@@ -32,6 +34,8 @@ server {
   }
 
   location /file {
+    # default is 1M; api needs higher for file import
+    client_max_body_size 100M;
     proxy_pass http://teams-api;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "Upgrade";


### PR DESCRIPTION
Motivation: default body max is 1M for nginx. Add explicitly to the example so it's higher for API connections, and so customers can know to override if they wish.

The headaches you'll run into by having a lower max body size are greater than the possibility of getting DoS'ed by huge requests, in my opinion.

Besides, the Sanic max request size is 100M so it makes sense to be consistent.