### PR TITLE
refactor FIFTYONE_AUTH_MODE

### DIFF
--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -329,7 +329,7 @@ appSettings:
 | casSettings.env.CAS_LOG_LEVEL | string | `"INFO"` | Set the CAS Log Level One of `DEBUG`, `INFO`, `WARN`, `ERROR` |
 | casSettings.env.CAS_MONGODB_URI_KEY | string | `"mongodbConnectionString"` | The key from `secret.fiftyone` that contains the CAS MongoDB Connection String. |
 | casSettings.env.FEATURE_FLAG_ENABLE_INVITATIONS | bool | `true` | Allow Admins to invite users by email NOTE: This is not supported when FIFTYONE_AUTH_MODE is `internal` |
-| casSettings.env.FIFTYONE_AUTH_MODE | string | `"internal"` | Configure `legacy` or `internal` Authentication Mode One of `legacy` or `internal` |
+| casSettings.env.FIFTYONE_AUTH_MODE | string | `"internal"` | Configure Authentication Mode. One of `legacy` or `internal` |
 | casSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy]. |
 | casSettings.image.repository | string | `"voxel51/teams-cas"` | Container image for teams-cas. |
 | casSettings.image.tag | string | `""` | Image tag for teams-cas. Defaults to the chart version. |

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -328,8 +328,8 @@ appSettings:
 | casSettings.env.CAS_DEFAULT_USER_ROLE | string | `"GUEST"` | Set the default user role for new users One of `GUEST`, `COLLABORATOR`, `MEMBER`, `ADMIN` |
 | casSettings.env.CAS_LOG_LEVEL | string | `"INFO"` | Set the CAS Log Level One of `DEBUG`, `INFO`, `WARN`, `ERROR` |
 | casSettings.env.CAS_MONGODB_URI_KEY | string | `"mongodbConnectionString"` | The key from `secret.fiftyone` that contains the CAS MongoDB Connection String. |
-| casSettings.env.ENABLE_LEGACY_MODE | bool | `true` | Toggle CAS Legacy Mode, which continues to use Auth0 integration |
-| casSettings.env.FEATURE_FLAG_ENABLE_INVITATIONS | bool | `true` | Allow Admins to invite users by email NOTE: This is not supported when ENABLE_LEGACY_MODE is `false` |
+| casSettings.env.FEATURE_FLAG_ENABLE_INVITATIONS | bool | `true` | Allow Admins to invite users by email NOTE: This is not supported when FIFTYONE_AUTH_MODE is `internal` |
+| casSettings.env.FIFTYONE_AUTH_MODE | string | `"internal"` | Configure `legacy` or `internal` Authentication Mode One of `legacy` or `internal` |
 | casSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy]. |
 | casSettings.image.repository | string | `"voxel51/teams-cas"` | Container image for teams-cas. |
 | casSettings.image.tag | string | `""` | Image tag for teams-cas. Defaults to the chart version. |

--- a/helm/fiftyone-teams-app/templates/_helpers.tpl
+++ b/helm/fiftyone-teams-app/templates/_helpers.tpl
@@ -193,7 +193,7 @@ Create a merged list of environment variables for fiftyone-teams-api
 */}}
 {{- define "fiftyone-teams-api.env-vars-list" -}}
 {{- $secretName := .Values.secret.name }}
-{{- if .Values.casSettings.env.ENABLE_LEGACY_MODE }}
+{{- if eq .Values.casSettings.env.FIFTYONE_AUTH_MODE "legacy" }}
 - name: AUTH0_API_CLIENT_ID
   valueFrom:
     secretKeyRef:
@@ -275,7 +275,7 @@ Create a merged list of environment variables for fiftyone-app
     secretKeyRef:
       name: {{ $secretName }}
       key: encryptionKey
-{{- if .Values.casSettings.env.ENABLE_LEGACY_MODE }}
+{{- if eq .Values.casSettings.env.FIFTYONE_AUTH_MODE "legacy" }}
 - name: FIFTYONE_TEAMS_AUDIENCE
   value: "https://$(FIFTYONE_TEAMS_DOMAIN)/api/v2/"
 - name: FIFTYONE_TEAMS_CLIENT_ID
@@ -315,7 +315,7 @@ Create a merged list of environment variables for fiftyone-teams-cas
     secretKeyRef:
       name: {{ $secretName }}
       key: fiftyoneAuthSecret
-{{- if .Values.casSettings.env.ENABLE_LEGACY_MODE }}
+{{- if eq .Values.casSettings.env.FIFTYONE_AUTH_MODE "legacy" }}
 - name: AUTH0_AUTH_CLIENT_ID
   valueFrom:
     secretKeyRef:
@@ -396,7 +396,7 @@ Create a merged list of environment variables for fiftyone-teams-plugins
     secretKeyRef:
       name: {{ $secretName }}
       key: encryptionKey
-{{- if .Values.casSettings.env.ENABLE_LEGACY_MODE }}
+{{- if eq .Values.casSettings.env.FIFTYONE_AUTH_MODE "legacy" }}
 - name: FIFTYONE_TEAMS_AUDIENCE
   value: "https://$(FIFTYONE_TEAMS_DOMAIN)/api/v2/"
 - name: FIFTYONE_TEAMS_CLIENT_ID
@@ -429,7 +429,7 @@ Create a merged list of environment variables for fiftyone-teams-app
 {{- $secretName := .Values.secret.name }}
 - name: API_URL
   value: {{ printf "http://%s:%.0f" .Values.apiSettings.service.name .Values.apiSettings.service.port | quote }}
-{{- if .Values.casSettings.env.ENABLE_LEGACY_MODE }}
+{{- if eq .Values.casSettings.env.FIFTYONE_AUTH_MODE "legacy" }}
 - name: AUTH0_AUDIENCE
   value: "https://$(AUTH0_DOMAIN)/api/v2/"
 - name: AUTH0_BASE_URL

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -202,7 +202,7 @@ casSettings:
     # -- Allow Admins to invite users by email
     # NOTE: This is not supported when FIFTYONE_AUTH_MODE is `internal`
     FEATURE_FLAG_ENABLE_INVITATIONS: true
-    # -- Configure `legacy` or `internal` Authentication Mode
+    # -- Configure Authentication Mode.
     # One of `legacy` or `internal`
     FIFTYONE_AUTH_MODE: internal
   image:

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -199,11 +199,12 @@ casSettings:
     # -- The key from `secret.fiftyone` that contains the CAS MongoDB Connection
     # String.
     CAS_MONGODB_URI_KEY: mongodbConnectionString
-    # -- Toggle CAS Legacy Mode, which continues to use Auth0 integration
-    ENABLE_LEGACY_MODE: true
     # -- Allow Admins to invite users by email
-    # NOTE: This is not supported when ENABLE_LEGACY_MODE is `false`
+    # NOTE: This is not supported when FIFTYONE_AUTH_MODE is `internal`
     FEATURE_FLAG_ENABLE_INVITATIONS: true
+    # -- Configure `legacy` or `internal` Authentication Mode
+    # One of `legacy` or `internal`
+    FIFTYONE_AUTH_MODE: internal
   image:
     # -- Instruct when the kubelet should pull (download) the specified image.
     # One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy].


### PR DESCRIPTION
# Rationale

Refactoring the helm chart to understand `FIFTYONE_AUTH_MODE` instead of `ENABLE_LEGACY_MODE`

## Changes

Changes `ENABLE_LEGACY_MODE: (true|false)` to `FIFTYONE_AUTH_MODE: "(internal|legacy)"`

## Testing

<details>
<summary> `FIFTYONE_AUTH_MODE: "internal"` </summary>

```
❯ export _K8S_ENVIRONMENT='newauth-dev'
export FTA_VERSION='1.6.0rc1+e5d4b9b'
export FOT_VERSION='1.6.0rc1+9d97347'
export APP_VERSION='v1.6.0-e5d4b9b.0'
export CAS_VERSION='v1.0.1-e5d4b9b.0'
export FO_VERSION='0.16.0rc1+9d97347'

helm diff -C1 upgrade ${_K8S_ENVIRONMENT}-fiftyone-ai ../fiftyone-teams-app-deploy/cas-auth-mode-refactor/helm/fiftyone-teams-app -f helm-configs/${_K8S_ENVIRONMENT}-values.yaml --namespace ${_K8S_ENVIRONMENT}-fiftyone-ai --set apiSettings.env.FIFTYONE_TEAMS_VERSION_OVERRIDE="api v${FTA_VERSION} / app v${FOT_VERSION} / cas ${CAS_VERSION} / teams app ${APP_VERSION}" --set apiSettings.env.FIFTYONE_ENV_ID="api v${FTA_VERSION} / app v${FOT_VERSION} / cas ${CAS_VERSION} / teams app ${APP_VERSION}" --set apiSettings.image.tag=v${FTA_VERSION//+/_} --set appSettings.image.tag=v${FOT_VERSION//+/_} --set casSettings.image.tag=${CAS_VERSION//+/_} --set pluginsSettings.image.tag=v${FOT_VERSION//+/_} --set teamsAppSettings.env.FIFTYONE_APP_INSTALL_FIFTYONE_OVERRIDE="pip install --extra-index-url \"https://us-central1-python.pkg.dev/computer-vision-team/dev-python/simple/\" fiftyone==${FO_VERSION}" --set teamsAppSettings.image.tag=${APP_VERSION//+/_}
newauth-dev-fiftyone-ai, teams-cas, Deployment (apps) has changed:
...
                value: "mongodbConnectionString"
-             - name: ENABLE_LEGACY_MODE
-               value: "false"
              - name: FEATURE_FLAG_ENABLE_INVITATIONS
                value: "false"
+             - name: FIFTYONE_AUTH_MODE
+               value: "internal"
            ports:
...
```

</details>

<details>
<summary> `FIFTYONE_AUTH_MODE: "legacy"` </summary>

```
❯ export _K8S_ENVIRONMENT='newauth-dev'
export FTA_VERSION='1.6.0rc1+e5d4b9b'
export FOT_VERSION='1.6.0rc1+9d97347'
export APP_VERSION='v1.6.0-e5d4b9b.0'
export CAS_VERSION='v1.0.1-e5d4b9b.0'
export FO_VERSION='0.16.0rc1+9d97347'

helm diff -C1 upgrade ${_K8S_ENVIRONMENT}-fiftyone-ai ../fiftyone-teams-app-deploy/cas-auth-mode-refactor/helm/fiftyone-teams-app -f helm-configs/${_K8S_ENVIRONMENT}-values.yaml --namespace ${_K8S_ENVIRONMENT}-fiftyone-ai --set apiSettings.env.FIFTYONE_TEAMS_VERSION_OVERRIDE="api v${FTA_VERSION} / app v${FOT_VERSION} / cas ${CAS_VERSION} / teams app ${APP_VERSION}" --set apiSettings.env.FIFTYONE_ENV_ID="api v${FTA_VERSION} / app v${FOT_VERSION} / cas ${CAS_VERSION} / teams app ${APP_VERSION}" --set apiSettings.image.tag=v${FTA_VERSION//+/_} --set appSettings.image.tag=v${FOT_VERSION//+/_} --set casSettings.image.tag=${CAS_VERSION//+/_} --set pluginsSettings.image.tag=v${FOT_VERSION//+/_} --set teamsAppSettings.env.FIFTYONE_APP_INSTALL_FIFTYONE_OVERRIDE="pip install --extra-index-url \"https://us-central1-python.pkg.dev/computer-vision-team/dev-python/simple/\" fiftyone==${FO_VERSION}" --set teamsAppSettings.image.tag=${APP_VERSION//+/_} --set casSettings.env.FIFTYONE_AUTH_MODE="legacy"
newauth-dev-fiftyone-ai, fiftyone-app, Deployment (apps) has changed:
...
                    key: encryptionKey
+             - name: FIFTYONE_TEAMS_AUDIENCE
+               value: "https://$(FIFTYONE_TEAMS_DOMAIN)/api/v2/"
+             - name: FIFTYONE_TEAMS_CLIENT_ID
+               valueFrom:
+                 secretKeyRef:
+                   name: newauth-dev-teams-secrets
+                   key: clientId
+             - name: FIFTYONE_TEAMS_DOMAIN
+               valueFrom:
+                 secretKeyRef:
+                   name: newauth-dev-teams-secrets
+                   key: auth0Domain
+             - name: FIFTYONE_TEAMS_ORGANIZATION
+               valueFrom:
+                 secretKeyRef:
+                   name: newauth-dev-teams-secrets
+                   key: organizationId
              - name: FIFTYONE_DATABASE_ADMIN
...
newauth-dev-fiftyone-ai, teams-api, Deployment (apps) has changed:
...
            env:
+             - name: AUTH0_API_CLIENT_ID
+               valueFrom:
+                 secretKeyRef:
+                   name: newauth-dev-teams-secrets
+                   key: apiClientId
+             - name: AUTH0_API_CLIENT_SECRET
+               valueFrom:
+                 secretKeyRef:
+                   name: newauth-dev-teams-secrets
+                   key: apiClientSecret
+             - name: AUTH0_DOMAIN
+               valueFrom:
+                 secretKeyRef:
+                   name: newauth-dev-teams-secrets
+                   key: auth0Domain
+             - name: AUTH0_CLIENT_ID
+               valueFrom:
+                 secretKeyRef:
+                   name: newauth-dev-teams-secrets
+                   key: clientId
              - name: FIFTYONE_DATABASE_NAME
...
newauth-dev-fiftyone-ai, teams-app, Deployment (apps) has changed:
...
                value: "http://teams-api:80"
+             - name: AUTH0_AUDIENCE
+               value: "https://$(AUTH0_DOMAIN)/api/v2/"
+             - name: AUTH0_BASE_URL
+               value: "https://newauth.dev.fiftyone.ai"
+             - name: AUTH0_CLIENT_ID
+               valueFrom:
+                 secretKeyRef:
+                   name: newauth-dev-teams-secrets
+                   key: clientId
+             - name: AUTH0_CLIENT_SECRET
+               valueFrom:
+                 secretKeyRef:
+                   name: newauth-dev-teams-secrets
+                   key: clientSecret
+             - name: AUTH0_DOMAIN
+               valueFrom:
+                 secretKeyRef:
+                   name: newauth-dev-teams-secrets
+                   key: auth0Domain
+             - name: AUTH0_ISSUER_BASE_URL
+               value: "https://$(AUTH0_DOMAIN)"
+             - name: AUTH0_ORGANIZATION
+               valueFrom:
+                 secretKeyRef:
+                   name: newauth-dev-teams-secrets
+                   key: organizationId
+             - name: AUTH0_SECRET
+               valueFrom:
+                 secretKeyRef:
+                   name: newauth-dev-teams-secrets
+                   key: cookieSecret
              - name: FIFTYONE_API_URI
...
newauth-dev-fiftyone-ai, teams-cas, Deployment (apps) has changed:
...
                    key: fiftyoneAuthSecret
+             - name: AUTH0_AUTH_CLIENT_ID
+               valueFrom:
+                 secretKeyRef:
+                   name: newauth-dev-teams-secrets
+                   key: clientId
+             - name: AUTH0_AUTH_CLIENT_SECRET
+               valueFrom:
+                 secretKeyRef:
+                   name: newauth-dev-teams-secrets
+                   key: clientSecret
+             - name: AUTH0_DOMAIN
+               valueFrom:
+                 secretKeyRef:
+                   name: newauth-dev-teams-secrets
+                   key: auth0Domain
+             - name: AUTH0_ISSUER_BASE_URL
+               value: "https://$(AUTH0_DOMAIN)"
+             - name: AUTH0_MGMT_CLIENT_ID
+               valueFrom:
+                 secretKeyRef:
+                   name: newauth-dev-teams-secrets
+                   key: apiClientId
+             - name: AUTH0_MGMT_CLIENT_SECRET
+               valueFrom:
+                 secretKeyRef:
+                   name: newauth-dev-teams-secrets
+                   key: apiClientSecret
+             - name: AUTH0_ORGANIZATION
+               valueFrom:
+                 secretKeyRef:
+                   name: newauth-dev-teams-secrets
+                   key: organizationId
+             - name: TEAMS_API_DATABASE_NAME
+               valueFrom:
+                 secretKeyRef:
+                   name: newauth-dev-teams-secrets
+                   key: fiftyoneDatabaseName
+             - name: TEAMS_API_MONGODB_URI
+               valueFrom:
+                 secretKeyRef:
+                   name: newauth-dev-teams-secrets
+                   key: mongodbConnectionString
              - name: NEXTAUTH_URL
...
                value: "mongodbConnectionString"
-             - name: ENABLE_LEGACY_MODE
-               value: "false"
              - name: FEATURE_FLAG_ENABLE_INVITATIONS
                value: "false"
+             - name: FIFTYONE_AUTH_MODE
+               value: "legacy"
            ports:
...
newauth-dev-fiftyone-ai, teams-plugins, Deployment (apps) has changed:
...
                    key: encryptionKey
+             - name: FIFTYONE_TEAMS_AUDIENCE
+               value: "https://$(FIFTYONE_TEAMS_DOMAIN)/api/v2/"
+             - name: FIFTYONE_TEAMS_CLIENT_ID
+               valueFrom:
+                 secretKeyRef:
+                   name: newauth-dev-teams-secrets
+                   key: clientId
+             - name: FIFTYONE_TEAMS_DOMAIN
+               valueFrom:
+                 secretKeyRef:
+                   name: newauth-dev-teams-secrets
+                   key: auth0Domain
+             - name: FIFTYONE_TEAMS_ORGANIZATION
+               valueFrom:
+                 secretKeyRef:
+                   name: newauth-dev-teams-secrets
+                   key: organizationId
              - name: FIFTYONE_INTERNAL_SERVICE
...
```

</details>

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
