### PR TITLE
bump release versions (prep for release later today)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,3 +57,10 @@ repos:
           - docker/README.md
           - helm/fiftyone-teams-app/README.md.gotmpl
           - helm/README.md
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.4.0
+    hooks:
+      - id: detect-secrets
+        args:
+          - --exclude-secrets
+          - '(password|REPLACEME|fiftyone-teams-tls-secret)'

--- a/docker/README.md
+++ b/docker/README.md
@@ -299,7 +299,7 @@ For example, `compose.override.yaml` might look like:
 ```yaml
 services:
   fiftyone-app:
-    image: voxel51/fiftyone-app-torch:v1.5.4
+    image: voxel51/fiftyone-app-torch:v1.5.5
 ```
 
 For more information, see the docs for
@@ -315,7 +315,7 @@ create a new IdP or modify your existing configuration.
 
 ### From Before FiftyOne Teams Version 1.1.0
 
-The FiftyOne 0.15.4 SDK (database version 0.23.3) is _NOT_ backwards-compatible
+The FiftyOne 0.15.5 SDK (database version 0.23.4) is _NOT_ backwards-compatible
 with FiftyOne Teams Database Versions prior to 0.19.0.
 The FiftyOne 0.10.x SDK is not forwards compatible
 with current FiftyOne Teams Database Versions.
@@ -332,16 +332,16 @@ versions prior to FiftyOne Teams version 1.1.0:
    (see
    [env.template](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/docker/env.template#L17)
    for details)
-1. [Upgrade to FiftyOne Teams version 1.5.4](#deploying-fiftyone-teams)
+1. [Upgrade to FiftyOne Teams version 1.5.5](#deploying-fiftyone-teams)
    with `FIFTYONE_DATABASE_ADMIN=true`
    (this is not the default in the `compose.yaml` for this release).
     - **NOTE:** FiftyOne SDK users will lose access to the
-      FiftyOne Teams Database at this step until they upgrade to `fiftyone==0.15.4`
-1. Upgrade your FiftyOne SDKs to version 0.15.4
+      FiftyOne Teams Database at this step until they upgrade to `fiftyone==0.15.5`
+1. Upgrade your FiftyOne SDKs to version 0.15.5
     - Login to the FiftyOne Teams UI
     - To obtain the CLI command to install the FiftyOne SDK associated with
       your FiftyOne Teams version, navigate to `Account > Install FiftyOne`
-1. Check if datasets have been migrated to version 0.23.3.
+1. Check if datasets have been migrated to version 0.23.4.
 
     ```shell
     fiftyone migrate --info
@@ -355,10 +355,10 @@ versions prior to FiftyOne Teams version 1.1.0:
 
 ### From FiftyOne Teams Version 1.1.0 and later
 
-The FiftyOne 0.15.4 SDK is backwards-compatible with
+The FiftyOne 0.15.5 SDK is backwards-compatible with
 FiftyOne Teams Database Versions 0.19.0 and later.
-You will not be able to connect to a FiftyOne Teams 1.5.4
-database (version 0.23.3) with any FiftyOne SDK before 0.15.4.
+You will not be able to connect to a FiftyOne Teams 1.5.5
+database (version 0.23.4) with any FiftyOne SDK before 0.15.5.
 
 Voxel51 always recommends using the latest version of the
 FiftyOne SDK compatible with your FiftyOne Teams deployment.
@@ -374,8 +374,8 @@ upgrading from FiftyOne Teams version 1.1.0 or later:
     - set `FIFTYONE_DATABASE_ADMIN=false`
     - `unset FIFTYONE_DATABASE_ADMIN`
         - This should generally be your default
-1. [Upgrade to FiftyOne Teams version 1.5.4](#deploying-fiftyone-teams)
-1. Upgrade FiftyOne Teams SDK users to FiftyOne Teams version 0.15.4
+1. [Upgrade to FiftyOne Teams version 1.5.5](#deploying-fiftyone-teams)
+1. Upgrade FiftyOne Teams SDK users to FiftyOne Teams version 0.15.5
     - Login to the FiftyOne Teams UI
     - To obtain the CLI command to install the FiftyOne SDK associated with
       your FiftyOne Teams version, navigate to `Account > Install FiftyOne`
@@ -385,10 +385,10 @@ upgrading from FiftyOne Teams version 1.1.0 or later:
     FIFTYONE_DATABASE_ADMIN=true fiftyone migrate --all
     ```
 
-    - **NOTE** Any FiftyOne SDK less than 0.15.4 will lose database connectivity
-      at this point. Upgrading to `fiftyone==0.15.4` is required
+    - **NOTE** Any FiftyOne SDK less than 0.15.5 will lose database connectivity
+      at this point. Upgrading to `fiftyone==0.15.5` is required
 
-1. To ensure that all datasets are now at version 0.23.3, run
+1. To ensure that all datasets are now at version 0.23.4, run
 
     ```shell
     fiftyone migrate --info
@@ -416,7 +416,7 @@ upgrading from FiftyOne Teams version 1.1.0 or later:
     FIFTYONE_DATABASE_ADMIN=true fiftyone migrate --all
     ```
 
-1. To ensure that all datasets are now at version 0.23.3, run
+1. To ensure that all datasets are now at version 0.23.4, run
 
     ```shell
     fiftyone migrate --info

--- a/docker/common-services.yaml
+++ b/docker/common-services.yaml
@@ -1,7 +1,7 @@
 ---
 services:
   teams-api-common:
-    image: voxel51/fiftyone-teams-api:v1.5.4
+    image: voxel51/fiftyone-teams-api:v1.5.5
     environment:
       AUTH0_CLIENT_ID: ${AUTH0_CLIENT_ID}
       AUTH0_AUDIENCE: ${AUTH0_AUDIENCE}
@@ -31,7 +31,7 @@ services:
     restart: always
 
   teams-app-common:
-    image: voxel51/fiftyone-teams-app:v1.5.4
+    image: voxel51/fiftyone-teams-app:v1.5.5
     environment:
       API_URL: ${API_URL}
       AUTH0_AUDIENCE: ${AUTH0_AUDIENCE}
@@ -43,7 +43,7 @@ services:
       AUTH0_SECRET: ${AUTH0_SECRET}
       APP_USE_HTTPS: ${APP_USE_HTTPS:-true}
       FIFTYONE_API_URI: ${FIFTYONE_API_URI:-"Please contact your Admin for an API URI"}
-      FIFTYONE_APP_TEAMS_SDK_RECOMMENDED_VERSION: 0.15.4
+      FIFTYONE_APP_TEAMS_SDK_RECOMMENDED_VERSION: 0.15.5
       FIFTYONE_SERVER_ADDRESS: ""
       FIFTYONE_SERVER_PATH_PREFIX: /api/proxy/fiftyone-teams
       FIFTYONE_TEAMS_PROXY_URL: ${FIFTYONE_TEAMS_PROXY_URL}
@@ -68,7 +68,7 @@ services:
     restart: always
 
   fiftyone-app-common:
-    image: voxel51/fiftyone-app:v1.5.4
+    image: voxel51/fiftyone-app:v1.5.5
     environment:
       API_URL: ${API_URL}
       FIFTYONE_DATABASE_ADMIN: false
@@ -99,7 +99,7 @@ services:
     restart: always
 
   teams-plugins-common:
-    image: voxel51/fiftyone-app:v1.5.4
+    image: voxel51/fiftyone-app:v1.5.5
     environment:
       API_URL: ${API_URL}
       FIFTYONE_DATABASE_ADMIN: false

--- a/helm/fiftyone-teams-app/Chart.yaml
+++ b/helm/fiftyone-teams-app/Chart.yaml
@@ -4,6 +4,6 @@ name: fiftyone-teams-app
 namespace: fiftyone-teams
 description: FiftyOne Teams is the enterprise version of the open source [FiftyOne](https://github.com/voxel51/fiftyone) project.
 type: application
-version: 1.5.4
-appVersion: "v1.5.4"
+version: 1.5.5
+appVersion: "v1.5.5"
 icon: https://voxel51.com/images/logo/voxel51-logo-horz-color-600dpi.png

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -15,7 +15,7 @@
 # fiftyone-teams-app
 
 <!-- markdownlint-disable line-length -->
-![Version: 1.5.4](https://img.shields.io/badge/Version-1.5.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.5.4](https://img.shields.io/badge/AppVersion-v1.5.4-informational?style=flat-square)
+![Version: 1.5.5](https://img.shields.io/badge/Version-1.5.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.5.5](https://img.shields.io/badge/AppVersion-v1.5.5-informational?style=flat-square)
 
 FiftyOne Teams is the enterprise version of the open source [FiftyOne](https://github.com/voxel51/fiftyone) project.
 <!-- markdownlint-enable line-length -->
@@ -32,6 +32,7 @@ Please contact Voxel51 for more information regarding Fiftyone Teams.
   - [Storage Credentials and `FIFTYONE_ENCRYPTION_KEY`](#storage-credentials-and-fiftyone_encryption_key)
   - [Proxies](#proxies)
   - [Text Similarity](#text-similarity)
+- [Values](#values)
 - [Upgrading From Previous Versions](#upgrading-from-previous-versions)
   - [From Early Adopter Versions (Versions less than 1.0)](#from-early-adopter-versions-versions-less-than-10)
   - [From Before FiftyOne Teams Version 1.1.0](#from-before-fiftyone-teams-version-110)
@@ -391,7 +392,7 @@ appSettings:
 | teamsAppSettings.dnsName | string | `""` | DNS Name for the teams-app service. Used in the chart managed ingress (`spec.tls.hosts` and `spec.rules[0].host`) and teams-app deployment environment variable `AUTH0_BASE_URL`. |
 | teamsAppSettings.env.APP_USE_HTTPS | bool | `true` | Controls the protocol of the teams-app. Configure your ingress to match. When `true`, uses the https protocol. When `false`, uses the http protocol. |
 | teamsAppSettings.env.FIFTYONE_APP_ALLOW_MEDIA_EXPORT | bool | `true` | When `false`, disables media export options |
-| teamsAppSettings.env.FIFTYONE_APP_TEAMS_SDK_RECOMMENDED_VERSION | string | `"0.15.4"` | The recommended fiftyone SDK version that will be displayed in the install modal (i.e. `pip install ... fiftyone==0.11.0`). |
+| teamsAppSettings.env.FIFTYONE_APP_TEAMS_SDK_RECOMMENDED_VERSION | string | `"0.15.5"` | The recommended fiftyone SDK version that will be displayed in the install modal (i.e. `pip install ... fiftyone==0.11.0`). |
 | teamsAppSettings.env.FIFTYONE_APP_THEME | string | `"dark"` | The default theme configuration. `dark`: Theme will be dark when user visits for the first time. `light`: Theme will be light theme when user visits for the first time. `always-dark`: Sets dark theme on each refresh (overrides user theme changes in the app). `always-light`: Sets light theme on each refresh (overrides user theme changes in the app). |
 | teamsAppSettings.env.RECOIL_DUPLICATE_ATOM_KEY_CHECKING_ENABLED | bool | `false` | Disable duplicate atom/selector key checking that generated false-positive errors. [Reference][recoil-env]. |
 | teamsAppSettings.fiftyoneApiOverride | string | `""` | Overrides the `FIFTYONE_API_URI` environment variable. When set `FIFTYONE_API_URI` controls the value shown in the API Key Modal providing guidance for connecting to the FiftyOne Teams API. `FIFTYONE_API_URI` uses the value from apiSettings.dnsName if it is set, or uses the teamsAppSettings.dnsName |
@@ -429,7 +430,7 @@ or modify your existing configuration to migrate to a new Auth0 Tenant.
 
 ### From Before FiftyOne Teams Version 1.1.0
 
-The FiftyOne 0.15.4 SDK (database version 0.23.3) is _NOT_ backwards-compatible
+The FiftyOne 0.15.5 SDK (database version 0.23.4) is _NOT_ backwards-compatible
 with FiftyOne Teams Database Versions prior to 0.19.0.
 The FiftyOne 0.10.x SDK is not forwards compatible
 with current FiftyOne Teams Database Versions.
@@ -442,16 +443,16 @@ versions prior to FiftyOne Teams version 1.1.0:
 1. In your `values.yaml`, set the required
    [FIFTYONE_ENCRYPTION_KEY](#storage-credentials-and-fiftyone_encryption_key)
    environment variable
-1. [Upgrade to FiftyOne Teams version 1.5.4](#launch-fiftyone-teams)
+1. [Upgrade to FiftyOne Teams version 1.5.5](#launch-fiftyone-teams)
    with `appSettings.env.FIFTYONE_DATABASE_ADMIN: true`
    (this is not the default value in `values.yaml` and must be overridden).
     > **NOTE:** At this step, FiftyOne SDK users will lose access to the
-    > FiftyOne Teams Database until they upgrade to `fiftyone==0.15.4`
-1. Upgrade your FiftyOne SDKs to version 0.15.4
+    > FiftyOne Teams Database until they upgrade to `fiftyone==0.15.5`
+1. Upgrade your FiftyOne SDKs to version 0.15.5
     - Login to the FiftyOne Teams UI
     - To obtain the CLI command to install the FiftyOne SDK associated with
       your FiftyOne Teams version, navigate to `Account > Install FiftyOne`
-1. Check if the datasets were migrated to version 0.23.3
+1. Check if the datasets were migrated to version 0.23.4
 
     ```shell
     fiftyone migrate --info
@@ -465,10 +466,10 @@ versions prior to FiftyOne Teams version 1.1.0:
 
 ### From FiftyOne Teams Version 1.1.0 and later
 
-The FiftyOne 0.15.4 SDK is backwards-compatible with
+The FiftyOne 0.15.5 SDK is backwards-compatible with
 FiftyOne Teams Database Versions 0.19.0 and later.
-You will not be able to connect to a FiftyOne Teams 1.5.4
-database (version 0.23.3) with any FiftyOne SDK before 0.15.4.
+You will not be able to connect to a FiftyOne Teams 1.5.5
+database (version 0.23.4) with any FiftyOne SDK before 0.15.5.
 
 We recommend using the latest version of the FiftyOne SDK
 compatible with your FiftyOne Teams deployment.
@@ -480,8 +481,8 @@ upgrading from FiftyOne Teams version 1.1.0 or later:
     - set `FIFTYONE_DATABASE_ADMIN=false`
     - `unset FIFTYONE_DATABASE_ADMIN`
         - This should generally be your default
-1. [Upgrade to FiftyOne Teams version 1.5.4](#launch-fiftyone-teams)
-1. Upgrade FiftyOne Teams SDK users to FiftyOne Teams version 0.15.4
+1. [Upgrade to FiftyOne Teams version 1.5.5](#launch-fiftyone-teams)
+1. Upgrade FiftyOne Teams SDK users to FiftyOne Teams version 0.15.5
     - Login to the FiftyOne Teams UI
     - To obtain the CLI command to install the FiftyOne SDK associated with
       your FiftyOne Teams version, navigate to `Account > Install FiftyOne`
@@ -491,10 +492,10 @@ upgrading from FiftyOne Teams version 1.1.0 or later:
     FIFTYONE_DATABASE_ADMIN=true fiftyone migrate --all
     ```
 
-    > **NOTE** Any FiftyOne SDK less than 0.15.4 will lose database connectivity
-    >  at this point. Upgrading to `fiftyone==0.15.4` is required
+    > **NOTE** Any FiftyOne SDK less than 0.15.5 will lose database connectivity
+    >  at this point. Upgrading to `fiftyone==0.15.5` is required
 
-1. Validate that all datasets are now at version 0.23.3, by running
+1. Validate that all datasets are now at version 0.23.4, by running
 
     ```shell
     fiftyone migrate --info

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -34,6 +34,7 @@ Please contact Voxel51 for more information regarding Fiftyone Teams.
   - [Storage Credentials and `FIFTYONE_ENCRYPTION_KEY`](#storage-credentials-and-fiftyone_encryption_key)
   - [Proxies](#proxies)
   - [Text Similarity](#text-similarity)
+- [Values](#values)
 - [Upgrading From Previous Versions](#upgrading-from-previous-versions)
   - [From Early Adopter Versions (Versions less than 1.0)](#from-early-adopter-versions-versions-less-than-10)
   - [From Before FiftyOne Teams Version 1.1.0](#from-before-fiftyone-teams-version-110)
@@ -271,7 +272,9 @@ appSettings:
 
 {{ template "chart.requirementsSection" . }}
 
-{{ template "chart.valuesSection" . }}
+## Values
+
+{{ template "chart.valuesTable" . }}
 
 ## Upgrading From Previous Versions
 

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -284,7 +284,7 @@ or modify your existing configuration to migrate to a new Auth0 Tenant.
 
 ### From Before FiftyOne Teams Version 1.1.0
 
-The FiftyOne 0.15.4 SDK (database version 0.23.3) is _NOT_ backwards-compatible
+The FiftyOne 0.15.5 SDK (database version 0.23.4) is _NOT_ backwards-compatible
 with FiftyOne Teams Database Versions prior to 0.19.0.
 The FiftyOne 0.10.x SDK is not forwards compatible
 with current FiftyOne Teams Database Versions.
@@ -297,16 +297,16 @@ versions prior to FiftyOne Teams version 1.1.0:
 1. In your `values.yaml`, set the required
    [FIFTYONE_ENCRYPTION_KEY](#storage-credentials-and-fiftyone_encryption_key)
    environment variable
-1. [Upgrade to FiftyOne Teams version 1.5.4](#launch-fiftyone-teams)
+1. [Upgrade to FiftyOne Teams version 1.5.5](#launch-fiftyone-teams)
    with `appSettings.env.FIFTYONE_DATABASE_ADMIN: true`
    (this is not the default value in `values.yaml` and must be overridden).
     > **NOTE:** At this step, FiftyOne SDK users will lose access to the
-    > FiftyOne Teams Database until they upgrade to `fiftyone==0.15.4`
-1. Upgrade your FiftyOne SDKs to version 0.15.4
+    > FiftyOne Teams Database until they upgrade to `fiftyone==0.15.5`
+1. Upgrade your FiftyOne SDKs to version 0.15.5
     - Login to the FiftyOne Teams UI
     - To obtain the CLI command to install the FiftyOne SDK associated with
       your FiftyOne Teams version, navigate to `Account > Install FiftyOne`
-1. Check if the datasets were migrated to version 0.23.3
+1. Check if the datasets were migrated to version 0.23.4
 
     ```shell
     fiftyone migrate --info
@@ -320,10 +320,10 @@ versions prior to FiftyOne Teams version 1.1.0:
 
 ### From FiftyOne Teams Version 1.1.0 and later
 
-The FiftyOne 0.15.4 SDK is backwards-compatible with
+The FiftyOne 0.15.5 SDK is backwards-compatible with
 FiftyOne Teams Database Versions 0.19.0 and later.
-You will not be able to connect to a FiftyOne Teams 1.5.4
-database (version 0.23.3) with any FiftyOne SDK before 0.15.4.
+You will not be able to connect to a FiftyOne Teams 1.5.5
+database (version 0.23.4) with any FiftyOne SDK before 0.15.5.
 
 We recommend using the latest version of the FiftyOne SDK
 compatible with your FiftyOne Teams deployment.
@@ -335,8 +335,8 @@ upgrading from FiftyOne Teams version 1.1.0 or later:
     - set `FIFTYONE_DATABASE_ADMIN=false`
     - `unset FIFTYONE_DATABASE_ADMIN`
         - This should generally be your default
-1. [Upgrade to FiftyOne Teams version 1.5.4](#launch-fiftyone-teams)
-1. Upgrade FiftyOne Teams SDK users to FiftyOne Teams version 0.15.4
+1. [Upgrade to FiftyOne Teams version 1.5.5](#launch-fiftyone-teams)
+1. Upgrade FiftyOne Teams SDK users to FiftyOne Teams version 0.15.5
     - Login to the FiftyOne Teams UI
     - To obtain the CLI command to install the FiftyOne SDK associated with
       your FiftyOne Teams version, navigate to `Account > Install FiftyOne`
@@ -346,10 +346,10 @@ upgrading from FiftyOne Teams version 1.1.0 or later:
     FIFTYONE_DATABASE_ADMIN=true fiftyone migrate --all
     ```
 
-    > **NOTE** Any FiftyOne SDK less than 0.15.4 will lose database connectivity
-    >  at this point. Upgrading to `fiftyone==0.15.4` is required
+    > **NOTE** Any FiftyOne SDK less than 0.15.5 will lose database connectivity
+    >  at this point. Upgrading to `fiftyone==0.15.5` is required
 
-1. Validate that all datasets are now at version 0.23.3, by running
+1. Validate that all datasets are now at version 0.23.4, by running
 
     ```shell
     fiftyone migrate --info

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -403,7 +403,7 @@ teamsAppSettings:
     FIFTYONE_APP_ALLOW_MEDIA_EXPORT: true
     # -- The recommended fiftyone SDK version that will be displayed in the
     # install modal (i.e. `pip install ... fiftyone==0.11.0`).
-    FIFTYONE_APP_TEAMS_SDK_RECOMMENDED_VERSION: 0.15.4
+    FIFTYONE_APP_TEAMS_SDK_RECOMMENDED_VERSION: 0.15.5
     # -- The default theme configuration.
     # `dark`: Theme will be dark when user visits for the first time.
     # `light`: Theme will be light theme when user visits for the first time.

--- a/helm/gke-example/values.yaml
+++ b/helm/gke-example/values.yaml
@@ -33,7 +33,7 @@ secret:
 
 # appSettings:
 #   env:
-#     # FIFTYONE_DATABASE_ADMIN is set to `false` by default for v1.5.4 installs
+#     # FIFTYONE_DATABASE_ADMIN is set to `false` by default for v1.5.5 installs
 #     # If you are performing a new install or an upgrade from v1.0 or earlier
 #     # you may want to set this value to `true`.
 #     # Please see https://helm.fiftyone.ai/#initial-installation-vs-upgrades for details

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -45,7 +45,7 @@ secret:
 
 # appSettings:
 #   env:
-#    FIFTYONE_DATABASE_ADMIN is set to `false` by default for v1.5.4 installs
+#    FIFTYONE_DATABASE_ADMIN is set to `false` by default for v1.5.5 installs
 #     If you are performing a new install or an upgrade from v1.0 or earlier you may want to set
 #     this value to `true`.
 #     Please see https://helm.fiftyone.ai/#initial-installation-vs-upgrades for details


### PR DESCRIPTION
# Rationale

Bump release versions for release later today

## Changes

```
16545  for file in $(find ./ -type f -exec grep -il '0.15' {} \;); do perl -pi -e 's/0\.15\.4/0.15.5/g' $file; done
16546  for file in $(find ./ -type f -exec grep -il '0.23' {} \;); do perl -pi -e 's/0\.23\.3/0.23.4/g' $file; done
16547  for file in $(find ./ -type f -exec grep -il '1.5' {} \;); do perl -pi -e 's/1\.5\.4/1.5.5/g' $file; done
```

## Testing

Will be used for test release.fiftyone.ai deploys later today, post merge

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
