### PR TITLE
docs: in docker docs, fix brokenlink to teams plugins doc

### DIFF
--- a/docker/docs/expose-teams-api.md
+++ b/docker/docs/expose-teams-api.md
@@ -45,7 +45,8 @@ security implications before using this method.
 
 1. Edit your `.env` file setting `API_BIND_ADDRESS` to `0.0.0.0`
 1. Recreate your environment using the
-   [plugin specific](./README.md#enabling-fiftyone-teams-plugins) command
+   [plugin specific](../README.md#enabling-fiftyone-teams-plugins)
+   command
 
    ```shell
    docker compose


### PR DESCRIPTION
# Rationale

While looking at the links in the docker directory, this one is broken.  Let's help it out.

## Changes

* Add an extra dot to find the link

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

n/a ^

## Testing

link now takes to the intended page

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
