### PR TITLE
In skaffold.yaml, bump chart version from 1.5.5 to 1.5.8.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,10 +34,10 @@
 
 ## Quickstart to Skaffold in Minikube
 
-1. Auth with gcloud
+1. Auth with gcloud for the project `computer-vision-team`
 
     ```shell
-    gcloud auth application-default login
+    make auth
     ```
 
 1. Install the asdf tools

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@ asdf:  ## Update plugins, add plugins, install plugins, set local, reshim
 	@echo "Reshimming.."
 	@asdf reshim
 
+auth:
+	gcloud auth application-default login --project computer-vision-team
 
 hooks:  ## Install git hooks (pre-commit)
 	@pre-commit install
@@ -39,7 +41,7 @@ hooks:  ## Install git hooks (pre-commit)
 pre-commit:  ## Run pre-commit against all files
 	@pre-commit run -a
 
-start:   ## Run minikube with ingress and gcp-auth
+start:  ## Run minikube with ingress and gcp-auth
 	# to persist mongodb data, we may want to start minikube with a volume mount
 	# minikube start --mount=true \
 	#   --mount-string=/var/tmp/mongodb_data:/tmp/hostpath-provisioner/fiftyone-teams/mongodb

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -36,7 +36,7 @@ deploy:
     releases:
       - name: fiftyone-teams
         chartPath: helm/fiftyone-teams-app
-        version: 1.5.5
+        version: 1.5.8
         createNamespace: true
         namespace: fiftyone-teams
         overrides:


### PR DESCRIPTION
# Rationale

Since v1.5.5 release, we haven't incremented the chart version in `skaffold.yaml`. Let's fix that.  It's ok for time being that the skaffold config file won't include v1.6.0 as we cannot yet build container images for arm64.

While here, let's make sure that we are authenticating with the proper gcloud project.  Failure to use the right one results in access errors to the internal container images.

## Changes

* `skaffold.yaml`
  * bump fityone-teams-app chart version from `v1.5.5` to `v1.5.8`
* `makefile`
  * add target `auth` with `--project` argument
* `CONTRIBUTING.md`
  * update to use `make auth` 


Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

n/a ^

## Testing

Use new commands and configurations to run v1.5.8 locally, successfully.

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
