### PR TITLE
Helm Unit Tests - Show diff when objects are not equal

### DIFF
--- a/tests/unit/api-deployment_test.go
+++ b/tests/unit/api-deployment_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -352,7 +351,7 @@ func (s *deploymentApiTemplateTest) TestContainerEnv() {
 				var expectedEnvVars []corev1.EnvVar
 				err := json.Unmarshal([]byte(expectedEnvVarJSON), &expectedEnvVars)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedEnvVars, envVars), "Envs should be equal")
+				s.Equal(expectedEnvVars, envVars, "Envs should be equal")
 			},
 		},
 		{
@@ -458,7 +457,7 @@ func (s *deploymentApiTemplateTest) TestContainerEnv() {
 				var expectedEnvVars []corev1.EnvVar
 				err := json.Unmarshal([]byte(expectedEnvVarJSON), &expectedEnvVars)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedEnvVars, envVars), "Envs should be equal")
+				s.Equal(expectedEnvVars, envVars, "Envs should be equal")
 			},
 		},
 	}
@@ -641,7 +640,7 @@ func (s *deploymentApiTemplateTest) TestContainerLivenessProbe() {
 				var expectedProbe *corev1.Probe
 				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedProbe, probe), "Liveness Probes should be equal")
+				s.Equal(expectedProbe, probe, "Liveness Probes should be equal")
 			},
 		},
 		{
@@ -662,7 +661,7 @@ func (s *deploymentApiTemplateTest) TestContainerLivenessProbe() {
 				var expectedProbe *corev1.Probe
 				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedProbe, probe), "Liveness Probes should be equal")
+				s.Equal(expectedProbe, probe, "Liveness Probes should be equal")
 			},
 		},
 	}
@@ -705,7 +704,7 @@ func (s *deploymentApiTemplateTest) TestContainerPorts() {
 				var expectedPorts []corev1.ContainerPort
 				err := json.Unmarshal([]byte(expectedPortsJSON), &expectedPorts)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedPorts, ports), "Ports should be equal")
+				s.Equal(expectedPorts, ports, "Ports should be equal")
 			},
 		},
 		{
@@ -725,7 +724,7 @@ func (s *deploymentApiTemplateTest) TestContainerPorts() {
 				var expectedPorts []corev1.ContainerPort
 				err := json.Unmarshal([]byte(expectedPortsJSON), &expectedPorts)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedPorts, ports), "Ports should be equal")
+				s.Equal(expectedPorts, ports, "Ports should be equal")
 			},
 		},
 	}
@@ -769,7 +768,7 @@ func (s *deploymentApiTemplateTest) TestContainerReadinessProbe() {
 				var expectedProbe *corev1.Probe
 				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedProbe, probe), "Readiness Probes should be equal")
+				s.Equal(expectedProbe, probe, "Readiness Probes should be equal")
 			},
 		},
 		{
@@ -790,7 +789,7 @@ func (s *deploymentApiTemplateTest) TestContainerReadinessProbe() {
 				var expectedProbe *corev1.Probe
 				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedProbe, probe), "Readiness Probes should be equal")
+				s.Equal(expectedProbe, probe, "Readiness Probes should be equal")
 			},
 		},
 	}
@@ -954,7 +953,7 @@ func (s *deploymentApiTemplateTest) TestContainerVolumeMounts() {
 				var expectedVolumeMounts []corev1.VolumeMount
 				err := json.Unmarshal([]byte(expectedJSON), &expectedVolumeMounts)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedVolumeMounts, volumeMounts), "Volume Mounts should be equal")
+				s.Equal(expectedVolumeMounts, volumeMounts, "Volume Mounts should be equal")
 			},
 		},
 		{
@@ -979,7 +978,7 @@ func (s *deploymentApiTemplateTest) TestContainerVolumeMounts() {
 				var expectedVolumeMounts []corev1.VolumeMount
 				err := json.Unmarshal([]byte(expectedJSON), &expectedVolumeMounts)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedVolumeMounts, volumeMounts), "Volume Mounts should be equal")
+				s.Equal(expectedVolumeMounts, volumeMounts, "Volume Mounts should be equal")
 			},
 		},
 	}
@@ -1046,7 +1045,7 @@ func (s *deploymentApiTemplateTest) TestAffinity() {
 				err := json.Unmarshal([]byte(affinityJSON), &expectedAffinity)
 				s.NoError(err)
 
-				s.True(reflect.DeepEqual(expectedAffinity, *affinity), "Affinity should be equal")
+				s.Equal(expectedAffinity, *affinity, "Affinity should be equal")
 			},
 		},
 	}
@@ -1382,7 +1381,7 @@ func (s *deploymentApiTemplateTest) TestTolerations() {
 				s.NoError(err)
 
 				s.Len(tolerations, 1, "Should only have 1 toleration")
-				s.True(reflect.DeepEqual(expectedTolerations[0], tolerations[0]), "Toleration should be equal")
+				s.Equal(expectedTolerations[0], tolerations[0], "Toleration should be equal")
 			},
 		},
 	}
@@ -1436,7 +1435,7 @@ func (s *deploymentApiTemplateTest) TestVolumes() {
 				var expectedVolumes []corev1.Volume
 				err := json.Unmarshal([]byte(expectedJSON), &expectedVolumes)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedVolumes, volumes), "Volumes should be equal")
+				s.Equal(expectedVolumes, volumes, "Volumes should be equal")
 			},
 		},
 		{
@@ -1465,7 +1464,7 @@ func (s *deploymentApiTemplateTest) TestVolumes() {
 				var expectedVolumes []corev1.Volume
 				err := json.Unmarshal([]byte(expectedJSON), &expectedVolumes)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedVolumes, volumes), "Volumes should be equal")
+				s.Equal(expectedVolumes, volumes, "Volumes should be equal")
 			},
 		},
 	}

--- a/tests/unit/api-service_test.go
+++ b/tests/unit/api-service_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -251,7 +250,7 @@ func (s *serviceApiTemplateTest) TestPorts() {
 				var expectedPorts []corev1.ServicePort
 				err := json.Unmarshal([]byte(expectedPortsJSON), &expectedPorts)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedPorts, ports), "Ports should be equal")
+				s.Equal(expectedPorts, ports, "Ports should be equal")
 			},
 		},
 		{
@@ -271,7 +270,7 @@ func (s *serviceApiTemplateTest) TestPorts() {
 				var expectedPorts []corev1.ServicePort
 				err := json.Unmarshal([]byte(expectedPortsJSON), &expectedPorts)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedPorts, ports), "Ports should be equal")
+				s.Equal(expectedPorts, ports, "Ports should be equal")
 			},
 		},
 		{
@@ -293,7 +292,7 @@ func (s *serviceApiTemplateTest) TestPorts() {
 				var expectedPorts []corev1.ServicePort
 				err := json.Unmarshal([]byte(expectedPortsJSON), &expectedPorts)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedPorts, ports), "Ports should be equal")
+				s.Equal(expectedPorts, ports, "Ports should be equal")
 			},
 		},
 		{
@@ -314,7 +313,7 @@ func (s *serviceApiTemplateTest) TestPorts() {
 				var expectedPorts []corev1.ServicePort
 				err := json.Unmarshal([]byte(expectedPortsJSON), &expectedPorts)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedPorts, ports), "Ports should be equal")
+				s.Equal(expectedPorts, ports, "Ports should be equal")
 			},
 		},
 	}

--- a/tests/unit/app-deployment_test.go
+++ b/tests/unit/app-deployment_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -347,7 +346,7 @@ func (s *deploymentAppTemplateTest) TestContainerEnv() {
 				var expectedEnvVars []corev1.EnvVar
 				err := json.Unmarshal([]byte(expectedEnvVarJSON), &expectedEnvVars)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedEnvVars, envVars), "Envs should be equal")
+				s.Equal(expectedEnvVars, envVars, "Envs should be equal")
 			},
 		},
 		{
@@ -443,7 +442,7 @@ func (s *deploymentAppTemplateTest) TestContainerEnv() {
 				var expectedEnvVars []corev1.EnvVar
 				err := json.Unmarshal([]byte(expectedEnvVarJSON), &expectedEnvVars)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedEnvVars, envVars), "Envs should be equal")
+				s.Equal(expectedEnvVars, envVars, "Envs should be equal")
 			},
 		},
 	}
@@ -625,7 +624,7 @@ func (s *deploymentAppTemplateTest) TestContainerLivenessProbe() {
 				var expectedProbe *corev1.Probe
 				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedProbe, probe), "Liveness Probes should be equal")
+				s.Equal(expectedProbe, probe, "Liveness Probes should be equal")
 			},
 		},
 		{
@@ -645,7 +644,7 @@ func (s *deploymentAppTemplateTest) TestContainerLivenessProbe() {
 				var expectedProbe *corev1.Probe
 				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedProbe, probe), "Liveness Probes should be equal")
+				s.Equal(expectedProbe, probe, "Liveness Probes should be equal")
 			},
 		},
 	}
@@ -688,7 +687,7 @@ func (s *deploymentAppTemplateTest) TestContainerPorts() {
 				var expectedPorts []corev1.ContainerPort
 				err := json.Unmarshal([]byte(expectedPortsJSON), &expectedPorts)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedPorts, ports), "Ports should be equal")
+				s.Equal(expectedPorts, ports, "Ports should be equal")
 			},
 		},
 		{
@@ -708,7 +707,7 @@ func (s *deploymentAppTemplateTest) TestContainerPorts() {
 				var expectedPorts []corev1.ContainerPort
 				err := json.Unmarshal([]byte(expectedPortsJSON), &expectedPorts)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedPorts, ports), "Ports should be equal")
+				s.Equal(expectedPorts, ports, "Ports should be equal")
 			},
 		},
 	}
@@ -751,7 +750,7 @@ func (s *deploymentAppTemplateTest) TestContainerReadinessProbe() {
 				var expectedProbe *corev1.Probe
 				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedProbe, probe), "Readiness Probes should be equal")
+				s.Equal(expectedProbe, probe, "Readiness Probes should be equal")
 			},
 		},
 		{
@@ -771,7 +770,7 @@ func (s *deploymentAppTemplateTest) TestContainerReadinessProbe() {
 				var expectedProbe *corev1.Probe
 				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedProbe, probe), "Readiness Probes should be equal")
+				s.Equal(expectedProbe, probe, "Readiness Probes should be equal")
 			},
 		},
 	}
@@ -935,7 +934,7 @@ func (s *deploymentAppTemplateTest) TestContainerVolumeMounts() {
 				var expectedVolumeMounts []corev1.VolumeMount
 				err := json.Unmarshal([]byte(expectedJSON), &expectedVolumeMounts)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedVolumeMounts, volumeMounts), "Volume Mounts should be equal")
+				s.Equal(expectedVolumeMounts, volumeMounts, "Volume Mounts should be equal")
 			},
 		},
 		{
@@ -960,7 +959,7 @@ func (s *deploymentAppTemplateTest) TestContainerVolumeMounts() {
 				var expectedVolumeMounts []corev1.VolumeMount
 				err := json.Unmarshal([]byte(expectedJSON), &expectedVolumeMounts)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedVolumeMounts, volumeMounts), "Volume Mounts should be equal")
+				s.Equal(expectedVolumeMounts, volumeMounts, "Volume Mounts should be equal")
 			},
 		},
 	}
@@ -1027,7 +1026,7 @@ func (s *deploymentAppTemplateTest) TestAffinity() {
 				err := json.Unmarshal([]byte(affinityJSON), &expectedAffinity)
 				s.NoError(err)
 
-				s.True(reflect.DeepEqual(expectedAffinity, *affinity), "Affinity should be equal")
+				s.Equal(expectedAffinity, *affinity, "Affinity should be equal")
 			},
 		},
 	}
@@ -1361,7 +1360,7 @@ func (s *deploymentAppTemplateTest) TestTolerations() {
 				s.NoError(err)
 
 				s.Len(tolerations, 1, "Should only have 1 toleration")
-				s.True(reflect.DeepEqual(expectedTolerations[0], tolerations[0]), "Toleration should be equal")
+				s.Equal(expectedTolerations[0], tolerations[0], "Toleration should be equal")
 			},
 		},
 	}
@@ -1415,7 +1414,7 @@ func (s *deploymentAppTemplateTest) TestVolumes() {
 				var expectedVolumes []corev1.Volume
 				err := json.Unmarshal([]byte(expectedJSON), &expectedVolumes)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedVolumes, volumes), "Volumes should be equal")
+				s.Equal(expectedVolumes, volumes, "Volumes should be equal")
 			},
 		},
 		{
@@ -1444,7 +1443,7 @@ func (s *deploymentAppTemplateTest) TestVolumes() {
 				var expectedVolumes []corev1.Volume
 				err := json.Unmarshal([]byte(expectedJSON), &expectedVolumes)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedVolumes, volumes), "Volumes should be equal")
+				s.Equal(expectedVolumes, volumes, "Volumes should be equal")
 			},
 		},
 	}

--- a/tests/unit/app-hpa_test.go
+++ b/tests/unit/app-hpa_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -256,7 +255,7 @@ func (s *horizontalPodAutoscalerAppTemplateTest) TestScaleTargetRef() {
 				var expectedRef autoscalingv2.CrossVersionObjectReference
 				err := json.Unmarshal([]byte(expectedRefJSON), &expectedRef)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedRef, ref), "Scale Target Refs should be equal")
+				s.Equal(expectedRef, ref, "Scale Target Refs should be equal")
 			},
 		},
 		{
@@ -273,7 +272,7 @@ func (s *horizontalPodAutoscalerAppTemplateTest) TestScaleTargetRef() {
 				var expectedRef autoscalingv2.CrossVersionObjectReference
 				err := json.Unmarshal([]byte(expectedRefJSON), &expectedRef)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedRef, ref), "Scale Target Refs should be equal")
+				s.Equal(expectedRef, ref, "Scale Target Refs should be equal")
 			},
 		},
 		{
@@ -291,7 +290,7 @@ func (s *horizontalPodAutoscalerAppTemplateTest) TestScaleTargetRef() {
 				var expectedRef autoscalingv2.CrossVersionObjectReference
 				err := json.Unmarshal([]byte(expectedRefJSON), &expectedRef)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedRef, ref), "Scale Target Refs should be equal")
+				s.Equal(expectedRef, ref, "Scale Target Refs should be equal")
 			},
 		},
 	}
@@ -484,7 +483,7 @@ func (s *horizontalPodAutoscalerAppTemplateTest) TestMetrics() {
 				var expectedMetrics []autoscalingv2.MetricSpec
 				err := json.Unmarshal([]byte(expectedJSON), &expectedMetrics)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedMetrics, metrics), "Volumes should be equal")
+				s.Equal(expectedMetrics, metrics, "Volumes should be equal")
 			},
 		},
 		{
@@ -520,7 +519,7 @@ func (s *horizontalPodAutoscalerAppTemplateTest) TestMetrics() {
 				var expectedMetrics []autoscalingv2.MetricSpec
 				err := json.Unmarshal([]byte(expectedJSON), &expectedMetrics)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedMetrics, metrics), "Volumes should be equal")
+				s.Equal(expectedMetrics, metrics, "Volumes should be equal")
 			},
 		},
 	}

--- a/tests/unit/app-service_test.go
+++ b/tests/unit/app-service_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -251,7 +250,7 @@ func (s *serviceAppTemplateTest) TestPorts() {
 				var expectedPorts []corev1.ServicePort
 				err := json.Unmarshal([]byte(expectedPortsJSON), &expectedPorts)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedPorts, ports), "Ports should be equal")
+				s.Equal(expectedPorts, ports, "Ports should be equal")
 			},
 		},
 		{
@@ -271,7 +270,7 @@ func (s *serviceAppTemplateTest) TestPorts() {
 				var expectedPorts []corev1.ServicePort
 				err := json.Unmarshal([]byte(expectedPortsJSON), &expectedPorts)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedPorts, ports), "Ports should be equal")
+				s.Equal(expectedPorts, ports, "Ports should be equal")
 			},
 		},
 		{
@@ -293,7 +292,7 @@ func (s *serviceAppTemplateTest) TestPorts() {
 				var expectedPorts []corev1.ServicePort
 				err := json.Unmarshal([]byte(expectedPortsJSON), &expectedPorts)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedPorts, ports), "Ports should be equal")
+				s.Equal(expectedPorts, ports, "Ports should be equal")
 			},
 		},
 		{
@@ -314,7 +313,7 @@ func (s *serviceAppTemplateTest) TestPorts() {
 				var expectedPorts []corev1.ServicePort
 				err := json.Unmarshal([]byte(expectedPortsJSON), &expectedPorts)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedPorts, ports), "Ports should be equal")
+				s.Equal(expectedPorts, ports, "Ports should be equal")
 			},
 		},
 	}

--- a/tests/unit/ingress_test.go
+++ b/tests/unit/ingress_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -398,7 +397,7 @@ func (s *ingressTemplateTest) TestTls() {
 				var expectedTls []networkingv1.IngressTLS
 				err := json.Unmarshal([]byte(expectedJSON), &expectedTls)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedTls, tls), "TLS should be equal")
+				s.Equal(expectedTls, tls, "TLS should be equal")
 			},
 		},
 		{
@@ -430,7 +429,7 @@ func (s *ingressTemplateTest) TestTls() {
 				var expectedTls []networkingv1.IngressTLS
 				err := json.Unmarshal([]byte(expectedJSON), &expectedTls)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedTls, tls), "TLS should be equal")
+				s.Equal(expectedTls, tls, "TLS should be equal")
 			},
 		},
 	}
@@ -489,7 +488,7 @@ func (s *ingressTemplateTest) TestRules() {
 				var expectedRules []networkingv1.IngressRule
 				err := json.Unmarshal([]byte(expectedJSON), &expectedRules)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedRules, tls), "Rules should be equal")
+				s.Equal(expectedRules, tls, "Rules should be equal")
 			},
 		},
 		{
@@ -522,7 +521,7 @@ func (s *ingressTemplateTest) TestRules() {
 				var expectedRules []networkingv1.IngressRule
 				err := json.Unmarshal([]byte(expectedJSON), &expectedRules)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedRules, tls), "Rules should be equal")
+				s.Equal(expectedRules, tls, "Rules should be equal")
 			},
 		},
 		{
@@ -574,7 +573,7 @@ func (s *ingressTemplateTest) TestRules() {
 				var expectedRules []networkingv1.IngressRule
 				err := json.Unmarshal([]byte(expectedJSON), &expectedRules)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedRules, tls), "Rules should be equal")
+				s.Equal(expectedRules, tls, "Rules should be equal")
 			},
 		},
 		{
@@ -635,7 +634,7 @@ func (s *ingressTemplateTest) TestRules() {
 				var expectedRules []networkingv1.IngressRule
 				err := json.Unmarshal([]byte(expectedJSON), &expectedRules)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedRules, tls), "Rules should be equal")
+				s.Equal(expectedRules, tls, "Rules should be equal")
 			},
 		},
 		{
@@ -736,7 +735,7 @@ func (s *ingressTemplateTest) TestRules() {
 				var expectedRules []networkingv1.IngressRule
 				err := json.Unmarshal([]byte(expectedJSON), &expectedRules)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedRules, tls), "Rules should be equal")
+				s.Equal(expectedRules, tls, "Rules should be equal")
 			},
 		},
 	}

--- a/tests/unit/plugins-deployment_test.go
+++ b/tests/unit/plugins-deployment_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -363,7 +362,7 @@ func (s *deploymentPluginsTemplateTest) TestContainerEnv() {
 				var expectedEnvVars []corev1.EnvVar
 				err := json.Unmarshal([]byte(expectedEnvVarJSON), &expectedEnvVars)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedEnvVars, envVars), "Envs should be equal")
+				s.Equal(expectedEnvVars, envVars, "Envs should be equal")
 			},
 		},
 		{
@@ -455,7 +454,7 @@ func (s *deploymentPluginsTemplateTest) TestContainerEnv() {
 				var expectedEnvVars []corev1.EnvVar
 				err := json.Unmarshal([]byte(expectedEnvVarJSON), &expectedEnvVars)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedEnvVars, envVars), "Envs should be equal")
+				s.Equal(expectedEnvVars, envVars, "Envs should be equal")
 			},
 		},
 		{
@@ -552,7 +551,7 @@ func (s *deploymentPluginsTemplateTest) TestContainerEnv() {
 				var expectedEnvVars []corev1.EnvVar
 				err := json.Unmarshal([]byte(expectedEnvVarJSON), &expectedEnvVars)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedEnvVars, envVars), "Envs should be equal")
+				s.Equal(expectedEnvVars, envVars, "Envs should be equal")
 			},
 		},
 	}
@@ -820,7 +819,7 @@ func (s *deploymentPluginsTemplateTest) TestContainerLivenessProbe() {
 				var expectedProbe *corev1.Probe
 				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedProbe, probe), "Liveness Probes should be equal")
+				s.Equal(expectedProbe, probe, "Liveness Probes should be equal")
 			},
 		},
 		{
@@ -841,7 +840,7 @@ func (s *deploymentPluginsTemplateTest) TestContainerLivenessProbe() {
 				var expectedProbe *corev1.Probe
 				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedProbe, probe), "Liveness Probes should be equal")
+				s.Equal(expectedProbe, probe, "Liveness Probes should be equal")
 			},
 		},
 	}
@@ -906,7 +905,7 @@ func (s *deploymentPluginsTemplateTest) TestContainerPorts() {
 				var expectedPorts []corev1.ContainerPort
 				err := json.Unmarshal([]byte(expectedPortsJSON), &expectedPorts)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedPorts, ports), "Ports should be equal")
+				s.Equal(expectedPorts, ports, "Ports should be equal")
 			},
 		},
 		{
@@ -927,7 +926,7 @@ func (s *deploymentPluginsTemplateTest) TestContainerPorts() {
 				var expectedPorts []corev1.ContainerPort
 				err := json.Unmarshal([]byte(expectedPortsJSON), &expectedPorts)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedPorts, ports), "Ports should be equal")
+				s.Equal(expectedPorts, ports, "Ports should be equal")
 			},
 		},
 	}
@@ -992,7 +991,7 @@ func (s *deploymentPluginsTemplateTest) TestContainerReadinessProbe() {
 				var expectedProbe *corev1.Probe
 				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedProbe, probe), "Readiness Probes should be equal")
+				s.Equal(expectedProbe, probe, "Readiness Probes should be equal")
 			},
 		},
 		{
@@ -1013,7 +1012,7 @@ func (s *deploymentPluginsTemplateTest) TestContainerReadinessProbe() {
 				var expectedProbe *corev1.Probe
 				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedProbe, probe), "Readiness Probes should be equal")
+				s.Equal(expectedProbe, probe, "Readiness Probes should be equal")
 			},
 		},
 	}
@@ -1246,7 +1245,7 @@ func (s *deploymentPluginsTemplateTest) TestContainerVolumeMounts() {
 				var expectedVolumeMounts []corev1.VolumeMount
 				err := json.Unmarshal([]byte(expectedJSON), &expectedVolumeMounts)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedVolumeMounts, volumeMounts), "Volume Mounts should be equal")
+				s.Equal(expectedVolumeMounts, volumeMounts, "Volume Mounts should be equal")
 			},
 		},
 		{
@@ -1272,7 +1271,7 @@ func (s *deploymentPluginsTemplateTest) TestContainerVolumeMounts() {
 				var expectedVolumeMounts []corev1.VolumeMount
 				err := json.Unmarshal([]byte(expectedJSON), &expectedVolumeMounts)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedVolumeMounts, volumeMounts), "Volume Mounts should be equal")
+				s.Equal(expectedVolumeMounts, volumeMounts, "Volume Mounts should be equal")
 			},
 		},
 	}
@@ -1363,7 +1362,7 @@ func (s *deploymentPluginsTemplateTest) TestAffinity() {
 				err := json.Unmarshal([]byte(affinityJSON), &expectedAffinity)
 				s.NoError(err)
 
-				s.True(reflect.DeepEqual(expectedAffinity, *affinity), "Affinity should be equal")
+				s.Equal(expectedAffinity, *affinity, "Affinity should be equal")
 			},
 		},
 	}
@@ -1847,7 +1846,7 @@ func (s *deploymentPluginsTemplateTest) TestTolerations() {
 				s.NoError(err)
 
 				s.Len(tolerations, 1, "Should only have 1 toleration")
-				s.True(reflect.DeepEqual(expectedTolerations[0], tolerations[0]), "Toleration should be equal")
+				s.Equal(expectedTolerations[0], tolerations[0], "Toleration should be equal")
 			},
 		},
 	}
@@ -1924,7 +1923,7 @@ func (s *deploymentPluginsTemplateTest) TestVolumes() {
 				var expectedVolumes []corev1.Volume
 				err := json.Unmarshal([]byte(expectedJSON), &expectedVolumes)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedVolumes, volumes), "Volumes should be equal")
+				s.Equal(expectedVolumes, volumes, "Volumes should be equal")
 			},
 		},
 		{
@@ -1954,7 +1953,7 @@ func (s *deploymentPluginsTemplateTest) TestVolumes() {
 				var expectedVolumes []corev1.Volume
 				err := json.Unmarshal([]byte(expectedJSON), &expectedVolumes)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedVolumes, volumes), "Volumes should be equal")
+				s.Equal(expectedVolumes, volumes, "Volumes should be equal")
 			},
 		},
 	}

--- a/tests/unit/plugins-hpa_test.go
+++ b/tests/unit/plugins-hpa_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -256,7 +255,7 @@ func (s *horizontalPodAutoscalerPluginsTemplateTest) TestScaleTargetRef() {
 				var expectedRef autoscalingv2.CrossVersionObjectReference
 				err := json.Unmarshal([]byte(expectedRefJSON), &expectedRef)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedRef, ref), "Scale Target Refs should be equal")
+				s.Equal(expectedRef, ref, "Scale Target Refs should be equal")
 			},
 		},
 		{
@@ -273,7 +272,7 @@ func (s *horizontalPodAutoscalerPluginsTemplateTest) TestScaleTargetRef() {
 				var expectedRef autoscalingv2.CrossVersionObjectReference
 				err := json.Unmarshal([]byte(expectedRefJSON), &expectedRef)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedRef, ref), "Scale Target Refs should be equal")
+				s.Equal(expectedRef, ref, "Scale Target Refs should be equal")
 			},
 		},
 		{
@@ -291,7 +290,7 @@ func (s *horizontalPodAutoscalerPluginsTemplateTest) TestScaleTargetRef() {
 				var expectedRef autoscalingv2.CrossVersionObjectReference
 				err := json.Unmarshal([]byte(expectedRefJSON), &expectedRef)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedRef, ref), "Scale Target Refs should be equal")
+				s.Equal(expectedRef, ref, "Scale Target Refs should be equal")
 			},
 		},
 	}
@@ -484,7 +483,7 @@ func (s *horizontalPodAutoscalerPluginsTemplateTest) TestMetrics() {
 				var expectedMetrics []autoscalingv2.MetricSpec
 				err := json.Unmarshal([]byte(expectedJSON), &expectedMetrics)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedMetrics, metrics), "Volumes should be equal")
+				s.Equal(expectedMetrics, metrics, "Volumes should be equal")
 			},
 		},
 		{
@@ -520,7 +519,7 @@ func (s *horizontalPodAutoscalerPluginsTemplateTest) TestMetrics() {
 				var expectedMetrics []autoscalingv2.MetricSpec
 				err := json.Unmarshal([]byte(expectedJSON), &expectedMetrics)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedMetrics, metrics), "Volumes should be equal")
+				s.Equal(expectedMetrics, metrics, "Volumes should be equal")
 			},
 		},
 	}

--- a/tests/unit/plugins-service_test.go
+++ b/tests/unit/plugins-service_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -324,7 +323,7 @@ func (s *servicePluginsTemplateTest) TestPorts() {
 				var expectedPorts []corev1.ServicePort
 				err := json.Unmarshal([]byte(expectedPortsJSON), &expectedPorts)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedPorts, ports), "Ports should be equal")
+				s.Equal(expectedPorts, ports, "Ports should be equal")
 			},
 		},
 		{
@@ -344,7 +343,7 @@ func (s *servicePluginsTemplateTest) TestPorts() {
 				var expectedPorts []corev1.ServicePort
 				err := json.Unmarshal([]byte(expectedPortsJSON), &expectedPorts)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedPorts, ports), "Ports should be equal")
+				s.Equal(expectedPorts, ports, "Ports should be equal")
 			},
 		},
 		{
@@ -365,7 +364,7 @@ func (s *servicePluginsTemplateTest) TestPorts() {
 				var expectedPorts []corev1.ServicePort
 				err := json.Unmarshal([]byte(expectedPortsJSON), &expectedPorts)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedPorts, ports), "Ports should be equal")
+				s.Equal(expectedPorts, ports, "Ports should be equal")
 			},
 		},
 		{
@@ -388,7 +387,7 @@ func (s *servicePluginsTemplateTest) TestPorts() {
 				var expectedPorts []corev1.ServicePort
 				err := json.Unmarshal([]byte(expectedPortsJSON), &expectedPorts)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedPorts, ports), "Ports should be equal")
+				s.Equal(expectedPorts, ports, "Ports should be equal")
 			},
 		},
 		{
@@ -410,7 +409,7 @@ func (s *servicePluginsTemplateTest) TestPorts() {
 				var expectedPorts []corev1.ServicePort
 				err := json.Unmarshal([]byte(expectedPortsJSON), &expectedPorts)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedPorts, ports), "Ports should be equal")
+				s.Equal(expectedPorts, ports, "Ports should be equal")
 			},
 		},
 	}

--- a/tests/unit/teams-app-deployment_test.go
+++ b/tests/unit/teams-app-deployment_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -358,7 +357,7 @@ func (s *deploymentTeamsAppTemplateTest) TestContainerEnv() {
           },
           {
             "name": "FIFTYONE_APP_TEAMS_SDK_RECOMMENDED_VERSION",
-            "value": "0.15.6"
+            "value": "0.15.7"
           },
           {
             "name": "FIFTYONE_APP_THEME",
@@ -372,7 +371,7 @@ func (s *deploymentTeamsAppTemplateTest) TestContainerEnv() {
 				var expectedEnvVars []corev1.EnvVar
 				err := json.Unmarshal([]byte(expectedEnvVarJSON), &expectedEnvVars)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedEnvVars, envVars), "Envs should be equal")
+				s.Equal(expectedEnvVars, envVars, "Envs should be equal")
 			},
 		},
 		{
@@ -473,7 +472,7 @@ func (s *deploymentTeamsAppTemplateTest) TestContainerEnv() {
           },
           {
             "name": "FIFTYONE_APP_TEAMS_SDK_RECOMMENDED_VERSION",
-            "value": "0.15.6"
+            "value": "0.15.7"
           },
           {
             "name": "FIFTYONE_APP_THEME",
@@ -491,7 +490,7 @@ func (s *deploymentTeamsAppTemplateTest) TestContainerEnv() {
 				var expectedEnvVars []corev1.EnvVar
 				err := json.Unmarshal([]byte(expectedEnvVarJSON), &expectedEnvVars)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedEnvVars, envVars), "Envs should be equal")
+				s.Equal(expectedEnvVars, envVars, "Envs should be equal")
 			},
 		},
 	}
@@ -674,7 +673,7 @@ func (s *deploymentTeamsAppTemplateTest) TestContainerLivenessProbe() {
 				var expectedProbe *corev1.Probe
 				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedProbe, probe), "Liveness Probes should be equal")
+				s.Equal(expectedProbe, probe, "Liveness Probes should be equal")
 			},
 		},
 		{
@@ -695,7 +694,7 @@ func (s *deploymentTeamsAppTemplateTest) TestContainerLivenessProbe() {
 				var expectedProbe *corev1.Probe
 				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedProbe, probe), "Liveness Probes should be equal")
+				s.Equal(expectedProbe, probe, "Liveness Probes should be equal")
 			},
 		},
 	}
@@ -738,7 +737,7 @@ func (s *deploymentTeamsAppTemplateTest) TestContainerPorts() {
 				var expectedPorts []corev1.ContainerPort
 				err := json.Unmarshal([]byte(expectedPortsJSON), &expectedPorts)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedPorts, ports), "Ports should be equal")
+				s.Equal(expectedPorts, ports, "Ports should be equal")
 			},
 		},
 		{
@@ -758,7 +757,7 @@ func (s *deploymentTeamsAppTemplateTest) TestContainerPorts() {
 				var expectedPorts []corev1.ContainerPort
 				err := json.Unmarshal([]byte(expectedPortsJSON), &expectedPorts)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedPorts, ports), "Ports should be equal")
+				s.Equal(expectedPorts, ports, "Ports should be equal")
 			},
 		},
 	}
@@ -802,7 +801,7 @@ func (s *deploymentTeamsAppTemplateTest) TestContainerReadinessProbe() {
 				var expectedProbe *corev1.Probe
 				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedProbe, probe), "Readiness Probes should be equal")
+				s.Equal(expectedProbe, probe, "Readiness Probes should be equal")
 			},
 		},
 		{
@@ -823,7 +822,7 @@ func (s *deploymentTeamsAppTemplateTest) TestContainerReadinessProbe() {
 				var expectedProbe *corev1.Probe
 				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedProbe, probe), "Readiness Probes should be equal")
+				s.Equal(expectedProbe, probe, "Readiness Probes should be equal")
 			},
 		},
 	}
@@ -987,7 +986,7 @@ func (s *deploymentTeamsAppTemplateTest) TestContainerVolumeMounts() {
 				var expectedVolumeMounts []corev1.VolumeMount
 				err := json.Unmarshal([]byte(expectedJSON), &expectedVolumeMounts)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedVolumeMounts, volumeMounts), "Volume Mounts should be equal")
+				s.Equal(expectedVolumeMounts, volumeMounts, "Volume Mounts should be equal")
 			},
 		},
 		{
@@ -1012,7 +1011,7 @@ func (s *deploymentTeamsAppTemplateTest) TestContainerVolumeMounts() {
 				var expectedVolumeMounts []corev1.VolumeMount
 				err := json.Unmarshal([]byte(expectedJSON), &expectedVolumeMounts)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedVolumeMounts, volumeMounts), "Volume Mounts should be equal")
+				s.Equal(expectedVolumeMounts, volumeMounts, "Volume Mounts should be equal")
 			},
 		},
 	}
@@ -1079,7 +1078,7 @@ func (s *deploymentTeamsAppTemplateTest) TestAffinity() {
 				err := json.Unmarshal([]byte(affinityJSON), &expectedAffinity)
 				s.NoError(err)
 
-				s.True(reflect.DeepEqual(expectedAffinity, *affinity), "Affinity should be equal")
+				s.Equal(expectedAffinity, *affinity, "Affinity should be equal")
 			},
 		},
 	}
@@ -1415,7 +1414,7 @@ func (s *deploymentTeamsAppTemplateTest) TestTolerations() {
 				s.NoError(err)
 
 				s.Len(tolerations, 1, "Should only have 1 toleration")
-				s.True(reflect.DeepEqual(expectedTolerations[0], tolerations[0]), "Toleration should be equal")
+				s.Equal(expectedTolerations[0], tolerations[0], "Toleration should be equal")
 			},
 		},
 	}
@@ -1469,7 +1468,7 @@ func (s *deploymentTeamsAppTemplateTest) TestVolumes() {
 				var expectedVolumes []corev1.Volume
 				err := json.Unmarshal([]byte(expectedJSON), &expectedVolumes)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedVolumes, volumes), "Volumes should be equal")
+				s.Equal(expectedVolumes, volumes, "Volumes should be equal")
 			},
 		},
 		{
@@ -1498,7 +1497,7 @@ func (s *deploymentTeamsAppTemplateTest) TestVolumes() {
 				var expectedVolumes []corev1.Volume
 				err := json.Unmarshal([]byte(expectedJSON), &expectedVolumes)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedVolumes, volumes), "Volumes should be equal")
+				s.Equal(expectedVolumes, volumes, "Volumes should be equal")
 			},
 		},
 	}

--- a/tests/unit/teams-app-hpa_test.go
+++ b/tests/unit/teams-app-hpa_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -258,7 +257,7 @@ func (s *horizontalPodAutoscalerTeamsAppTemplateTest) TestScaleTargetRef() {
 				var expectedRef autoscalingv2.CrossVersionObjectReference
 				err := json.Unmarshal([]byte(expectedRefJSON), &expectedRef)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedRef, ref), "Scale Target Refs should be equal")
+				s.Equal(expectedRef, ref, "Scale Target Refs should be equal")
 			},
 		},
 		{
@@ -275,7 +274,7 @@ func (s *horizontalPodAutoscalerTeamsAppTemplateTest) TestScaleTargetRef() {
 				var expectedRef autoscalingv2.CrossVersionObjectReference
 				err := json.Unmarshal([]byte(expectedRefJSON), &expectedRef)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedRef, ref), "Scale Target Refs should be equal")
+				s.Equal(expectedRef, ref, "Scale Target Refs should be equal")
 			},
 		},
 		{
@@ -293,7 +292,7 @@ func (s *horizontalPodAutoscalerTeamsAppTemplateTest) TestScaleTargetRef() {
 				var expectedRef autoscalingv2.CrossVersionObjectReference
 				err := json.Unmarshal([]byte(expectedRefJSON), &expectedRef)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedRef, ref), "Scale Target Refs should be equal")
+				s.Equal(expectedRef, ref, "Scale Target Refs should be equal")
 			},
 		},
 	}
@@ -486,7 +485,7 @@ func (s *horizontalPodAutoscalerTeamsAppTemplateTest) TestMetrics() {
 				var expectedMetrics []autoscalingv2.MetricSpec
 				err := json.Unmarshal([]byte(expectedJSON), &expectedMetrics)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedMetrics, metrics), "Volumes should be equal")
+				s.Equal(expectedMetrics, metrics, "Volumes should be equal")
 			},
 		},
 		{
@@ -522,7 +521,7 @@ func (s *horizontalPodAutoscalerTeamsAppTemplateTest) TestMetrics() {
 				var expectedMetrics []autoscalingv2.MetricSpec
 				err := json.Unmarshal([]byte(expectedJSON), &expectedMetrics)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedMetrics, metrics), "Volumes should be equal")
+				s.Equal(expectedMetrics, metrics, "Volumes should be equal")
 			},
 		},
 	}

--- a/tests/unit/teams-app-service_test.go
+++ b/tests/unit/teams-app-service_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -253,7 +252,7 @@ func (s *serviceTeamsAppTemplateTest) TestPorts() {
 				var expectedPorts []corev1.ServicePort
 				err := json.Unmarshal([]byte(expectedPortsJSON), &expectedPorts)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedPorts, ports), "Ports should be equal")
+				s.Equal(expectedPorts, ports, "Ports should be equal")
 			},
 		},
 		{
@@ -273,7 +272,7 @@ func (s *serviceTeamsAppTemplateTest) TestPorts() {
 				var expectedPorts []corev1.ServicePort
 				err := json.Unmarshal([]byte(expectedPortsJSON), &expectedPorts)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedPorts, ports), "Ports should be equal")
+				s.Equal(expectedPorts, ports, "Ports should be equal")
 			},
 		},
 		{
@@ -295,7 +294,7 @@ func (s *serviceTeamsAppTemplateTest) TestPorts() {
 				var expectedPorts []corev1.ServicePort
 				err := json.Unmarshal([]byte(expectedPortsJSON), &expectedPorts)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedPorts, ports), "Ports should be equal")
+				s.Equal(expectedPorts, ports, "Ports should be equal")
 			},
 		},
 		{
@@ -316,7 +315,7 @@ func (s *serviceTeamsAppTemplateTest) TestPorts() {
 				var expectedPorts []corev1.ServicePort
 				err := json.Unmarshal([]byte(expectedPortsJSON), &expectedPorts)
 				s.NoError(err)
-				s.True(reflect.DeepEqual(expectedPorts, ports), "Ports should be equal")
+				s.Equal(expectedPorts, ports, "Ports should be equal")
 			},
 		},
 	}


### PR DESCRIPTION
# Rationale

While reviewing the newly added helm unit tests, we realized that failures in DeepEquals weren't showing the diffs (of expected vs actual).  The testify library already supports this using the https://pkg.go.dev/github.com/stretchr/testify/assert#Equal.  Let's replace the calls to `s.True(reflect.DeepEqual(...))` with `s.Equal(...)`.

While running the tests, noticed failed tests in `tests/unit/teams-app-deployment_test.go` that expected the old chart version.

## Changes

* Update assertions
* Change version number from `0.15.6` to `0.15.7`.

## Testing

<details>
<summary>Passing Helm Unit Tests</summary>

```
$ make test-unit-helm
=== RUN   TestDeploymentApiTemplate
=== PAUSE TestDeploymentApiTemplate
...
        --- PASS: TestDeploymentPluginsTemplate/TestVolumes/defaultValues (0.30s)
PASS
ok  	github.com/voxel51/fiftyone-teams/unit	19.216s
```

</details>

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
