### PR TITLE
add more details around `teams-plugins` no_proxy

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -158,6 +158,9 @@ There are three modes for plugins
     - Containers need the following access to plugin storage
       - `teams-plugins` requires `read`
       - `fiftyone-api` requires `read-write`
+    - If you are [using a proxy](#environment-proxies), make sure to add the
+      `teams-plugins` service name to your `no_proxy` and
+      `NO_PROXY` environment variables.
     - Example `docker compose` command for this mode
 
         ```shell

--- a/docker/README.md
+++ b/docker/README.md
@@ -158,7 +158,7 @@ There are three modes for plugins
     - Containers need the following access to plugin storage
       - `teams-plugins` requires `read`
       - `fiftyone-api` requires `read-write`
-    - If you are [using a proxy](#environment-proxies), make sure to add the
+    - If you are [using a proxy](#environment-proxies), add the
       `teams-plugins` service name to your `no_proxy` and
       `NO_PROXY` environment variables.
     - Example `docker compose` command for this mode

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -161,9 +161,9 @@ There are three modes for plugins
               at the `FIFTYONE_PLUGINS_DIR` path
             - `ReadOnly` permission to the `teams-plugins` deployment
               at the `FIFTYONE_PLUGINS_DIR` path
-        - If you are [using a proxy](#proxies), make sure to add the
-              `teams-plugins` service name to your `no_proxy` and
-              `NO_PROXY` environment variables.
+        - If you are [using a proxy](#proxies), add the
+          `teams-plugins` service name to your `no_proxy` and
+          `NO_PROXY` environment variables.
 
 Use the FiftyOne Teams UI to deploy plugins by navigating to `https://<DEPOY_URL>/settings/plugins`.
 Early-adopter plugins installed manually must be

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -161,6 +161,9 @@ There are three modes for plugins
               at the `FIFTYONE_PLUGINS_DIR` path
             - `ReadOnly` permission to the `teams-plugins` deployment
               at the `FIFTYONE_PLUGINS_DIR` path
+        - If you are [using a proxy](#proxies), make sure to add the
+              `teams-plugins` service name to your `no_proxy` and
+              `NO_PROXY` environment variables.
 
 Use the FiftyOne Teams UI to deploy plugins by navigating to `https://<DEPOY_URL>/settings/plugins`.
 Early-adopter plugins installed manually must be

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -163,9 +163,9 @@ There are three modes for plugins
               at the `FIFTYONE_PLUGINS_DIR` path
             - `ReadOnly` permission to the `teams-plugins` deployment
               at the `FIFTYONE_PLUGINS_DIR` path
-        - If you are [using a proxy](#proxies), make sure to add the
-              `teams-plugins` service name to your `no_proxy` and
-              `NO_PROXY` environment variables.
+        - If you are [using a proxy](#proxies), add the
+          `teams-plugins` service name to your `no_proxy` and
+          `NO_PROXY` environment variables.
 
 Use the FiftyOne Teams UI to deploy plugins by navigating to `https://<DEPOY_URL>/settings/plugins`.
 Early-adopter plugins installed manually must be

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -163,6 +163,9 @@ There are three modes for plugins
               at the `FIFTYONE_PLUGINS_DIR` path
             - `ReadOnly` permission to the `teams-plugins` deployment
               at the `FIFTYONE_PLUGINS_DIR` path
+        - If you are [using a proxy](#proxies), make sure to add the
+              `teams-plugins` service name to your `no_proxy` and
+              `NO_PROXY` environment variables.
 
 Use the FiftyOne Teams UI to deploy plugins by navigating to `https://<DEPOY_URL>/settings/plugins`.
 Early-adopter plugins installed manually must be


### PR DESCRIPTION
We just had a conversation with a customer who was running into issues when they enabled `teams-plugins`

This was due to the fact that they hadn't added `teams-plugins` to their `no_proxy` configuration

This change adds guidance to help with this configuration change in the future.