### PR TITLE
adds some documentation around custom plugins images

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -201,6 +201,10 @@ create a new Docker Volume shared between FiftyOne Teams services.
 For multi-node deployments, please implement a storage
 solution allowing the access the deployed plugins.
 
+If you build plugins that have custom dependencies, you will need to build and
+use
+[Custom Plugins Images](https://github.com/voxel51/fiftyone-teams-app/docs/custom-plugins.md)
+
 Use the FiftyOne Teams UI to deploy plugins by navigating to `https://<DEPOY_URL>/settings/plugins`.
 Early-adopter plugins installed manually must
 be redeployed using the FiftyOne Teams UI.

--- a/docs/custom-plugins.md
+++ b/docs/custom-plugins.md
@@ -86,5 +86,5 @@ number as the FiftyOne Teams release, the Helm chart will
 automatically use the chart version to pull your image.
 
 Please see
-[FiftyOne Teams Plugins](../helm/README.md#fiftyone-teams-plugins)
+[FiftyOne Teams Plugins](../helm/fiftyone-teams-app/README.md#fiftyone-teams-plugins)
 for additional information regarding `teams-plugins` configuration.

--- a/docs/custom-plugins.md
+++ b/docs/custom-plugins.md
@@ -66,7 +66,7 @@ services:
 ```
 
 Please see
-[Enabling FiftyOne Teams Plugins](docker/README.md#enabling-fiftyone-teams-plugins)
+[Enabling FiftyOne Teams Plugins](../docker/README.md#enabling-fiftyone-teams-plugins)
 for example `docker compose` commands for starting and upgrading your
 deployment.
 
@@ -86,5 +86,5 @@ number as the FiftyOne Teams release, the Helm chart will
 automatically use the chart version to pull your image.
 
 Please see
-[FiftyOne Teams Plugins](helm/README.md#fiftyone-teams-plugins)
+[FiftyOne Teams Plugins](../helm/README.md#fiftyone-teams-plugins)
 for additional information regarding `teams-plugins` configuration.

--- a/docs/custom-plugins.md
+++ b/docs/custom-plugins.md
@@ -1,0 +1,90 @@
+<!-- markdownlint-disable no-inline-html line-length -->
+<!-- markdownlint-disable-next-line first-line-heading -->
+<div align="center">
+<p align="center">
+
+<img src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
+
+</p>
+</div>
+<!-- markdownlint-enable no-inline-html line-length -->
+
+---
+
+# Custom Plugins Images
+
+Some plugins have custom python dependencies, which requires the
+creation of a new plugins image.  This document outlines the steps
+Voxel51 recommends for creating those custom plugins containers.
+
+## Create a New Image From an Existing Voxel51 Image
+
+By default, dedicated plugins use the `voxel51/fiftyone-app` image.
+Basing your custom image on the existing base image will ensure that
+the required `fiftyone` packages and configurations are available.
+
+As an example, you might use the following Dockerfile to build a
+custom `your-internal-registry/fiftyone-app-internal` image:
+
+```dockerfile
+ARG TEAMS_IMAGE_NAME
+
+FROM python:3.10 as wheelhouse
+
+RUN pip wheel --wheel-dir=/tmp/wheels pandas
+
+FROM ${TEAMS_IMAGE_NAME} as pandarelease
+
+RUN --mount=type=cache,from=wheelhouse,target=/wheelhouse,ro \
+    pip --no-cache-dir install -q --no-index \
+    --find-links=/wheelhouse/tmp/wheels pandas
+```
+
+With a Dockerfile like this, you could use the following commands to
+build, and publish, your image to your internal registry
+
+```shell
+$ TEAMS_VERSION=v1.6.0
+$ docker buildx build --push \
+    --build-arg TEAMS_IMAGE_NAME='voxel51/fiftyone-app:${TEAMS_VERSION}' \
+ -t your-internal-registry/fiftyone-app-internal:${TEAMS_VERSION} .
+```
+
+You should upgrade your custom plugins image using the `TEAMS_VERSION`
+you plan to use in your FiftyOne Teams Deployment.
+
+## Using Your Custom Plugins Image in Docker Compose
+
+Once you have built a custom plugins image, you can add it to your
+`compose.override.yaml` using something similar to the following:
+
+```yaml
+services:
+  teams-plugins:
+    image: your-internal-registry/fiftyone-app-internal:v1.6.0
+```
+
+Please see
+[Enabling FiftyOne Teams Plugins](docker/README.md#enabling-fiftyone-teams-plugins)
+for example `docker compose` commands for starting and upgrading your
+deployment.
+
+## Using Your Custom Plugins Image in Helm Deployments
+
+Once you have build a custom plugins image, you can add it to your
+`values.yaml` using something similar to the following:
+
+```yaml
+pluginsSettings:
+  image:
+    repository: your-internal-registry/fiftyone-app-internal
+```
+
+Assuming you have built your custom container with the same version
+number as the FiftyOne Teams release, the Helm chart will
+automatically use the chart version to pull your image.
+
+Please see
+[FiftyOne Teams Plugins](helm/README.md#fiftyone-teams-plugins)
+for additional information regarding `teams-plugins` configuration.

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -575,7 +575,17 @@ upgrading from FiftyOne Teams version 1.1.0 or later:
 A minimal example `values.yaml` may be found
 [here](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/values.yaml).
 
-1. Edit the `values.yaml` file
+1. Edit the `values.yaml` file, setting these required customer provided settings
+    1. Secrets
+        1. `secret.fiftyone.mongodbConnectionString`
+        1. `secret.fiftyone.cookieSecret`
+        1. `secret.fiftyone.encryptionKey`
+        1. `secret.fiftyone.fiftyoneAuthSecret`
+
+        > **Note**: All the secret fields defined in the Helm chart must be set.
+        > If `secret.create=false`, the secret you provide must contain all the fields
+        > in the chart's `secret.fiftyone`.
+    1. `teamsAppSettings.dnsName`
 1. Deploy FiftyOne Teams with `helm install`
     1. For a new installation, run
 

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -168,6 +168,10 @@ There are three modes for plugins
           add the `teams-plugins` service name to your `no_proxy` and
           `NO_PROXY` environment variables.
 
+If you build plugins that have custom requirements, you will need to build and
+use
+[Custom Plugins Images](https://github.com/voxel51/fiftyone-teams-app/docs/custom-plugins.md)
+
 Use the FiftyOne Teams UI to deploy plugins by navigating to `https://<DEPOY_URL>/settings/plugins`.
 Early-adopter plugins installed manually must be
 redeployed using the FiftyOne Teams UI.
@@ -571,17 +575,7 @@ upgrading from FiftyOne Teams version 1.1.0 or later:
 A minimal example `values.yaml` may be found
 [here](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/values.yaml).
 
-1. Edit the `values.yaml` file, setting these required customer provided settings
-    1. Secrets
-        1. `secret.fiftyone.mongodbConnectionString`
-        1. `secret.fiftyone.cookieSecret`
-        1. `secret.fiftyone.encryptionKey`
-        1. `secret.fiftyone.fiftyoneAuthSecret`
-
-        > **Note**: All the secret fields defined in the Helm chart must be set.
-        > If `secret.create=false`, the secret you provide must contain all the fields
-        > in the chart's `secret.fiftyone`.
-    1. `teamsAppSettings.dnsName`
+1. Edit the `values.yaml` file
 1. Deploy FiftyOne Teams with `helm install`
     1. For a new installation, run
 

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -168,7 +168,7 @@ There are three modes for plugins
           add the `teams-plugins` service name to your `no_proxy` and
           `NO_PROXY` environment variables.
 
-If you build plugins that have custom requirements, you will need to build and
+If you build plugins that have custom dependencies, you will need to build and
 use
 [Custom Plugins Images](https://github.com/voxel51/fiftyone-teams-app/docs/custom-plugins.md)
 
@@ -575,17 +575,7 @@ upgrading from FiftyOne Teams version 1.1.0 or later:
 A minimal example `values.yaml` may be found
 [here](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/values.yaml).
 
-1. Edit the `values.yaml` file, setting these required customer provided settings
-    1. Secrets
-        1. `secret.fiftyone.mongodbConnectionString`
-        1. `secret.fiftyone.cookieSecret`
-        1. `secret.fiftyone.encryptionKey`
-        1. `secret.fiftyone.fiftyoneAuthSecret`
-
-        > **Note**: All the secret fields defined in the Helm chart must be set.
-        > If `secret.create=false`, the secret you provide must contain all the fields
-        > in the chart's `secret.fiftyone`.
-    1. `teamsAppSettings.dnsName`
+1. Edit the `values.yaml` file
 1. Deploy FiftyOne Teams with `helm install`
     1. For a new installation, run
 

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -170,7 +170,7 @@ There are three modes for plugins
           add the `teams-plugins` service name to your `no_proxy` and
           `NO_PROXY` environment variables.
 
-If you build plugins that have custom requirements, you will need to build and
+If you build plugins that have custom dependencies, you will need to build and
 use
 [Custom Plugins Images](https://github.com/voxel51/fiftyone-teams-app/docs/custom-plugins.md)
 

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -170,6 +170,10 @@ There are three modes for plugins
           add the `teams-plugins` service name to your `no_proxy` and
           `NO_PROXY` environment variables.
 
+If you build plugins that have custom requirements, you will need to build and
+use
+[Custom Plugins Images](https://github.com/voxel51/fiftyone-teams-app/docs/custom-plugins.md)
+
 Use the FiftyOne Teams UI to deploy plugins by navigating to `https://<DEPOY_URL>/settings/plugins`.
 Early-adopter plugins installed manually must be
 redeployed using the FiftyOne Teams UI.


### PR DESCRIPTION
# Rationale

Got a Slack Message [from a customer](https://voxel51.slack.com/archives/C06QD55JFGC/p1712231912862079) asking for more information about building/using custom plugins images.

The links in the documents may not actually work until this is published.

## Changes

Add an example dockerfile and configuration parameters.  Entirely documentation-based.

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

## Testing

Built `local-image/fiftyone-app-tophertest:v1.5.8` locally

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
