### PR TITLE
Add new configuration for CAS "no legacy" mode

### DIFF
--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -324,12 +324,15 @@ appSettings:
 | appSettings.volumeMounts | list | `[]` | Volume mounts for fiftyone-app. [Reference][volumes]. |
 | appSettings.volumes | list | `[]` | Volumes for fiftyone-app. [Reference][volumes]. |
 | casSettings.affinity | object | `{}` | Affinity and anti-affinity for teams-cas. [Reference][affinity]. |
-| casSettings.databaseName | string | `"cas"` | Provide the name for the CAS Database |
-| casSettings.env | object | `{}` |  |
+| casSettings.env.CAS_DATABASE_NAME | string | `"cas"` | Provide the name for the CAS database |
+| casSettings.env.CAS_DEFAULT_USER_ROLE | string | `"GUEST"` | Set the default user role for new users One of `GUEST`, `COLLABORATOR`, `MEMBER`, `ADMIN` |
+| casSettings.env.CAS_LOG_LEVEL | string | `"INFO"` | Set the CAS Log Level One of `DEBUG`, `INFO`, `WARN`, `ERROR` |
+| casSettings.env.CAS_MONGODB_URI_KEY | string | `"mongodbConnectionString"` | The key from `secret.fiftyone` that contains the CAS MongoDB Connection String. |
+| casSettings.env.ENABLE_LEGACY_MODE | bool | `true` | Toggle CAS Legacy Mode, which continues to use Auth0 integration |
+| casSettings.env.FEATURE_FLAG_ENABLE_INVITATIONS | bool | `true` | Allow Admins to invite users by email NOTE: This is not supported when ENABLE_LEGACY_MODE is `false` |
 | casSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy]. |
 | casSettings.image.repository | string | `"voxel51/teams-cas"` | Container image for teams-cas. |
 | casSettings.image.tag | string | `""` | Image tag for teams-cas. Defaults to the chart version. |
-| casSettings.mongodbUriKey | string | `"mongodbConnectionString"` | Provide the key from secret.fiftyone for the CAS MongoDB Connection String |
 | casSettings.nodeSelector | object | `{}` | nodeSelector for teams-cas. [Reference][node-selector]. |
 | casSettings.podAnnotations | object | `{}` | Annotations for pods for teams-cas. [Reference][annotations]. |
 | casSettings.podSecurityContext | object | `{}` | Pod-level security attributes and common container settings for teams-cas. [Reference][security-context]. |
@@ -406,6 +409,7 @@ appSettings:
 | secret.fiftyone.clientSecret | string | `""` | Voxel51-provided Auth0 Client Secret. |
 | secret.fiftyone.cookieSecret | string | `""` | A randomly generated string for cookie encryption. To generate, run `openssl rand -hex 32`. |
 | secret.fiftyone.encryptionKey | string | `""` | Encryption key for storage credentials. [Reference][fiftyone-encryption-key]. |
+| secret.fiftyone.fiftyoneAuthSecret | string | `""` | A randomly generated string for CAS Authentication. |
 | secret.fiftyone.fiftyoneDatabaseName | string | `""` | MongoDB Database Name for FiftyOne Teams. |
 | secret.fiftyone.mongodbConnectionString | string | `""` | MongoDB Connection String. [Reference][mongodb-connection-string]. |
 | secret.fiftyone.organizationId | string | `""` | Voxel51-provided Auth0 Organization ID. |

--- a/helm/fiftyone-teams-app/templates/_helpers.tpl
+++ b/helm/fiftyone-teams-app/templates/_helpers.tpl
@@ -359,6 +359,8 @@ Create a merged list of environment variables for fiftyone-teams-cas
       name: {{ $secretName }}
       key: mongodbConnectionString
 {{- end }}
+- name: NEXTAUTH_URL
+  value: {{ printf "https://%s/cas/api/auth" .Values.teamsAppSettings.dnsName | quote }}
 {{- range $key, $val := .Values.casSettings.env }}
 - name: {{ $key }}
   value: {{ $val | quote }}

--- a/helm/fiftyone-teams-app/templates/_helpers.tpl
+++ b/helm/fiftyone-teams-app/templates/_helpers.tpl
@@ -255,6 +255,11 @@ Create a merged list of environment variables for fiftyone-app
 {{- $secretName := .Values.secret.name }}
 - name: API_URL
   value: {{ printf "http://%s:%.0f" .Values.apiSettings.service.name .Values.apiSettings.service.port | quote }}
+- name: FIFTYONE_AUTH_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ $secretName }}
+      key: fiftyoneAuthSecret
 - name: FIFTYONE_DATABASE_NAME
   valueFrom:
     secretKeyRef:
@@ -270,11 +275,7 @@ Create a merged list of environment variables for fiftyone-app
     secretKeyRef:
       name: {{ $secretName }}
       key: encryptionKey
-- name: FIFTYONE_TEAMS_DOMAIN
-  valueFrom:
-    secretKeyRef:
-      name: {{ $secretName }}
-      key: auth0Domain
+{{- if .Values.casSettings.env.ENABLE_LEGACY_MODE }}
 - name: FIFTYONE_TEAMS_AUDIENCE
   value: "https://$(FIFTYONE_TEAMS_DOMAIN)/api/v2/"
 - name: FIFTYONE_TEAMS_CLIENT_ID
@@ -282,16 +283,17 @@ Create a merged list of environment variables for fiftyone-app
     secretKeyRef:
       name: {{ $secretName }}
       key: clientId
+- name: FIFTYONE_TEAMS_DOMAIN
+  valueFrom:
+    secretKeyRef:
+      name: {{ $secretName }}
+      key: auth0Domain
 - name: FIFTYONE_TEAMS_ORGANIZATION
   valueFrom:
     secretKeyRef:
       name: {{ $secretName }}
       key: organizationId
-- name: FIFTYONE_AUTH_SECRET
-  valueFrom:
-    secretKeyRef:
-      name: {{ $secretName }}
-      key: fiftyoneAuthSecret
+{{- end }}
 {{- range $key, $val := .Values.appSettings.env }}
 - name: {{ $key }}
   value: {{ $val | quote }}
@@ -370,6 +372,13 @@ Create a merged list of environment variables for fiftyone-teams-plugins
 {{- $secretName := .Values.secret.name }}
 - name: API_URL
   value: {{ printf "http://%s:%.0f" .Values.apiSettings.service.name .Values.apiSettings.service.port | quote }}
+- name: FIFTYONE_AUTH_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ $secretName }}
+      key: fiftyoneAuthSecret
+- name: FIFTYONE_DATABASE_ADMIN
+  value: "false"
 - name: FIFTYONE_DATABASE_NAME
   valueFrom:
     secretKeyRef:
@@ -380,18 +389,12 @@ Create a merged list of environment variables for fiftyone-teams-plugins
     secretKeyRef:
       name: {{ $secretName }}
       key: mongodbConnectionString
-- name: FIFTYONE_DATABASE_ADMIN
-  value: "false"
 - name: FIFTYONE_ENCRYPTION_KEY
   valueFrom:
     secretKeyRef:
       name: {{ $secretName }}
       key: encryptionKey
-- name: FIFTYONE_TEAMS_DOMAIN
-  valueFrom:
-    secretKeyRef:
-      name: {{ $secretName }}
-      key: auth0Domain
+{{- if .Values.casSettings.env.ENABLE_LEGACY_MODE }}
 - name: FIFTYONE_TEAMS_AUDIENCE
   value: "https://$(FIFTYONE_TEAMS_DOMAIN)/api/v2/"
 - name: FIFTYONE_TEAMS_CLIENT_ID
@@ -399,16 +402,17 @@ Create a merged list of environment variables for fiftyone-teams-plugins
     secretKeyRef:
       name: {{ $secretName }}
       key: clientId
+- name: FIFTYONE_TEAMS_DOMAIN
+  valueFrom:
+    secretKeyRef:
+      name: {{ $secretName }}
+      key: auth0Domain
 - name: FIFTYONE_TEAMS_ORGANIZATION
   valueFrom:
     secretKeyRef:
       name: {{ $secretName }}
       key: organizationId
-- name: FIFTYONE_AUTH_SECRET
-  valueFrom:
-    secretKeyRef:
-      name: {{ $secretName }}
-      key: fiftyoneAuthSecret
+{{- end }}
 {{- range $key, $val := .Values.pluginsSettings.env }}
 - name: {{ $key }}
   value: {{ $val | quote }}
@@ -424,11 +428,6 @@ Create a merged list of environment variables for fiftyone-teams-app
 - name: API_URL
   value: {{ printf "http://%s:%.0f" .Values.apiSettings.service.name .Values.apiSettings.service.port | quote }}
 {{- if .Values.casSettings.env.ENABLE_LEGACY_MODE }}
-- name: AUTH0_DOMAIN
-  valueFrom:
-    secretKeyRef:
-      name: {{ $secretName }}
-      key: auth0Domain
 - name: AUTH0_AUDIENCE
   value: "https://$(AUTH0_DOMAIN)/api/v2/"
 - name: AUTH0_BASE_URL
@@ -443,6 +442,11 @@ Create a merged list of environment variables for fiftyone-teams-app
     secretKeyRef:
       name: {{ $secretName }}
       key: clientSecret
+- name: AUTH0_DOMAIN
+  valueFrom:
+    secretKeyRef:
+      name: {{ $secretName }}
+      key: auth0Domain
 - name: AUTH0_ISSUER_BASE_URL
   value: "https://$(AUTH0_DOMAIN)"
 - name: AUTH0_ORGANIZATION

--- a/helm/fiftyone-teams-app/templates/_helpers.tpl
+++ b/helm/fiftyone-teams-app/templates/_helpers.tpl
@@ -193,6 +193,7 @@ Create a merged list of environment variables for fiftyone-teams-api
 */}}
 {{- define "fiftyone-teams-api.env-vars-list" -}}
 {{- $secretName := .Values.secret.name }}
+{{- if .Values.casSettings.env.ENABLE_LEGACY_MODE }}
 - name: AUTH0_API_CLIENT_ID
   valueFrom:
     secretKeyRef:
@@ -213,6 +214,7 @@ Create a merged list of environment variables for fiftyone-teams-api
     secretKeyRef:
       name: {{ $secretName }}
       key: clientId
+{{- end }}
 - name: FIFTYONE_DATABASE_NAME
   valueFrom:
     secretKeyRef:
@@ -301,20 +303,49 @@ Create a merged list of environment variables for fiftyone-teams-cas
 */}}
 {{- define "teams-cas.env-vars-list" -}}
 {{- $secretName := .Values.secret.name }}
-- name: CAS_DATABASE_NAME
-  value: {{ .Values.casSettings.databaseName }}
 - name: CAS_MONGODB_URI
   valueFrom:
     secretKeyRef:
       name: {{ $secretName }}
-      key: {{ .Values.casSettings.mongodbUriKey }}
+      key: {{ .Values.casSettings.env.CAS_MONGODB_URI_KEY }}
 - name: FIFTYONE_AUTH_SECRET
   valueFrom:
     secretKeyRef:
       name: {{ $secretName }}
       key: fiftyoneAuthSecret
-- name: NEXTAUTH_URL
-  value: {{ printf "https://%s/cas/api/auth" .Values.teamsAppSettings.dnsName | quote }}
+{{- if .Values.casSettings.env.ENABLE_LEGACY_MODE }}
+- name: AUTH0_AUTH_CLIENT_ID
+  valueFrom:
+    secretKeyRef:
+      name: {{ $secretName }}
+      key: clientId
+- name: AUTH0_AUTH_CLIENT_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ $secretName }}
+      key: clientSecret
+- name: AUTH0_DOMAIN
+  valueFrom:
+    secretKeyRef:
+      name: {{ $secretName }}
+      key: auth0Domain
+- name: AUTH0_ISSUER_BASE_URL
+  value: "https://$(AUTH0_DOMAIN)"
+- name: AUTH0_MGMT_CLIENT_ID
+  valueFrom:
+    secretKeyRef:
+      name: {{ $secretName }}
+      key: apiClientId
+- name: AUTH0_MGMT_CLIENT_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ $secretName }}
+      key: apiClientSecret
+- name: AUTH0_ORGANIZATION
+  valueFrom:
+    secretKeyRef:
+      name: {{ $secretName }}
+      key: organizationId
 - name: TEAMS_API_DATABASE_NAME
   valueFrom:
     secretKeyRef:
@@ -325,6 +356,7 @@ Create a merged list of environment variables for fiftyone-teams-cas
     secretKeyRef:
       name: {{ $secretName }}
       key: mongodbConnectionString
+{{- end }}
 {{- range $key, $val := .Values.casSettings.env }}
 - name: {{ $key }}
   value: {{ $val | quote }}
@@ -391,6 +423,7 @@ Create a merged list of environment variables for fiftyone-teams-app
 {{- $secretName := .Values.secret.name }}
 - name: API_URL
   value: {{ printf "http://%s:%.0f" .Values.apiSettings.service.name .Values.apiSettings.service.port | quote }}
+{{- if .Values.casSettings.env.ENABLE_LEGACY_MODE }}
 - name: AUTH0_DOMAIN
   valueFrom:
     secretKeyRef:
@@ -422,6 +455,7 @@ Create a merged list of environment variables for fiftyone-teams-app
     secretKeyRef:
       name: {{ $secretName }}
       key: cookieSecret
+{{- end }}
 - name: FIFTYONE_API_URI
 {{- if .Values.teamsAppSettings.fiftyoneApiOverride }}
   value: {{ .Values.teamsAppSettings.fiftyoneApiOverride }}

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -186,10 +186,24 @@ appSettings:
 
 # Central Authentication Service (teams-cas) configurations
 casSettings:
-  # -- Provide the name for the CAS Database
-  databaseName: cas
   # Environment Variables are passed to the teams-cas containers
-  env: {}
+  env:
+    # -- Provide the name for the CAS database
+    CAS_DATABASE_NAME: cas
+    # -- Set the default user role for new users
+    # One of `GUEST`, `COLLABORATOR`, `MEMBER`, `ADMIN`
+    CAS_DEFAULT_USER_ROLE: GUEST
+    # -- Set the CAS Log Level
+    # One of `DEBUG`, `INFO`, `WARN`, `ERROR`
+    CAS_LOG_LEVEL: INFO
+    # -- The key from `secret.fiftyone` that contains the CAS MongoDB Connection
+    # String.
+    CAS_MONGODB_URI_KEY: mongodbConnectionString
+    # -- Toggle CAS Legacy Mode, which continues to use Auth0 integration
+    ENABLE_LEGACY_MODE: true
+    # -- Allow Admins to invite users by email
+    # NOTE: This is not supported when ENABLE_LEGACY_MODE is `false`
+    FEATURE_FLAG_ENABLE_INVITATIONS: true
   image:
     # -- Instruct when the kubelet should pull (download) the specified image.
     # One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy].
@@ -198,9 +212,6 @@ casSettings:
     repository: voxel51/teams-cas
     # -- Image tag for teams-cas. Defaults to the chart version.
     tag: ""
-
-  # -- Provide the key from secret.fiftyone for the CAS MongoDB Connection String
-  mongodbUriKey: mongodbConnectionString
 
   # -- Number of pods in the teams-cas deployment's ReplicaSet. [Reference][deployment].
   replicaCount: 2
@@ -441,6 +452,8 @@ secret:
     cookieSecret: ""
     # -- Encryption key for storage credentials. [Reference][fiftyone-encryption-key].
     encryptionKey: ""
+    # -- A randomly generated string for CAS Authentication.
+    fiftyoneAuthSecret: ""
 
 serviceAccount:
   # -- Service Account annotations. [Reference][annotations].


### PR DESCRIPTION
# Rationale

Based on the documentation [here](https://docs.google.com/document/d/1aNuQGPHz3pKCVU7Zd17UDAVJN9kYqGVRGWSm4WlCwWM/edit#heading=h.k6nuqv7tv8sz) we need to update the CAS environment variables for 'no-legacy' (newauth.dev.fiftyone.ai) deployments

This is all still in the scope of `release/v1.6.0` so there is time to adjust this (and I'm sure there will be more changes) but this PR is to give a first look at the changes to discuss alternative perspectives on how best to introduce these changes.

## Changes

Refactoring the helm chart to:
- omit Auth0 configurations when `no-legacy` mode is in use
- add defaults for the new CAS environment variables, where appropriate
- add new CAS environment variables to the CAS deployment

## Testing

Tested with the `voxel51/cloud-build-and-deploy:topher/cas-no-legacy-helm-chart` branch (PR forthcoming)

<details>
<summary>Helm Diff</summary>

```
❯ export _K8S_ENVIRONMENT='newauth-dev'
export FTA_VERSION='1.6.0.dev7+882a081'
export FOT_VERSION='1.6.0+178d72c'
export APP_VERSION='v1.6.0-882a081.0'
export CAS_VERSION='v1.0.1-882a081.0'
export FO_VERSION='0.16.0+178d72c'

helm diff -C1 upgrade ${_K8S_ENVIRONMENT}-fiftyone-ai ../fiftyone-teams-app-deploy/helm/fiftyone-teams-app -f helm-configs/${_K8S_ENVIRONMENT}-values.yaml --namespace ${_K8S_ENVIRONMENT}-fiftyone-ai --set apiSettings.env.FIFTYONE_TEAMS_VERSION_OVERRIDE="api v${FTA_VERSION} / app v${FOT_VERSION} / cas ${CAS_VERSION} / teams app ${APP_VERSION}" --set apiSettings.env.FIFTYONE_ENV_ID="api v${FTA_VERSION} / app v${FOT_VERSION} / cas ${CAS_VERSION} / teams app ${APP_VERSION}" --set apiSettings.image.tag=v${FTA_VERSION//+/_} --set appSettings.image.tag=v${FOT_VERSION//+/_} --set casSettings.image.tag=${CAS_VERSION//+/_} --set pluginsSettings.image.tag=v${FOT_VERSION//+/_} --set teamsAppSettings.env.FIFTYONE_APP_INSTALL_FIFTYONE_OVERRIDE="pip install --extra-index-url \"https://us-central1-python.pkg.dev/computer-vision-team/dev-python/simple/\" fiftyone==${FO_VERSION}" --set teamsAppSettings.image.tag=${APP_VERSION//+/_}
newauth-dev-fiftyone-ai, teams-api, Deployment (apps) has changed:
...
            env:
-             - name: AUTH0_API_CLIENT_ID
-               valueFrom:
-                 secretKeyRef:
-                   name: newauth-dev-teams-secrets
-                   key: apiClientId
-             - name: AUTH0_API_CLIENT_SECRET
-               valueFrom:
-                 secretKeyRef:
-                   name: newauth-dev-teams-secrets
-                   key: apiClientSecret
-             - name: AUTH0_DOMAIN
-               valueFrom:
-                 secretKeyRef:
-                   name: newauth-dev-teams-secrets
-                   key: auth0Domain
-             - name: AUTH0_CLIENT_ID
-               valueFrom:
-                 secretKeyRef:
-                   name: newauth-dev-teams-secrets
-                   key: clientId
              - name: FIFTYONE_DATABASE_NAME
...
newauth-dev-fiftyone-ai, teams-app, Deployment (apps) has changed:
...
                value: "http://teams-api:80"
-             - name: AUTH0_DOMAIN
-               valueFrom:
-                 secretKeyRef:
-                   name: newauth-dev-teams-secrets
-                   key: auth0Domain
-             - name: AUTH0_AUDIENCE
-               value: "https://$(AUTH0_DOMAIN)/api/v2/"
-             - name: AUTH0_BASE_URL
-               value: "https://newauth.dev.fiftyone.ai"
-             - name: AUTH0_CLIENT_ID
-               valueFrom:
-                 secretKeyRef:
-                   name: newauth-dev-teams-secrets
-                   key: clientId
-             - name: AUTH0_CLIENT_SECRET
-               valueFrom:
-                 secretKeyRef:
-                   name: newauth-dev-teams-secrets
-                   key: clientSecret
-             - name: AUTH0_ISSUER_BASE_URL
-               value: "https://$(AUTH0_DOMAIN)"
-             - name: AUTH0_ORGANIZATION
-               valueFrom:
-                 secretKeyRef:
-                   name: newauth-dev-teams-secrets
-                   key: organizationId
-             - name: AUTH0_SECRET
-               valueFrom:
-                 secretKeyRef:
-                   name: newauth-dev-teams-secrets
-                   key: cookieSecret
              - name: FIFTYONE_API_URI
...
newauth-dev-fiftyone-ai, teams-cas, Deployment (apps) has changed:
...
            env:
-             - name: CAS_DATABASE_NAME
-               value: cas
              - name: CAS_MONGODB_URI
...
                    key: fiftyoneAuthSecret
-             - name: NEXTAUTH_URL
-               value: "https://newauth.dev.fiftyone.ai/cas/api/auth"
-             - name: TEAMS_API_DATABASE_NAME
-               valueFrom:
-                 secretKeyRef:
-                   name: newauth-dev-teams-secrets
-                   key: fiftyoneDatabaseName
-             - name: TEAMS_API_MONGODB_URI
-               valueFrom:
-                 secretKeyRef:
-                   name: newauth-dev-teams-secrets
-                   key: mongodbConnectionString
+             - name: CAS_DATABASE_NAME
+               value: "cas"
+             - name: CAS_DEFAULT_USER_ROLE
+               value: "ADMIN"
+             - name: CAS_LOG_LEVEL
+               value: "DEBUG"
+             - name: CAS_MONGODB_URI_KEY
+               value: "mongodbConnectionString"
              - name: ENABLE_LEGACY_MODE
+               value: "false"
+             - name: FEATURE_FLAG_ENABLE_INVITATIONS
                value: "false"
...
```
</details>

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
