### PR TITLE
More CAS Env Var Updates

### DIFF
--- a/docker/internal-auth/common-services.yaml
+++ b/docker/internal-auth/common-services.yaml
@@ -32,6 +32,7 @@ services:
     image: voxel51/fiftyone-teams-api:v1.6.0
     environment:
       CAS_BASE_URL: ${CAS_BASE_URL}
+      FEATURE_FLAG_ENABLE_INVITATIONS: false
       FIFTYONE_AUTH_SECRET: ${FIFTYONE_AUTH_SECRET}
       FIFTYONE_DATABASE_NAME: ${FIFTYONE_DATABASE_NAME}
       FIFTYONE_DATABASE_URI: ${FIFTYONE_DATABASE_URI}
@@ -60,6 +61,7 @@ services:
     environment:
       API_URL: ${API_URL}
       APP_USE_HTTPS: ${APP_USE_HTTPS:-true}
+      FEATURE_FLAG_ENABLE_INVITATIONS: false
       FIFTYONE_API_URI: ${FIFTYONE_API_URI:-"Please contact your Admin for an API URI"}
       FIFTYONE_APP_ALLOW_MEDIA_EXPORT: ${FIFTYONE_APP_ALLOW_MEDIA_EXPORT:-true}
       FIFTYONE_APP_TEAMS_SDK_RECOMMENDED_VERSION: 0.16.0
@@ -67,7 +69,6 @@ services:
       FIFTYONE_SERVER_ADDRESS: ""
       FIFTYONE_SERVER_PATH_PREFIX: /api/proxy/fiftyone-teams
       FIFTYONE_TEAMS_PROXY_URL: ${FIFTYONE_TEAMS_PROXY_URL}
-      NEXTAUTH_BASEPATH: /cas/api/auth
       NODE_ENV: production
       RECOIL_DUPLICATE_ATOM_KEY_CHECKING_ENABLED: false
       # If you are routing through a proxy server you will want to set
@@ -93,9 +94,9 @@ services:
     environment:
       CAS_DATABASE_NAME: ${CAS_DATABASE_NAME}
       CAS_DEFAULT_USER_ROLE: ${CAS_DEFAULT_USER_ROLE}
-      CAS_LOG_LEVEL: ${CAS_LOG_LEVEL}
       CAS_MONGODB_URI: ${CAS_MONGO_DB_URI:-$FIFTYONE_DATABASE_URI}
-      FEATURE_FLAG_ENABLE_INVITATIONS: false
+      CAS_URL: ${BASE_URL}
+      DEBUG: ${CAS_DEBUG}
       FIFTYONE_AUTH_MODE: internal
       FIFTYONE_AUTH_SECRET: ${FIFTYONE_AUTH_SECRET}
       NEXTAUTH_URL: ${BASE_URL}/cas/api/auth

--- a/docker/internal-auth/compose.dedicated-plugins.yaml
+++ b/docker/internal-auth/compose.dedicated-plugins.yaml
@@ -11,6 +11,7 @@ services:
       file: common-services.yaml
       service: teams-api-common
     environment:
+      FIFTYONE_PLUGINS_CACHE_ENABLED: true
       FIFTYONE_PLUGINS_DIR: /opt/plugins
     volumes:
       - plugins-vol:/opt/plugins

--- a/docker/internal-auth/compose.plugins.yaml
+++ b/docker/internal-auth/compose.plugins.yaml
@@ -16,6 +16,7 @@ services:
       file: common-services.yaml
       service: teams-api-common
     environment:
+      FIFTYONE_PLUGINS_CACHE_ENABLED: true
       FIFTYONE_PLUGINS_DIR: /opt/plugins
     volumes:
       - plugins-vol:/opt/plugins

--- a/docker/internal-auth/env.template
+++ b/docker/internal-auth/env.template
@@ -51,8 +51,12 @@ CAS_BASE_URL=http://teams-cas:3000/cas/api
 CAS_BIND_ADDRESS=127.0.0.1
 CAS_BIND_PORT=3030
 CAS_DATABASE_NAME=fiftyone-cas
+# CAS_DEBUG defines what CAS logs to display
+# e.g. `cas:*` - shows all cas logs
+#      `cas:*:info` - shows only CAS INFO logs
+#      `cas:*,-cas:*:debug` - shows all cas logs except DEBUG logs
+CAS_DEBUG="cas:*,-cas:*:debug"
 CAS_DEFAULT_USER_ROLE=GUEST
-CAS_LOG_LEVEL=INFO
 
 # The following are docker-compose links and will work in most situations
 FIFTYONE_TEAMS_PROXY_URL=http://fiftyone-app:5151

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -354,12 +354,12 @@ appSettings:
 | appSettings.volumeMounts | list | `[]` | Volume mounts for fiftyone-app. [Reference][volumes]. |
 | appSettings.volumes | list | `[]` | Volumes for fiftyone-app. [Reference][volumes]. |
 | casSettings.affinity | object | `{}` | Affinity and anti-affinity for teams-cas. [Reference][affinity]. |
+| casSettings.enable_invitations | bool | `true` | Allow ADMINs to invite users by email NOTE: This is currently not supported when `FIFTYONE_AUTH_MODE: internal` |
 | casSettings.env.CAS_DATABASE_NAME | string | `"cas"` | Provide the name for the CAS database |
 | casSettings.env.CAS_DEFAULT_USER_ROLE | string | `"GUEST"` | Set the default user role for new users One of `GUEST`, `COLLABORATOR`, `MEMBER`, `ADMIN` |
-| casSettings.env.CAS_LOG_LEVEL | string | `"INFO"` | Set the CAS Log Level One of `DEBUG`, `INFO`, `WARN`, `ERROR` |
-| casSettings.env.CAS_MONGODB_URI_KEY | string | `"mongodbConnectionString"` | The key from `secret.fiftyone` that contains the CAS MongoDB Connection String. |
-| casSettings.env.FEATURE_FLAG_ENABLE_INVITATIONS | bool | `true` | Allow Admins to invite users by email NOTE: This is not supported when FIFTYONE_AUTH_MODE is `internal` |
-| casSettings.env.FIFTYONE_AUTH_MODE | string | `"internal"` | Configure Authentication Mode. One of `legacy` or `internal` |
+| casSettings.env.CAS_MONGODB_URI_KEY | string | `"mongodbConnectionString"` | The key from `secret.fiftyone.name` that contains the CAS MongoDB Connection String. |
+| casSettings.env.DEBUG | string | `"cas:*,-cas:*:debug"` | Set the log level for CAS examples: `DEBUG: cas:*` - shows all CAS logs `DEBUG: cas:*:info` - shows all CAS INFO logs `DEBUG: cas:*,-cas:*:debug` - shows all CAS logs except DEBUG logs |
+| casSettings.env.FIFTYONE_AUTH_MODE | string | `"legacy"` | Configure Authentication Mode. One of `legacy` or `internal` |
 | casSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy]. |
 | casSettings.image.repository | string | `"voxel51/teams-cas"` | Container image for teams-cas. |
 | casSettings.image.tag | string | `""` | Image tag for teams-cas. Defaults to the chart version. |

--- a/helm/fiftyone-teams-app/templates/_helpers.tpl
+++ b/helm/fiftyone-teams-app/templates/_helpers.tpl
@@ -197,9 +197,9 @@ Create a merged list of environment variables for fiftyone-teams-api
   value: {{ printf "http://%s:%.0f/cas/api" .Values.casSettings.service.name .Values.casSettings.service.port | quote }}
 - name: FEATURE_FLAG_ENABLE_INVITATIONS
 {{- if eq .Values.casSettings.env.FIFTYONE_AUTH_MODE "internal" }}
-  value: false
+  value: "false"
 {{- else }}
-  value: {{ .Values.casSettings.enable_invitations }}
+  value: "{{ .Values.casSettings.enable_invitations }}"
 {{- end }}
 - name: FIFTYONE_AUTH_SECRET
   valueFrom:
@@ -379,9 +379,9 @@ Create a merged list of environment variables for fiftyone-teams-app
   value: {{ printf "http://%s:%.0f" .Values.apiSettings.service.name .Values.apiSettings.service.port | quote }}
 - name: FEATURE_FLAG_ENABLE_INVITATIONS
 {{- if eq .Values.casSettings.env.FIFTYONE_AUTH_MODE "internal" }}
-  value: false
+  value: "false"
 {{- else }}
-  value: {{ .Values.casSettings.enable_invitations }}
+  value: "{{ .Values.casSettings.enable_invitations }}"
 {{- end }}
 - name: FIFTYONE_API_URI
 {{- if .Values.teamsAppSettings.fiftyoneApiOverride }}

--- a/helm/fiftyone-teams-app/templates/_helpers.tpl
+++ b/helm/fiftyone-teams-app/templates/_helpers.tpl
@@ -193,28 +193,19 @@ Create a merged list of environment variables for fiftyone-teams-api
 */}}
 {{- define "fiftyone-teams-api.env-vars-list" -}}
 {{- $secretName := .Values.secret.name }}
-{{- if eq .Values.casSettings.env.FIFTYONE_AUTH_MODE "legacy" }}
-- name: AUTH0_API_CLIENT_ID
-  valueFrom:
-    secretKeyRef:
-      name: {{ $secretName }}
-      key: apiClientId
-- name: AUTH0_API_CLIENT_SECRET
-  valueFrom:
-    secretKeyRef:
-      name: {{ $secretName }}
-      key: apiClientSecret
-- name: AUTH0_DOMAIN
-  valueFrom:
-    secretKeyRef:
-      name: {{ $secretName }}
-      key: auth0Domain
-- name: AUTH0_CLIENT_ID
-  valueFrom:
-    secretKeyRef:
-      name: {{ $secretName }}
-      key: clientId
+- name: CAS_BASE_URL
+  value: {{ printf "http://%s:%.0f/cas/api" .Values.casSettings.service.name .Values.casSettings.service.port | quote }}
+- name: FEATURE_FLAG_ENABLE_INVITATIONS
+{{- if eq .Values.casSettings.env.FIFTYONE_AUTH_MODE "internal" }}
+  value: false
+{{- else }}
+  value: {{ .Values.casSettings.enable_invitations }}
 {{- end }}
+- name: FIFTYONE_AUTH_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ $secretName }}
+      key: fiftyoneAuthSecret
 - name: FIFTYONE_DATABASE_NAME
   valueFrom:
     secretKeyRef:
@@ -235,13 +226,6 @@ Create a merged list of environment variables for fiftyone-teams-api
     secretKeyRef:
       name: {{ $secretName }}
       key: fiftyoneDatabaseName
-- name: CAS_BASE_URL
-  value: {{ printf "http://%s:%.0f/cas/api" .Values.casSettings.service.name .Values.casSettings.service.port | quote }}
-- name: FIFTYONE_AUTH_SECRET
-  valueFrom:
-    secretKeyRef:
-      name: {{ $secretName }}
-      key: fiftyoneAuthSecret
 {{- range $key, $val := .Values.apiSettings.env }}
 - name: {{ $key }}
   value: {{ $val | quote }}
@@ -275,25 +259,6 @@ Create a merged list of environment variables for fiftyone-app
     secretKeyRef:
       name: {{ $secretName }}
       key: encryptionKey
-{{- if eq .Values.casSettings.env.FIFTYONE_AUTH_MODE "legacy" }}
-- name: FIFTYONE_TEAMS_AUDIENCE
-  value: "https://$(FIFTYONE_TEAMS_DOMAIN)/api/v2/"
-- name: FIFTYONE_TEAMS_CLIENT_ID
-  valueFrom:
-    secretKeyRef:
-      name: {{ $secretName }}
-      key: clientId
-- name: FIFTYONE_TEAMS_DOMAIN
-  valueFrom:
-    secretKeyRef:
-      name: {{ $secretName }}
-      key: auth0Domain
-- name: FIFTYONE_TEAMS_ORGANIZATION
-  valueFrom:
-    secretKeyRef:
-      name: {{ $secretName }}
-      key: organizationId
-{{- end }}
 {{- range $key, $val := .Values.appSettings.env }}
 - name: {{ $key }}
   value: {{ $val | quote }}
@@ -310,11 +275,15 @@ Create a merged list of environment variables for fiftyone-teams-cas
     secretKeyRef:
       name: {{ $secretName }}
       key: {{ .Values.casSettings.env.CAS_MONGODB_URI_KEY }}
+- name: CAS_URL
+  value: {{ printf "https://%s" .Values.teamsAppSettings.dnsName | quote }}
 - name: FIFTYONE_AUTH_SECRET
   valueFrom:
     secretKeyRef:
       name: {{ $secretName }}
       key: fiftyoneAuthSecret
+- name: NEXTAUTH_URL
+  value: {{ printf "https://%s/cas/api/auth" .Values.teamsAppSettings.dnsName | quote }}
 {{- if eq .Values.casSettings.env.FIFTYONE_AUTH_MODE "legacy" }}
 - name: AUTH0_AUTH_CLIENT_ID
   valueFrom:
@@ -359,8 +328,6 @@ Create a merged list of environment variables for fiftyone-teams-cas
       name: {{ $secretName }}
       key: mongodbConnectionString
 {{- end }}
-- name: NEXTAUTH_URL
-  value: {{ printf "https://%s/cas/api/auth" .Values.teamsAppSettings.dnsName | quote }}
 {{- range $key, $val := .Values.casSettings.env }}
 - name: {{ $key }}
   value: {{ $val | quote }}
@@ -396,25 +363,6 @@ Create a merged list of environment variables for fiftyone-teams-plugins
     secretKeyRef:
       name: {{ $secretName }}
       key: encryptionKey
-{{- if eq .Values.casSettings.env.FIFTYONE_AUTH_MODE "legacy" }}
-- name: FIFTYONE_TEAMS_AUDIENCE
-  value: "https://$(FIFTYONE_TEAMS_DOMAIN)/api/v2/"
-- name: FIFTYONE_TEAMS_CLIENT_ID
-  valueFrom:
-    secretKeyRef:
-      name: {{ $secretName }}
-      key: clientId
-- name: FIFTYONE_TEAMS_DOMAIN
-  valueFrom:
-    secretKeyRef:
-      name: {{ $secretName }}
-      key: auth0Domain
-- name: FIFTYONE_TEAMS_ORGANIZATION
-  valueFrom:
-    secretKeyRef:
-      name: {{ $secretName }}
-      key: organizationId
-{{- end }}
 {{- range $key, $val := .Values.pluginsSettings.env }}
 - name: {{ $key }}
   value: {{ $val | quote }}
@@ -429,38 +377,11 @@ Create a merged list of environment variables for fiftyone-teams-app
 {{- $secretName := .Values.secret.name }}
 - name: API_URL
   value: {{ printf "http://%s:%.0f" .Values.apiSettings.service.name .Values.apiSettings.service.port | quote }}
-{{- if eq .Values.casSettings.env.FIFTYONE_AUTH_MODE "legacy" }}
-- name: AUTH0_AUDIENCE
-  value: "https://$(AUTH0_DOMAIN)/api/v2/"
-- name: AUTH0_BASE_URL
-  value: {{ printf "https://%s" .Values.teamsAppSettings.dnsName | quote }}
-- name: AUTH0_CLIENT_ID
-  valueFrom:
-    secretKeyRef:
-      name: {{ $secretName }}
-      key: clientId
-- name: AUTH0_CLIENT_SECRET
-  valueFrom:
-    secretKeyRef:
-      name: {{ $secretName }}
-      key: clientSecret
-- name: AUTH0_DOMAIN
-  valueFrom:
-    secretKeyRef:
-      name: {{ $secretName }}
-      key: auth0Domain
-- name: AUTH0_ISSUER_BASE_URL
-  value: "https://$(AUTH0_DOMAIN)"
-- name: AUTH0_ORGANIZATION
-  valueFrom:
-    secretKeyRef:
-      name: {{ $secretName }}
-      key: organizationId
-- name: AUTH0_SECRET
-  valueFrom:
-    secretKeyRef:
-      name: {{ $secretName }}
-      key: cookieSecret
+- name: FEATURE_FLAG_ENABLE_INVITATIONS
+{{- if eq .Values.casSettings.env.FIFTYONE_AUTH_MODE "internal" }}
+  value: false
+{{- else }}
+  value: {{ .Values.casSettings.enable_invitations }}
 {{- end }}
 - name: FIFTYONE_API_URI
 {{- if .Values.teamsAppSettings.fiftyoneApiOverride }}
@@ -487,9 +408,6 @@ Create a merged list of environment variables for fiftyone-teams-app
 {{- else }}
   value: {{ printf "http://%s:%.0f" .Values.appSettings.service.name .Values.appSettings.service.port | quote }}
 {{- end }}
-- name: NEXTAUTH_BASEPATH
-  value: "/cas/api/auth"
-
 {{- range $key, $val := .Values.teamsAppSettings.env }}
 - name: {{ $key }}
   value: {{ $val | quote }}

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -186,6 +186,9 @@ appSettings:
 
 # Central Authentication Service (teams-cas) configurations
 casSettings:
+  # -- Allow ADMINs to invite users by email
+  # NOTE: This is currently not supported when `FIFTYONE_AUTH_MODE: internal`
+  enable_invitations: true
   # Environment Variables are passed to the teams-cas containers
   env:
     # -- Provide the name for the CAS database
@@ -193,18 +196,18 @@ casSettings:
     # -- Set the default user role for new users
     # One of `GUEST`, `COLLABORATOR`, `MEMBER`, `ADMIN`
     CAS_DEFAULT_USER_ROLE: GUEST
-    # -- Set the CAS Log Level
-    # One of `DEBUG`, `INFO`, `WARN`, `ERROR`
-    CAS_LOG_LEVEL: INFO
-    # -- The key from `secret.fiftyone` that contains the CAS MongoDB Connection
-    # String.
+    # -- The key from `secret.fiftyone.name` that contains the CAS MongoDB
+    # Connection String.
     CAS_MONGODB_URI_KEY: mongodbConnectionString
-    # -- Allow Admins to invite users by email
-    # NOTE: This is not supported when FIFTYONE_AUTH_MODE is `internal`
-    FEATURE_FLAG_ENABLE_INVITATIONS: true
+    # -- Set the log level for CAS
+    # examples:
+    # `DEBUG: cas:*` - shows all CAS logs
+    # `DEBUG: cas:*:info` - shows all CAS INFO logs
+    # `DEBUG: cas:*,-cas:*:debug` - shows all CAS logs except DEBUG logs
+    DEBUG: cas:*,-cas:*:debug
     # -- Configure Authentication Mode.
     # One of `legacy` or `internal`
-    FIFTYONE_AUTH_MODE: internal
+    FIFTYONE_AUTH_MODE: legacy
   image:
     # -- Instruct when the kubelet should pull (download) the specified image.
     # One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy].


### PR DESCRIPTION
# Rationale

Updates from Developers in the [CAS Deployment](https://docs.google.com/document/d/1aNuQGPHz3pKCVU7Zd17UDAVJN9kYqGVRGWSm4WlCwWM/edit#heading=h.k6nuqv7tv8sz) documentation requires updates to our deployment artifacts.

## Changes

Update Helm Chart to reflect new env var requirements
Update Docker Compose `internal-auth` configurations to reflect new env var requirements
Some alphabetization, where reasonable

## Testing

<details>
<summary> `internal` auth mode test </summary>

```
❯ export _K8S_ENVIRONMENT='newauth-dev'
export FTA_VERSION='1.6.0rc2+2be7b3d'
export FOT_VERSION='1.6.0rc2+c8939b3'
export APP_VERSION='v1.6.0-2be7b3d.0'
export CAS_VERSION='v1.0.1-2be7b3d.0'
export FO_VERSION='0.16.0rc2+c8939b3'

helm diff -C1 upgrade ${_K8S_ENVIRONMENT}-fiftyone-ai ../fiftyone-teams-app-deploy/update-env-vars/helm/fiftyone-teams-app -f helm-configs/${_K8S_ENVIRONMENT}-values.yaml --namespace ${_K8S_ENVIRONMENT}-fiftyone-ai --set apiSettings.env.FIFTYONE_TEAMS_VERSION_OVERRIDE="api v${FTA_VERSION} / app v${FOT_VERSION} / cas ${CAS_VERSION} / teams app ${APP_VERSION}" --set apiSettings.env.FIFTYONE_ENV_ID="api v${FTA_VERSION} / app v${FOT_VERSION} / cas ${CAS_VERSION} / teams app ${APP_VERSION}" --set apiSettings.image.tag=v${FTA_VERSION//+/_} --set appSettings.image.tag=v${FOT_VERSION//+/_} --set casSettings.image.tag=${CAS_VERSION//+/_} --set pluginsSettings.image.tag=v${FOT_VERSION//+/_} --set teamsAppSettings.env.FIFTYONE_APP_INSTALL_FIFTYONE_OVERRIDE="pip install --extra-index-url \"https://us-central1-python.pkg.dev/computer-vision-team/dev-python/simple/\" fiftyone==${FO_VERSION}" --set teamsAppSettings.image.tag=${APP_VERSION//+/_}
newauth-dev-fiftyone-ai, teams-api, Deployment (apps) has changed:
...
            env:
+             - name: CAS_BASE_URL
+               value: "http://teams-cas:80/cas/api"
+             - name: FEATURE_FLAG_ENABLE_INVITATIONS
+               value: false
+             - name: FIFTYONE_AUTH_SECRET
+               valueFrom:
+                 secretKeyRef:
+                   name: newauth-dev-teams-secrets
+                   key: fiftyoneAuthSecret
              - name: FIFTYONE_DATABASE_NAME
...
                    key: fiftyoneDatabaseName
-             - name: CAS_BASE_URL
-               value: "http://teams-cas:80/cas/api"
-             - name: FIFTYONE_AUTH_SECRET
-               valueFrom:
-                 secretKeyRef:
-                   name: newauth-dev-teams-secrets
-                   key: fiftyoneAuthSecret
              - name: FIFTYONE_ENV
...
newauth-dev-fiftyone-ai, teams-app, Deployment (apps) has changed:
...
                value: "http://teams-api:80"
+             - name: FEATURE_FLAG_ENABLE_INVITATIONS
+               value: false
              - name: FIFTYONE_API_URI
...
                value: "http://teams-plugins:80"
-             - name: NEXTAUTH_BASEPATH
-               value: "/cas/api/auth"
              - name: APP_USE_HTTPS
...
newauth-dev-fiftyone-ai, teams-cas, Deployment (apps) has changed:
...
                    key: mongodbConnectionString
+             - name: CAS_URL
+               value: "https://newauth.dev.fiftyone.ai"
              - name: FIFTYONE_AUTH_SECRET
...
                value: "ADMIN"
-             - name: CAS_LOG_LEVEL
-               value: "INFO"
              - name: CAS_MONGODB_URI_KEY
                value: "mongodbConnectionString"
-             - name: FEATURE_FLAG_ENABLE_INVITATIONS
-               value: "true"
+             - name: DEBUG
+               value: "cas:*,-cas:*:debug"
              - name: FIFTYONE_AUTH_MODE
...
```

</details>

<details>

<summary> `legacy` auth mode test </summary>

```
❯ export _K8S_ENVIRONMENT='newauth-dev'
export FTA_VERSION='1.6.0rc2+2be7b3d'
export FOT_VERSION='1.6.0rc2+c8939b3'
export APP_VERSION='v1.6.0-2be7b3d.0'
export CAS_VERSION='v1.0.1-2be7b3d.0'
export FO_VERSION='0.16.0rc2+c8939b3'

helm diff -C1 upgrade ${_K8S_ENVIRONMENT}-fiftyone-ai ../fiftyone-teams-app-deploy/update-env-vars/helm/fiftyone-teams-app -f helm-configs/${_K8S_ENVIRONMENT}-values.yaml --namespace ${_K8S_ENVIRONMENT}-fiftyone-ai --set apiSettings.env.FIFTYONE_TEAMS_VERSION_OVERRIDE="api v${FTA_VERSION} / app v${FOT_VERSION} / cas ${CAS_VERSION} / teams app ${APP_VERSION}" --set apiSettings.env.FIFTYONE_ENV_ID="api v${FTA_VERSION} / app v${FOT_VERSION} / cas ${CAS_VERSION} / teams app ${APP_VERSION}" --set apiSettings.image.tag=v${FTA_VERSION//+/_} --set appSettings.image.tag=v${FOT_VERSION//+/_} --set casSettings.image.tag=${CAS_VERSION//+/_} --set pluginsSettings.image.tag=v${FOT_VERSION//+/_} --set teamsAppSettings.env.FIFTYONE_APP_INSTALL_FIFTYONE_OVERRIDE="pip install --extra-index-url \"https://us-central1-python.pkg.dev/computer-vision-team/dev-python/simple/\" fiftyone==${FO_VERSION}" --set teamsAppSettings.image.tag=${APP_VERSION//+/_} --set casSettings.env.FIFTYONE_AUTH_MODE=legacy
newauth-dev-fiftyone-ai, teams-api, Deployment (apps) has changed:
...
            env:
+             - name: CAS_BASE_URL
+               value: "http://teams-cas:80/cas/api"
+             - name: FEATURE_FLAG_ENABLE_INVITATIONS
+               value: true
+             - name: FIFTYONE_AUTH_SECRET
+               valueFrom:
+                 secretKeyRef:
+                   name: newauth-dev-teams-secrets
+                   key: fiftyoneAuthSecret
              - name: FIFTYONE_DATABASE_NAME
...
                    key: fiftyoneDatabaseName
-             - name: CAS_BASE_URL
-               value: "http://teams-cas:80/cas/api"
-             - name: FIFTYONE_AUTH_SECRET
-               valueFrom:
-                 secretKeyRef:
-                   name: newauth-dev-teams-secrets
-                   key: fiftyoneAuthSecret
              - name: FIFTYONE_ENV
...
newauth-dev-fiftyone-ai, teams-app, Deployment (apps) has changed:
...
                value: "http://teams-api:80"
+             - name: FEATURE_FLAG_ENABLE_INVITATIONS
+               value: true
              - name: FIFTYONE_API_URI
...
                value: "http://teams-plugins:80"
-             - name: NEXTAUTH_BASEPATH
-               value: "/cas/api/auth"
              - name: APP_USE_HTTPS
...
newauth-dev-fiftyone-ai, teams-cas, Deployment (apps) has changed:
...
                    key: mongodbConnectionString
+             - name: CAS_URL
+               value: "https://newauth.dev.fiftyone.ai"
              - name: FIFTYONE_AUTH_SECRET
...
                value: "https://newauth.dev.fiftyone.ai/cas/api/auth"
+             - name: AUTH0_AUTH_CLIENT_ID
+               valueFrom:
+                 secretKeyRef:
+                   name: newauth-dev-teams-secrets
+                   key: clientId
+             - name: AUTH0_AUTH_CLIENT_SECRET
+               valueFrom:
+                 secretKeyRef:
+                   name: newauth-dev-teams-secrets
+                   key: clientSecret
+             - name: AUTH0_DOMAIN
+               valueFrom:
+                 secretKeyRef:
+                   name: newauth-dev-teams-secrets
+                   key: auth0Domain
+             - name: AUTH0_ISSUER_BASE_URL
+               value: "https://$(AUTH0_DOMAIN)"
+             - name: AUTH0_MGMT_CLIENT_ID
+               valueFrom:
+                 secretKeyRef:
+                   name: newauth-dev-teams-secrets
+                   key: apiClientId
+             - name: AUTH0_MGMT_CLIENT_SECRET
+               valueFrom:
+                 secretKeyRef:
+                   name: newauth-dev-teams-secrets
+                   key: apiClientSecret
+             - name: AUTH0_ORGANIZATION
+               valueFrom:
+                 secretKeyRef:
+                   name: newauth-dev-teams-secrets
+                   key: organizationId
+             - name: TEAMS_API_DATABASE_NAME
+               valueFrom:
+                 secretKeyRef:
+                   name: newauth-dev-teams-secrets
+                   key: fiftyoneDatabaseName
+             - name: TEAMS_API_MONGODB_URI
+               valueFrom:
+                 secretKeyRef:
+                   name: newauth-dev-teams-secrets
+                   key: mongodbConnectionString
              - name: CAS_DATABASE_NAME
...
                value: "ADMIN"
-             - name: CAS_LOG_LEVEL
-               value: "INFO"
              - name: CAS_MONGODB_URI_KEY
                value: "mongodbConnectionString"
-             - name: FEATURE_FLAG_ENABLE_INVITATIONS
-               value: "true"
+             - name: DEBUG
+               value: "cas:*,-cas:*:debug"
              - name: FIFTYONE_AUTH_MODE
-               value: "internal"
+               value: "legacy"
            ports:
...
```

</details>

## To Do

Still have not started to address the compose `legacy-auth` configurations or DRYing up the compose configurations.  This is not part of the planned Beta release so is a "tomorrow topher" problem.

Lots of Doc updates to do (particularly in the docker directory)

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
