### PR TITLE
Update PR template to remind of parity between Docker Compose and Helm [AS-103]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,10 @@
 
 <!-- Describe the changes. -->
 
+Checklist
+
+* [ ] This PR maintains parity between Docker Compose and Helm
+
 ## Testing
 
 <!-- Describe the way the changes were tested. -->


### PR DESCRIPTION
# Rationale

To err is human. However, let's reduce the drift in changes between Docker Compose and Helm. To help, let's add a checkbox to the PR template to remind us maintaining parity with the changes we introduce.

## Changes

- Updated PR template

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

This PR

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
