### PR TITLE
add TOC to docker and helm README too

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,4 +54,6 @@ repos:
           - --bullets
           - '-'
           - -i
-        files: helm/fiftyone-teams-app/README.md.gotmpl
+          - docker/README.md
+          - helm/fiftyone-teams-app/README.md.gotmpl
+          - helm/README.md

--- a/docker/README.md
+++ b/docker/README.md
@@ -10,6 +10,26 @@
 </div>
 <!-- markdownlint-enable no-inline-html line-length -->
 
+<!-- toc -->
+
+- [Deploying FiftyOne Teams App with Docker Compose](#deploying-fiftyone-teams-app-with-docker-compose)
+  - [Initial Installation vs. Upgrades](#initial-installation-vs-upgrades)
+    - [FiftyOne Teams Upgrade Notes](#fiftyone-teams-upgrade-notes)
+      - [Enabling Snapshot Archival](#enabling-snapshot-archival)
+      - [Enabling FiftyOne Teams Authenticated API](#enabling-fiftyone-teams-authenticated-api)
+      - [Enabling FiftyOne Teams Plugins](#enabling-fiftyone-teams-plugins)
+      - [Storage Credentials and `FIFTYONE_ENCRYPTION_KEY`](#storage-credentials-and-fiftyone_encryption_key)
+      - [Environment Proxies](#environment-proxies)
+      - [Text Similarity](#text-similarity)
+  - [Upgrade Process Recommendations](#upgrade-process-recommendations)
+    - [From Early Adopter Versions (Versions less than 1.0)](#from-early-adopter-versions-versions-less-than-10)
+    - [From Before FiftyOne Teams Version 1.1.0](#from-before-fiftyone-teams-version-110)
+    - [From FiftyOne Teams Version 1.1.0 and later](#from-fiftyone-teams-version-110-and-later)
+  - [Deploying FiftyOne Teams](#deploying-fiftyone-teams)
+  - [FiftyOne Teams Environment Variables](#fiftyone-teams-environment-variables)
+
+<!-- tocstop -->
+
 ---
 
 # Deploying FiftyOne Teams App with Docker Compose

--- a/helm/README.md
+++ b/helm/README.md
@@ -10,6 +10,24 @@
 </div>
 <!-- markdownlint-enable no-inline-html line-length -->
 
+<!-- toc -->
+
+- [FiftyOne Teams Helm Resources](#fiftyone-teams-helm-resources)
+  - [Installing FiftyOne Teams](#installing-fiftyone-teams)
+    - [Example with `values.yaml`](#example-with-valuesyaml)
+    - [A Full Deployment Example on GKE](#a-full-deployment-example-on-gke)
+      - [Download the Example Configuration Files](#download-the-example-configuration-files)
+      - [Create the Necessary Helm Repos](#create-the-necessary-helm-repos)
+    - [Install and Configure cert-manager](#install-and-configure-cert-manager)
+      - [Create a ClusterIssuer](#create-a-clusterissuer)
+      - [Install and Configure MongoDB](#install-and-configure-mongodb)
+      - [Obtain a Global Static IP Address and Configure a DNS Entry](#obtain-a-global-static-ip-address-and-configure-a-dns-entry)
+      - [Set up http to https Forwarding](#set-up-http-to-https-forwarding)
+      - [Install FiftyOne Teams App](#install-fiftyone-teams-app)
+      - [Installation Complete](#installation-complete)
+
+<!-- tocstop -->
+
 ---
 
 # FiftyOne Teams Helm Resources


### PR DESCRIPTION
someone did a neat thing and added a TOC to helm.fiftyone.ai

This extends that work and adds a TOC to the `README.md` files in the top-level of the `fiftyone-teams-app-deploy/helm` and `fiftyone-teams-app-deploy/docker` directories.