### PR TITLE
`FIFTYONE_API_URI` belongs on `teams-app` not `fiftyone-app`

### DIFF
--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -32,6 +32,7 @@ Please contact Voxel51 for more information regarding Fiftyone Teams.
   - [Storage Credentials and `FIFTYONE_ENCRYPTION_KEY`](#storage-credentials-and-fiftyone_encryption_key)
   - [Proxies](#proxies)
   - [Text Similarity](#text-similarity)
+- [Values](#values)
 - [Upgrading From Previous Versions](#upgrading-from-previous-versions)
   - [From Early Adopter Versions (Versions less than 1.0)](#from-early-adopter-versions-versions-less-than-10)
   - [From Before FiftyOne Teams Version 1.1.0](#from-before-fiftyone-teams-version-110)
@@ -271,7 +272,6 @@ appSettings:
 | apiSettings.env.FIFTYONE_INTERNAL_SERVICE | bool | `true` | Whether the SDK is running in an internal service context. When running in FiftyOne Teams, set to `true`. |
 | apiSettings.env.GRAPHQL_DEFAULT_LIMIT | int | `10` | Default number of returned items when listing in GraphQL queries. Can be overridden in the request. |
 | apiSettings.env.LOGGING_LEVEL | string | `"INFO"` | Logging level. Overrides the value of `FIFTYONE_ENV`. Can be one of "DEBUG", "INFO", "WARN", "ERROR", or "CRITICAL". |
-| apiSettings.fiftyoneApiOverride | string | `""` | Overrides the `FIFTYONE_API_URI` environment variable when set `FIFTYONE_API_URI` controls the value shown in the API Key Modal providing guidance for connecting to the FiftyOne Teams API. `FIFTYONE_API_URI` uses the value from apiSettings.dnsName if it is set, or uses the teamsAppSettings.dnsName |
 | apiSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy]. |
 | apiSettings.image.repository | string | `"voxel51/fiftyone-teams-api"` | Container image for the teams-api. |
 | apiSettings.image.tag | string | `""` | Image tag for teams-api. Defaults to the chart version. |
@@ -395,6 +395,7 @@ appSettings:
 | teamsAppSettings.env.FIFTYONE_APP_TEAMS_SDK_RECOMMENDED_VERSION | string | `"0.15.3"` | The recommended fiftyone SDK version that will be displayed in the install modal (i.e. `pip install ... fiftyone==0.11.0`). |
 | teamsAppSettings.env.FIFTYONE_APP_THEME | string | `"dark"` | The default theme configuration. `dark`: Theme will be dark when user visits for the first time. `light`: Theme will be light theme when user visits for the first time. `always-dark`: Sets dark theme on each refresh (overrides user theme changes in the app). `always-light`: Sets light theme on each refresh (overrides user theme changes in the app). |
 | teamsAppSettings.env.RECOIL_DUPLICATE_ATOM_KEY_CHECKING_ENABLED | bool | `false` | Disable duplicate atom/selector key checking that generated false-positive errors. [Reference][recoil-env]. |
+| teamsAppSettings.fiftyoneApiOverride | string | `""` | Overrides the `FIFTYONE_API_URI` environment variable when set `FIFTYONE_API_URI` controls the value shown in the API Key Modal providing guidance for connecting to the FiftyOne Teams API. `FIFTYONE_API_URI` uses the value from apiSettings.dnsName if it is set, or uses the teamsAppSettings.dnsName |
 | teamsAppSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. Reference][image-pull-policy]. |
 | teamsAppSettings.image.repository | string | `"voxel51/fiftyone-teams-app"` | Container image for teams-app. |
 | teamsAppSettings.image.tag | string | `""` | Image tag for teams-app. Defaults to the chart version. |

--- a/helm/fiftyone-teams-app/templates/_helpers.tpl
+++ b/helm/fiftyone-teams-app/templates/_helpers.tpl
@@ -219,14 +219,6 @@ Create a merged list of environment variables for fiftyone-app
 {{- $secretName := .Values.secret.name }}
 - name: API_URL
   value: {{ printf "http://%s:%.0f" .Values.apiSettings.service.name .Values.apiSettings.service.port | quote }}
-- name: FIFTYONE_API_URI
-{{- if .Values.apiSettings.fiftyoneApiOverride }}
-  value: {{ .Values.apiSettings.fiftyoneApiOverride }}
-{{- else if .Values.apiSettings.dnsName }}
-  value: {{ printf "https://%s" .Values.apiSettings.dnsName }}
-{{- else }}
-  value: {{ printf "https://%s" .Values.teamsAppSettings.dnsName }}
-{{- end }}
 - name: FIFTYONE_DATABASE_NAME
   valueFrom:
     secretKeyRef:
@@ -351,6 +343,14 @@ Create a merged list of environment variables for fiftyone-teams-app
     secretKeyRef:
       name: {{ $secretName }}
       key: cookieSecret
+- name: FIFTYONE_API_URI
+{{- if .Values.apiSettings.fiftyoneApiOverride }}
+  value: {{ .Values.apiSettings.fiftyoneApiOverride }}
+{{- else if .Values.apiSettings.dnsName }}
+  value: {{ printf "https://%s" .Values.apiSettings.dnsName }}
+{{- else }}
+  value: {{ printf "https://%s" .Values.teamsAppSettings.dnsName }}
+{{- end }}
 - name: FIFTYONE_SERVER_ADDRESS
   value: ""
 - name: FIFTYONE_SERVER_PATH_PREFIX

--- a/helm/fiftyone-teams-app/templates/_helpers.tpl
+++ b/helm/fiftyone-teams-app/templates/_helpers.tpl
@@ -344,8 +344,8 @@ Create a merged list of environment variables for fiftyone-teams-app
       name: {{ $secretName }}
       key: cookieSecret
 - name: FIFTYONE_API_URI
-{{- if .Values.apiSettings.fiftyoneApiOverride }}
-  value: {{ .Values.apiSettings.fiftyoneApiOverride }}
+{{- if .Values.teamsAppSettings.fiftyoneApiOverride }}
+  value: {{ .Values.teamsAppSettings.fiftyoneApiOverride }}
 {{- else if .Values.apiSettings.dnsName }}
   value: {{ printf "https://%s" .Values.apiSettings.dnsName }}
 {{- else }}

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -32,13 +32,6 @@ apiSettings:
     # -- Image tag for teams-api. Defaults to the chart version.
     tag: ""
 
-  # -- Overrides the `FIFTYONE_API_URI` environment variable when set
-  # `FIFTYONE_API_URI` controls the value shown in the API Key Modal providing guidance
-  # for connecting to the FiftyOne Teams API.
-  # `FIFTYONE_API_URI` uses the value from apiSettings.dnsName if it is set, or
-  # uses the teamsAppSettings.dnsName
-  fiftyoneApiOverride: ""
-
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -428,6 +421,14 @@ teamsAppSettings:
     repository: voxel51/fiftyone-teams-app
     # -- Image tag for teams-app. Defaults to the chart version.
     tag: ""
+
+  # -- Overrides the `FIFTYONE_API_URI` environment variable when set
+  # `FIFTYONE_API_URI` controls the value shown in the API Key Modal providing guidance
+  # for connecting to the FiftyOne Teams API.
+  # `FIFTYONE_API_URI` uses the value from apiSettings.dnsName if it is set, or
+  # uses the teamsAppSettings.dnsName
+  fiftyoneApiOverride: ""
+
   # -- Number of pods in the teams-app deployment's ReplicaSet.
   # Ignored when `teamsAppSettings.autoscaling.enabled: true`. [Reference][deployment].
   replicaCount: 2


### PR DESCRIPTION
I, mistakenly, put this in the wrong set of env vars, and we all missed it during the review (all of the helm-chart output said it was wrong... 🤷 )

I got the docker part right, so no changes needed there.

Also, I botched the docs...

<details>
<summary>Helm Update with no overrides</summary>

```
❯ helm diff -C1 upgrade demo-fiftyone-ai ../fiftyone-teams-app-deploy/helm/fiftyone-teams-app -f helm-configs/demo-values.yaml
demo-fiftyone-ai, teams-app, Deployment (apps) has changed:
...
                    key: cookieSecret
+             - name: FIFTYONE_API_URI
+               value: https://demo-api.fiftyone.ai
              - name: FIFTYONE_SERVER_ADDRESS
...
```
</details>

<details>
<summary>Helm Update with no `apiSettings.dnsName`</summary>

```
❯ helm diff -C1 upgrade demo-fiftyone-ai ../fiftyone-teams-app-deploy/helm/fiftyone-teams-app -f helm-configs/demo-values.yaml --set apiSettings.dnsName=""
demo-fiftyone-ai, demo-fiftyone-ai-fiftyone-teams-app, Ingress (networking.k8s.io) has changed:
[ommitted expected ingress changes that only happen if you remove the dnsName for apiSettings]
demo-fiftyone-ai, teams-app, Deployment (apps) has changed:
...
                    key: cookieSecret
+             - name: FIFTYONE_API_URI
+               value: https://demo.fiftyone.ai
              - name: FIFTYONE_SERVER_ADDRESS
...
```
</details>

<details>
<summary>Helm Update with `teamsAppSettings.apiUriOverride</summary>

```
❯ helm diff -C1 upgrade demo-fiftyone-ai ../fiftyone-teams-app-deploy/helm/fiftyone-teams-app -f helm-configs/demo-values.yaml --set teamsAppSettings.fiftyoneApiOverride="some random string"
demo-fiftyone-ai, teams-app, Deployment (apps) has changed:
...
                    key: cookieSecret
+             - name: FIFTYONE_API_URI
+               value: some random string
              - name: FIFTYONE_SERVER_ADDRESS
...
```
</details>