### PR TITLE
Add pre commit hook detect secrets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,3 +55,10 @@ repos:
           - '-'
           - -i
         files: helm/fiftyone-teams-app/README.md.gotmpl
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.4.0
+    hooks:
+      - id: detect-secrets
+        args:
+          - --exclude-secrets
+          - '(password|REPLACEME|fiftyone-teams-tls-secret)'


### PR DESCRIPTION
# Rationale

Since this repo is a boilerplate for installation, it may contain secret information that we do not want to add to this public repository.

To prevent that, I added a new pre-commit hook https://github.com/Yelp/detect-secrets.  It takes a while to run, but the commit runtime tradeoff is preferable to commiting secrets.

## Changes

* Added pre-commit hook `detect-secrets`

## Testing

After installing the hook via `make hooks`, we can run this one hook against the repo

```shell
[fiftyone-teams-app-deploy]$ time pre-commit run detect-secrets --all-files
Detect secrets...........................................................Passed
pre-commit run detect-secrets --all-files  21.80s user 0.46s system 108% cpu 20.576 total
```

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
