### PR TITLE
docs: reformat the base helm/values.yaml template.  Update docs for p…

### DIFF
--- a/helm/docs/expose-teams-api.md
+++ b/helm/docs/expose-teams-api.md
@@ -62,6 +62,7 @@ Add a Second Host to the Ingress Controller
 ## Path-Based Routing
 
 Path based routing doesn't require additional DNS entries and TLS certificates.
+In `values.yaml`, remove `apiSettings.dnsName`.
 This routes traffic to the API paths to the `teams-api` service.
 
 Every Ingress Controller implementation is different.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,42 +1,56 @@
 ---
-# Voxel51 provided you with a voxel51-docker.json file, you can use the following command to create a Pull Secret:
-#  kubectl --namespace your-namespace-here create secret generic regcred \
-#    --from-file=.dockerconfigjson=./voxel51-docker.json --type kubernetes.io/dockerconfigjson
-# If you use the Voxel51 command above your imagePullSecrets would look like:
+# # Voxel51 provided you with a voxel51-docker.json file, you can use the following command to create a Pull Secret:
+# #
+# # ```shell
+# #  kubectl --namespace your-namespace-here create secret generic regcred \
+# #    --from-file=.dockerconfigjson=./voxel51-docker.json --type kubernetes.io/dockerconfigjson
+# # ```
+# #
+# # If you use the Voxel51 command above your imagePullSecrets would look like:
 # imagePullSecrets:
-#  - name: regcred
+#   - name: regcred
 
 secret:
   fiftyone:
-    # These secrets come from Voxel51
+    # Voxel51 provides these secrets
     apiClientId:
     apiClientSecret:
     auth0Domain:
     clientId:
     clientSecret:
     organizationId:
+
     # These secrets come from your MongoDB implementation
     fiftyoneDatabaseName: fiftyone
     mongodbConnectionString: mongodb://username:password@somehostname/?authSource=admin
-    # This secret is a required random string used to encrypt session cookies
-    # Use something like `openssl rand -hex 32` to generate this string
-    cookieSecret:
-    # This key is required and is used to encrypt storage credentials in the MongoDB
-    #   do NOT lose this key!
-    # generate keys by executing the following in python:
+
+    # This secret is a required random string used to encrypt session cookies.
+    # To generate this string, run
     #
+    # ```shell
+    # openssl rand -hex 32
+    # ````
+    #
+    cookieSecret:
+
+    # This required key is used to encrypt storage credentials in the database.
+    #   Do NOT lose this key!
+    # To generate this key, run (in python)
+    #
+    # ```python
     # from cryptography.fernet import Fernet
     # print(Fernet.generate_key().decode())
+    # ```
+    #
     encryptionKey:
 
 # apiSettings:
-#   Set `dnsName` to expose the API with host-based routing.
-#   See https://helm.fiftyone.ai/docs/expose-teams-api.html for more information.
+#   # Set `dnsName` to expose the API for host-based routing only.
+#   # See https://helm.fiftyone.ai/docs/expose-teams-api.html for more information.
 #   dnsName: your-api.hostname.here
 #   env:
-#     Set FIFTYONE_PLUGINS_DIR if you are enabling plugins in a dedicated
-#       `teams-plugins` deployment
-#     See https://github.com/voxel51/fiftyone-teams-app-deploy/tree/main/helm#enabling-fiftyone-teams-plugins
+#     # Set FIFTYONE_PLUGINS_DIR if you are enabling plugins in a dedicated `teams-plugins` deployment
+#     # See https://github.com/voxel51/fiftyone-teams-app-deploy/tree/main/helm#enabling-fiftyone-teams-plugins
 #     FIFTYONE_PLUGINS_DIR: /opt/plugins
 #     Set FIFTYONE_TEAMS_VERSION_OVERRIDE to override the `Install FiftyOne`
 #       bash command in the `Settings > Install FiftyOne` modal
@@ -45,22 +59,23 @@ secret:
 
 # appSettings:
 #   env:
-#    FIFTYONE_DATABASE_ADMIN is set to `false` by default for v1.5.7 installs
-#     If you are performing a new install or an upgrade from v1.0 or earlier you may want to set
-#     this value to `true`.
-#     Please see https://helm.fiftyone.ai/#initial-installation-vs-upgrades for details
-#    FIFTYONE_DATABASE_ADMIN: false
-#    Set FIFTYONE_PLUGINS_DIR and FIFTYONE_PLUGINS_CACHE_ENABLED if you are
-#     enabling plugins in the `fiftyone-app` deployment
-#    See https://github.com/voxel51/fiftyone-teams-app-deploy/tree/main/helm#enabling-fiftyone-teams-plugins
-#    FIFTYONE_PLUGINS_DIR: /opt/plugins
+#     # FIFTYONE_DATABASE_ADMIN is set to `false` by default for installs.
+#     # If you are performing a new install or an upgrade from
+#     # v1.0 or earlier you may want to set this value to `true`.
+#     # Please see https://helm.fiftyone.ai/#initial-installation-vs-upgrades for details.
+#     # FIFTYONE_DATABASE_ADMIN: false
+#     FIFTYONE_DATABASE_ADMIN: true
+#     # Set FIFTYONE_PLUGINS_DIR and FIFTYONE_PLUGINS_CACHE_ENABLED
+#     # when enabling plugins in the `fiftyone-app` deployment
+#     # See https://github.com/voxel51/fiftyone-teams-app-deploy/tree/main/helm#enabling-fiftyone-teams-plugins
+#     # FIFTYONE_PLUGINS_DIR: /opt/plugins
 
 # pluginsSettings:
 #   enabled: true
 #   env:
-#     Set FIFTYONE_PLUGINS_DIR and FIFTYONE_PLUGINS_CACHE_ENABLED if you are
-#      enabling plugins in a dedicated `teams-plugins` deployment
-#     See https://github.com/voxel51/fiftyone-teams-app-deploy/tree/main/helm#enabling-fiftyone-teams-plugins
+#     # Set FIFTYONE_PLUGINS_DIR and FIFTYONE_PLUGINS_CACHE_ENABLED
+#     # when enabling plugins in a dedicated `teams-plugins` deployment.
+#     # See https://github.com/voxel51/fiftyone-teams-app-deploy/tree/main/helm#enabling-fiftyone-teams-plugins
 #     FIFTYONE_PLUGINS_DIR: /opt/plugins
 #     FIFTYONE_PLUGINS_CACHE_ENABLED: true
 


### PR DESCRIPTION
# Rationale

When stubbing values.yaml, I use the `helm/values.yaml` and typically frequently reformat it. Let's update the template to save time.

Also let's add some clarity when using path based routing to not set `apiSettings.dnsName`.

## Changes

* docs

## Testing

n/a
