### PR TITLE
Docs - Compose DB Migration

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -409,7 +409,9 @@ upgrading from FiftyOne Teams version 1.1.0 or later:
    files (included in this repository),
     1. Rename the `env.template` file to `.env`
     1. Edit the `.env` file, setting the parameters required for this deployment.
-       [See table below](#fiftyone-teams-environment-variables).
+       See the
+       [FiftyOne Teams Environment Variables](#fiftyone-teams-environment-variables)
+       table.
     1. Create a `compose.override.yaml` with any configuration overrides for
        this deployment.
 1. In the same directory, run
@@ -424,19 +426,24 @@ upgrading from FiftyOne Teams version 1.1.0 or later:
     FIFTYONE_DATABASE_ADMIN=true fiftyone migrate --all
     ```
 
+    > **NOTE**: Skip this step when performing an initial installation with
+    > `services.fiftyone-app.environment.FIFTYONE_DATABASE_ADMIN: true`.
+    > For more information, see
+    > [Initial Installation vs. Upgrades](#initial-installation-vs-upgrades)
+
 1. To ensure that all datasets are now at version 0.23.5, run
 
     ```shell
     fiftyone migrate --info
     ```
 
-The FiftyOne Teams App is now exposed on port 3000.
+The FiftyOne Teams App is now exposed on port `3000`.
 An SSL endpoint (Load Balancer or Nginx Proxy or something similar)
 will need to be configured to route traffic from the SSL endpoint
-to port 3000 on the host running the FiftyOne Teams App.
+to port `3000` on the host running the FiftyOne Teams App.
 
 An example nginx site configuration that forwards http traffic to
-https, and https traffic for `your.server.name` to port 3000.
+https, and https traffic for `your.server.name` to port `3000`.
 See
 [./example-nginx-site.conf](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/docker/example-nginx-site.conf).
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -425,11 +425,11 @@ upgrading from FiftyOne Teams version 1.1.0 or later:
           ```
 
 1. Deploy FiftyOne Teams
-   1. In the same directory, run
+    1. In the same directory, run
 
-      ```shell
-      docker-compose up -d
-      ```
+        ```shell
+        docker-compose up -d
+        ```
 
 1. After the successful installation, and logging into Fiftyone Teams
     1. In `compose.override.yaml` remove the `FIFTYONE_DATABASE_ADMIN` override

--- a/docker/README.md
+++ b/docker/README.md
@@ -415,14 +415,14 @@ upgrading from FiftyOne Teams version 1.1.0 or later:
        table.
     1. Create a `compose.override.yaml` with any configuration overrides for
        this deployment.
-       1. For the first installation, set
+        1. For the first installation, set
 
-          ```yaml
-          services:
-            fiftyone-app-common:
-              environment:
-                FIFTYONE_DATABASE_ADMIN: true
-          ```
+            ```yaml
+            services:
+              fiftyone-app-common:
+                environment:
+                  FIFTYONE_DATABASE_ADMIN: true
+            ```
 
 1. Deploy FiftyOne Teams
     1. In the same directory, run

--- a/docker/README.md
+++ b/docker/README.md
@@ -404,7 +404,8 @@ upgrading from FiftyOne Teams version 1.1.0 or later:
 
 ## Deploying FiftyOne Teams
 
-1. Install docker-compose
+1. Install
+   [Docker Compose](https://docs.docker.com/compose/install/)
 1. From a directory containing the files `compose.yaml` and `env.template`
    files (included in this repository),
     1. Rename the `env.template` file to `.env`
@@ -414,28 +415,43 @@ upgrading from FiftyOne Teams version 1.1.0 or later:
        table.
     1. Create a `compose.override.yaml` with any configuration overrides for
        this deployment.
-1. In the same directory, run
+       1. For the first installation, set
 
-    ```shell
-    docker-compose up -d
-    ```
+          ```yaml
+          services:
+            fiftyone-app-common:
+              environment:
+                FIFTYONE_DATABASE_ADMIN: true
+          ```
 
-1. Have the admin run to upgrade all datasets
+1. Deploy FiftyOne Teams
+   1. In the same directory, run
 
-    ```shell
-    FIFTYONE_DATABASE_ADMIN=true fiftyone migrate --all
-    ```
+      ```shell
+      docker-compose up -d
+      ```
 
-    > **NOTE**: Skip this step when performing an initial installation with
-    > `services.fiftyone-app.environment.FIFTYONE_DATABASE_ADMIN: true`.
-    > For more information, see
-    > [Initial Installation vs. Upgrades](#initial-installation-vs-upgrades)
+1. After the successful installation, and logging into Fiftyone Teams
+    1. In `compose.override.yaml` remove the `FIFTYONE_DATABASE_ADMIN` override
 
-1. To ensure that all datasets are now at version 0.23.5, run
+        ```yaml
+        services:
+          fiftyone-app-common:
+            environment:
+              # FIFTYONE_DATABASE_ADMIN: true
+        ```
 
-    ```shell
-    fiftyone migrate --info
-    ```
+        > **Note**: This example shows commenting this line,
+        > however you may remove the line.
+
+         or set it to `false` like in
+
+        ```yaml
+        services:
+          fiftyone-app-common:
+            environment:
+              # FIFTYONE_DATABASE_ADMIN: false
+        ```
 
 The FiftyOne Teams App is now exposed on port `3000`.
 An SSL endpoint (Load Balancer or Nginx Proxy or something similar)

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -37,7 +37,7 @@ Please contact Voxel51 for more information regarding Fiftyone Teams.
   - [From Early Adopter Versions (Versions less than 1.0)](#from-early-adopter-versions-versions-less-than-10)
   - [From Before FiftyOne Teams Version 1.1.0](#from-before-fiftyone-teams-version-110)
   - [From FiftyOne Teams Version 1.1.0 and later](#from-fiftyone-teams-version-110-and-later)
-- [Launch FiftyOne Teams](#launch-fiftyone-teams)
+- [Deploying FiftyOne Teams](#deploying-fiftyone-teams)
 
 <!-- tocstop -->
 
@@ -508,7 +508,7 @@ versions prior to FiftyOne Teams version 1.1.0:
 1. In your `values.yaml`, set the required
    [FIFTYONE_ENCRYPTION_KEY](#storage-credentials-and-fiftyone_encryption_key)
    environment variable
-1. [Upgrade to FiftyOne Teams version 1.6.0](#launch-fiftyone-teams)
+1. [Upgrade to FiftyOne Teams version 1.6.0](#deploying-fiftyone-teams)
    with `appSettings.env.FIFTYONE_DATABASE_ADMIN: true`
    (this is not the default value in `values.yaml` and must be overridden).
     > **NOTE:** At this step, FiftyOne SDK users will lose access to the
@@ -546,7 +546,7 @@ upgrading from FiftyOne Teams version 1.1.0 or later:
     - set `FIFTYONE_DATABASE_ADMIN=false`
     - `unset FIFTYONE_DATABASE_ADMIN`
         - This should generally be your default
-1. [Upgrade to FiftyOne Teams version 1.6.0](#launch-fiftyone-teams)
+1. [Upgrade to FiftyOne Teams version 1.6.0](#deploying-fiftyone-teams)
 1. Upgrade FiftyOne Teams SDK users to FiftyOne Teams version 0.16.0
     - Login to the FiftyOne Teams UI
     - To obtain the CLI command to install the FiftyOne SDK associated with
@@ -566,13 +566,24 @@ upgrading from FiftyOne Teams version 1.1.0 or later:
     fiftyone migrate --info
     ```
 
-## Launch FiftyOne Teams
+## Deploying FiftyOne Teams
 
 A minimal example `values.yaml` may be found
 [here](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/values.yaml).
 
-1. Edit the `values.yaml` file
-1. Deploy FiftyOne Teams with `helm install`
+1. Install
+   [Helm](https://helm.sh/docs/intro/install/)
+1. In the values file (typically `values.yaml`) provided by Voxel51
+   set the deployment specific configurations
+    1. For the first installation, set
+
+        ```yaml
+        appSettings:
+          env:
+            FIFTYONE_DATABASE_ADMIN: true
+        ```
+
+1. Deploy FiftyOne Teams
     1. For a new installation, run
 
         ```shell
@@ -580,6 +591,27 @@ A minimal example `values.yaml` may be found
         helm repo update voxel51
         helm install fiftyone-teams-app voxel51/fiftyone-teams-app -f ./values.yaml
         ```
+
+        1. After the successful installation, and logging into Fiftyone Teams
+        1. In your values file, remove the
+           `appSettings.env.FIFTYONE_DATABASE_ADMIN` override
+
+            ```yaml
+            appSettings:
+              env:
+                # FIFTYONE_DATABASE_ADMIN: true
+            ```
+
+            > **Note**: This example shows commenting this line,
+            > however you may remove the line.
+
+            or set it to `false` like in
+
+            ```yaml
+            appSettings:
+              env:
+                FIFTYONE_DATABASE_ADMIN: false
+            ```
 
     1. To upgrade an existing helm installation, run
 
@@ -598,6 +630,24 @@ A minimal example `values.yaml` may be found
         >    ```shell
         >    helm diff -C1 upgrade fiftyone-teams-app voxel51/fiftyone-teams-app -f values.yaml
         >    ```
+
+1. When `appSettings.env.FIFTYONE_DATABASE_ADMIN` is not `true`,
+   have the admin run to upgrade all datasets
+
+    ```shell
+    FIFTYONE_DATABASE_ADMIN=true fiftyone migrate --all
+    ```
+
+    > **NOTE**: Skip this step when performing an initial installation with
+    > `services.fiftyone-app.environment.FIFTYONE_DATABASE_ADMIN: true`.
+    > For more information, see
+    > [Initial Installation vs. Upgrades](#initial-installation-vs-upgrades)
+
+1. To ensure that all datasets are now at version 0.23.5, run
+
+    ```shell
+    fiftyone migrate --info
+    ```
 
 <!-- Reference Links -->
 [affinity]: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/


### PR DESCRIPTION
# Rationale

A customer recently reported an error while running the db migration.  Let's take this opportunity to express that for a new installation, when the configuration is set to initialize the database on first run, that this step may not be necessary.

## Changes

* Docker Compose Docs

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
