### PR TITLE
Adding fixture `tests/fixtures/docker/.env` 

### DIFF
--- a/tests/fixtures/docker/.env
+++ b/tests/fixtures/docker/.env
@@ -1,0 +1,18 @@
+# Data for Unit Tests
+# Auth0
+AUTH0_API_CLIENT_ID="test-auth0-api-client-id"
+AUTH0_API_CLIENT_SECRET="test-auth0-api-client-secret"
+AUTH0_AUDIENCE="test-auth0-audience"
+AUTH0_CLIENT_ID="test-auth0-client-id"
+AUTH0_CLIENT_SECRET="test-auth0-client-secret"
+AUTH0_DOMAIN="test-auth0-domain"
+AUTH0_ISSUER_BASE_URL="test-auth0-issuer-base-url"
+AUTH0_ORGANIZATION="test-auth0-organization"
+AUTH0_SECRET="test-auth0-secret"
+
+# FiftyOne
+FIFTYONE_DATABASE_URI="mongodb://root:test-secret@mongodb.local/?authSource=admin"
+FIFTYONE_ENCRYPTION_KEY="test-fiftyone-encryption-key"
+
+# Internal Auth
+FIFTYONE_AUTH_SECRET="test-fiftyone-auth-secret"


### PR DESCRIPTION
# Rationale

While topher ran the unit tests, encountered an error:

```txt
Couldn't find env file: /Users/topher/workspace/fiftyone-teams-app-deploy/v1.6.0/tests/fixtures/docker/.env
```

## Changes

Add `tests/fixtures/docker/.env` (that was previously not added due to match in `gitignore`)

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
