### PR TITLE
[AS-107] Add Integration Tests for Docker Compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,8 @@
 compose.override*yaml
 helm/gke-example/values-*.yaml
 helm/gke-example/voxel51-docker.json
-tests/integration/*/test_output.log
-tests/integration/*/test_output/*
+tests/integration/*/test_output*.log
+tests/integration/*/test_output*/*
 tests/integration/*/test_reports/*
 tests/unit/*/test_output.log
 tests/unit/*/test_output/*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,7 +76,7 @@ repos:
       - id: detect-secrets
         args:
           - --exclude-secrets
-          - '(password|REPLACEME|fiftyone-teams-tls-secret|btv8BiFCaPIayWU3IU3a_Lm_EMIIk-t6H_yN1ORV45o=|5b32118032bfd50b64b3cc7c0e0821f4e84f63ad517a9687ac2b6ce6ab261976|test-*|/api/proxy/fiftyone-teams|/opt/plugins)'
+          - '(password|REPLACEME|fiftyone-teams-tls-secret|3-9XjJ-gUV?vp\^e\(WUk>LD&lAjh7yEji|btv8BiFCaPIayWU3IU3a_Lm_EMIIk-t6H_yN1ORV45o=|5b32118032bfd50b64b3cc7c0e0821f4e84f63ad517a9687ac2b6ce6ab261976|test-*|/api/proxy/fiftyone-teams|/opt/plugins)'
   - repo: https://github.com/dnephin/pre-commit-golang
     rev: v0.5.1
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -101,23 +101,21 @@ helm-repos:  ## add helm repos for the project
 clean: clean-unit-compose clean-unit-helm clean-integration-compose clean-integration-helm  ## delete all test output and reports
 
 clean-integration-compose:  ## delete docker compose integration test output and reports
-	rm -rf tests/integration/compose/test_output || true
-	rm -rf tests/integration/compose/test_reports || true
+	rm -rf tests/integration/compose/test_output_internal || true
+	rm -rf tests/integration/compose/test_output_legacy || true
 	rm tests/integration/compose/test_output.log || true
 
 clean-integration-helm:  ## delete helm integration test output and reports
-	rm -rf tests/integration/helm/test_output || true
-	rm -rf tests/integration/helm/test_reports || true
+	rm -rf tests/integration/helm/test_output_internal || true
+	rm -rf tests/integration/helm/test_output_legacy || true
 	rm tests/integration/helm/test_output.log || true
 
 clean-unit-compose:  ## delete docker compose unit test output and reports
 	rm -rf tests/unit/compose/test_output || true
-	rm -rf tests/unit/compose/test_reports || true
 	rm tests/unit/compose/test_output.log || true
 
 clean-unit-helm:  ## delete helm unit test output and reports
 	rm -rf tests/unit/helm/test_output || true
-	rm -rf tests/unit/helm/test_reports || true
 	rm tests/unit/helm/test_output.log || true
 
 dependencies-integration-compose:  ## create a (temporary) directory for mongodb container
@@ -138,28 +136,39 @@ test-unit-helm:  ## run go test on the tests/unit/helm directory
 
 test-unit-compose-interleaved: install-terratest-log-parser  ## run go test on the tests/unit/compose directory and run the terratest_log_parser for reports
 	@cd tests/unit/compose; \
-	rm -rf test_reports; \
-	mkdir test_reports; \
+	rm -rf test_output/*; \
 	go test -count=1 -timeout=10m -v -tags unit | tee test_output.log; \
 	${ASDF}/packages/bin/terratest_log_parser -testlog test_output.log -outputdir test_output
 
 test-unit-helm-interleaved: install-terratest-log-parser  ## run go test on the tests/unit/helm directory and run the terratest_log_parser for reports
 	@cd tests/unit/helm; \
-	rm -rf test_reports; \
-	mkdir test_reports; \
+	rm -rf test_output/*; \
 	go test -count=1 -timeout=10m -v -tags unit | tee test_output.log; \
 	${ASDF}/packages/bin/terratest_log_parser -testlog test_output.log -outputdir test_output
 
-test-integration-compose: dependencies-integration-compose ## run go test on the tests/integration/compose directory
-	@cd tests/integration/compose; \
-	go test -count=1 -timeout=10m -v -tags integration
+test-integration-compose: test-integration-compose-internal test-integration-compose-legacy ## run go test on the tests/integration/compose directory for both internal and legacy auth modes
 
-test-integration-compose-interleaved: install-terratest-log-parser dependencies-integration-compose clean-integration-compose ## run go test on the tests/integration/compose directory and run the terratest_log_parser for reports
+test-integration-compose-internal: dependencies-integration-compose ## run go test on the tests/integration/compose directory for internal auth mode
 	@cd tests/integration/compose; \
-	rm -rf test_reports; \
-	mkdir test_reports; \
-	go test -count=1 -timeout=10m -v -tags integration | tee test_output.log; \
-	${ASDF}/packages/bin/terratest_log_parser -testlog test_output.log -outputdir test_output
+	go test -count=1 -timeout=10m -v -tags integrationComposeInternalAuth
+
+test-integration-compose-legacy: dependencies-integration-compose ## run go test on the tests/integration/compose directory for legacy auth mode
+	@cd tests/integration/compose; \
+	go test -count=1 -timeout=10m -v -tags integrationComposeLegacyAuth
+
+test-integration-compose-interleaved:  test-integration-compose-interleaved-internal test-integration-compose-interleaved-legacy  ## run go test on the tests/integration/compose directory and run the terratest_log_parser for reports
+
+test-integration-compose-interleaved-internal: install-terratest-log-parser dependencies-integration-compose clean-integration-compose ## run go test on the tests/integration/compose directory for internal auth mode and run the terratest_log_parser for reports
+	@cd tests/integration/compose; \
+	rm -rf test_output_internal/*; \
+	go test -count=1 -timeout=10m -v -tags integrationComposeInternalAuth | tee test_output_internal.log; \
+	${ASDF}/packages/bin/terratest_log_parser -testlog test_output_internal.log -outputdir test_output_internal
+
+test-integration-compose-interleaved-legacy: install-terratest-log-parser dependencies-integration-compose clean-integration-compose ## run go test on the tests/integration/compose directory for legacy auth mode and run the terratest_log_parser for reports
+	@cd tests/integration/compose; \
+	rm -rf test_output_legacy/*; \
+	go test -count=1 -timeout=10m -v -tags integrationComposeLegacyAuth | tee test_output_legacy.log; \
+	${ASDF}/packages/bin/terratest_log_parser -testlog test_output_legacy.log -outputdir test_output_legacy
 
 install-terratest-log-parser:  ## install terratest_log_parser
 	go install github.com/gruntwork-io/terratest/cmd/terratest_log_parser@latest

--- a/tests/fixtures/docker/compose.override.darwin.yaml
+++ b/tests/fixtures/docker/compose.override.darwin.yaml
@@ -1,0 +1,9 @@
+services:
+  fiftyone-app:
+    platform: linux/amd64
+  teams-api:
+    platform: linux/amd64
+  teams-app:
+    platform: linux/amd64
+  teams-cas:
+    platform: linux/amd64

--- a/tests/fixtures/docker/compose.override.yaml
+++ b/tests/fixtures/docker/compose.override.yaml
@@ -1,0 +1,4 @@
+services:
+  fiftyone-app:
+    environment:
+      FIFTYONE_DATABASE_ADMIN: true

--- a/tests/fixtures/docker/integration_internal_auth.env
+++ b/tests/fixtures/docker/integration_internal_auth.env
@@ -1,22 +1,4 @@
-# Data for Integration Tests for Legacy Auth Mode
-
-# Auth0
-# CAS doesn't validate the Auth0 Legacy Mode values when it starts.
-# Without a web server, we cannot access the Web UI because we get an infinite redirect loop
-# resulting in 404s: `Requested URL /api/cas not found`
-AUTH0_API_CLIENT_ID=""
-AUTH0_API_CLIENT_SECRET=""
-AUTH0_AUDIENCE=""
-AUTH0_CLIENT_ID=""
-AUTH0_CLIENT_SECRET=""
-AUTH0_DOMAIN=""
-AUTH0_ISSUER_BASE_URL=""
-AUTH0_ORGANIZATION=""
-
-# This is a randomly generated string
-AUTH0_SECRET=5b32118032bfd50b64b3cc7c0e0821f4e84f63ad517a9687ac2b6ce6ab261976
-
-AUTH0_BASE_URL=http://local.fiftyone.ai
+# Data for Integration Tests for Internal Auth Mode
 
 # FiftyOne
 FIFTYONE_DATABASE_URI="mongodb://root:3-9XjJ-gUV?vp^e(WUk>LD&lAjh7yEji@mongodb/?authSource=admin"  # This is a randomly generated password

--- a/tests/fixtures/docker/integration_legacy_auth.env
+++ b/tests/fixtures/docker/integration_legacy_auth.env
@@ -1,0 +1,48 @@
+# Data for Integration Tests
+
+# Auth0
+# CAS doesn't validate the Auth0 Legacy Mode values when it starts.
+# Without a web server, we cannot access the Web UI because we get an infinite redirect loop
+# resulting in 404s: `Requested URL /api/cas not found`
+AUTH0_API_CLIENT_ID=""
+AUTH0_API_CLIENT_SECRET=""
+AUTH0_AUDIENCE=""
+AUTH0_CLIENT_ID=""
+AUTH0_CLIENT_SECRET=""
+AUTH0_DOMAIN=""
+AUTH0_ISSUER_BASE_URL=""
+AUTH0_ORGANIZATION=""
+
+# This is a randomly generated string
+AUTH0_SECRET=5b32118032bfd50b64b3cc7c0e0821f4e84f63ad517a9687ac2b6ce6ab261976
+
+AUTH0_BASE_URL=http://local.fiftyone.ai
+
+# FiftyOne
+FIFTYONE_DATABASE_URI="mongodb://root:3-9XjJ-gUV?vp^e(WUk>LD&lAjh7yEji@mongodb/?authSource=admin"  # This is a randomly generated password
+FIFTYONE_ENCRYPTION_KEY="btv8BiFCaPIayWU3IU3a_Lm_EMIIk-t6H_yN1ORV45o=" # This is a randomly generated string
+
+# Internal Auth
+FIFTYONE_AUTH_SECRET="test-fiftyone-auth-secret"
+
+# MongoDB
+MONGODB_PASSWORD="3-9XjJ-gUV?vp^e(WUk>LD&lAjh7yEji" # This is a randomly generated string  # pragma: allowlist secret
+MONGODB_USERNAME=root
+MONGODB_DIR=/tmp/mongodb
+MONGODB_BIND_ADDRESS=127.0.0.1
+
+APP_USE_HTTPS=false
+FIFTYONE_API_URI=http://local.fiftyone.ai
+BASE_URL=http://local.fiftyone.ai
+
+# Show debug logs
+API_LOGGING_LEVEL=DEBUG
+FIFTYONE_ENV=development
+CAS_DEBUG="cas:*"
+
+# Image tags
+VERSION=v1.6.0
+FIFTYONE_APP_RC=${VERSION}rc14
+FIFTYONE_TEAMS_API_RC=${VERSION}rc13
+FIFTYONE_TEAMS_APP_RC=${VERSION}-rc.11
+FIFTYONE_TEAMS_CAS_RC=${VERSION}-rc.11

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -3,8 +3,8 @@ module github.com/voxel51/fiftyone-teams-app-deploy
 go 1.21.6
 
 require (
-	github.com/compose-spec/compose-go/v2 v2.0.0-rc.8
-	github.com/gruntwork-io/terratest v0.46.11
+	github.com/compose-spec/compose-go/v2 v2.0.2
+	github.com/gruntwork-io/terratest v0.46.13
 	github.com/stretchr/testify v1.8.4
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.28.4
@@ -90,6 +90,7 @@ require (
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gotest.tools/v3 v3.4.0 // indirect
 	k8s.io/client-go v0.28.4 // indirect
 	k8s.io/klog/v2 v2.100.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9 // indirect

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -8,8 +8,8 @@ github.com/aws/aws-sdk-go v1.44.122/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8WK8raXaxBx6fRVTlJILwEwQGL1I/ByEI=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
-github.com/compose-spec/compose-go/v2 v2.0.0-rc.8 h1:b7l+GqFF+2W4M4kLQUDRTGhqmTiRwT3bYd9X7xrxp5Q=
-github.com/compose-spec/compose-go/v2 v2.0.0-rc.8/go.mod h1:bEPizBkIojlQ20pi2vNluBa58tevvj0Y18oUSHPyfdc=
+github.com/compose-spec/compose-go/v2 v2.0.2 h1:zhXMV7VWI00Su0LdKt8/sxeXxcjLWhmGmpEyw+ZYznI=
+github.com/compose-spec/compose-go/v2 v2.0.2/go.mod h1:bEPizBkIojlQ20pi2vNluBa58tevvj0Y18oUSHPyfdc=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
@@ -81,8 +81,8 @@ github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB7
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gruntwork-io/go-commons v0.8.0 h1:k/yypwrPqSeYHevLlEDmvmgQzcyTwrlZGRaxEM6G0ro=
 github.com/gruntwork-io/go-commons v0.8.0/go.mod h1:gtp0yTtIBExIZp7vyIV9I0XQkVwiQZze678hvDXof78=
-github.com/gruntwork-io/terratest v0.46.11 h1:1Z9G18I2FNuH87Ro0YtjW4NH9ky4GDpfzE7+ivkPeB8=
-github.com/gruntwork-io/terratest v0.46.11/go.mod h1:DVZG/s7eP1u3KOQJJfE6n7FDriMWpDvnj85XIlZMEM8=
+github.com/gruntwork-io/terratest v0.46.13 h1:FDaEoZ7DtkomV8pcwLdBV/VsytdjnPRqJkIriYEYwjs=
+github.com/gruntwork-io/terratest v0.46.13/go.mod h1:8sxu3Qup8TxtbzOHzq0MUrQffJj/G61/OwlsReaCwpo=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.0 h1:B9UzwGQJehnUY1yNrnwREHc3fGbC2xefo8g4TbElacI=
@@ -233,6 +233,7 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -254,6 +255,7 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.17.0 h1:FvmRgNOcs3kOa+T20R1uhfP9F6HgG2mfxDv1vrx1Htc=
 golang.org/x/tools v0.17.0/go.mod h1:xsh6VxdV005rRVaS6SSAf9oiAqljS7UZUacMZ8Bnsps=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/tests/integration/compose/common_test.go
+++ b/tests/integration/compose/common_test.go
@@ -1,5 +1,5 @@
-//go:build docker || compose || integration || integrationComposeInternalAuth || integrationComposeLegacyAuth
-// +build docker compose integration integrationComposeInternalAuth integrationComposeLegacyAuth
+//go:build docker || compose || integration || integrationComposeInternalAuth || integrationComposeLegacyAuth || integrationComposeInternalAuth
+// +build docker compose integration integrationComposeInternalAuth integrationComposeLegacyAuth integrationComposeInternalAuth
 
 package integration
 
@@ -12,7 +12,8 @@ import (
 )
 
 const (
-	envFixtureFilePath = "../../fixtures/docker/integration_legacy_auth.env"
+	legacyAuthEnvFixtureFilePath   = "../../fixtures/docker/integration_legacy_auth.env"
+	internalAuthFixtureEnvFilePath = "../../fixtures/docker/integration_internal_auth.env"
 )
 
 func validate_endpoint(t *testing.T, url string, expectedBody string, expectedStatus int) {

--- a/tests/integration/compose/common_test.go
+++ b/tests/integration/compose/common_test.go
@@ -1,0 +1,27 @@
+//go:build docker || compose || integration || integrationComposeInternalAuth || integrationComposeLegacyAuth
+// +build docker compose integration integrationComposeInternalAuth integrationComposeLegacyAuth
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gruntwork-io/terratest/modules/docker"
+	http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
+)
+
+const (
+	envFixtureFilePath = "../../fixtures/docker/integration_legacy_auth.env"
+)
+
+func validate_endpoint(t *testing.T, url string, expectedBody string, expectedStatus int) {
+	maxRetries := 10
+	timeBetweenRetries := 3 * time.Second
+	http_helper.HttpGetWithRetry(t, url, nil, expectedStatus, expectedBody, maxRetries, timeBetweenRetries)
+}
+
+func get_logs(t *testing.T, dockerOptions *docker.Options, container string) string {
+	output := docker.RunDockerComposeAndGetStdOut(t, dockerOptions, "logs", container)
+	return output
+}

--- a/tests/integration/compose/common_test.go
+++ b/tests/integration/compose/common_test.go
@@ -14,7 +14,20 @@ import (
 const (
 	legacyAuthEnvFixtureFilePath   = "../../fixtures/docker/integration_legacy_auth.env"
 	internalAuthFixtureEnvFilePath = "../../fixtures/docker/integration_internal_auth.env"
+	// Override FIFTYONE_DATABASE_ADMIN to true (until we can override via environment variable)
+	overrideFile = "../../tests/fixtures/docker/compose.override.yaml"
+	// To run the containers on macOS arm64, we need to set the platform
+	darwinOverrideFile = "../../tests/fixtures/docker/compose.override.darwin.yaml"
+	mongodbComposeFile = "../../tests/fixtures/docker/compose.override.mongodb.yaml"
 )
+
+type serviceValidations struct {
+	name             string
+	url              string
+	responsePayload  string
+	httpResponseCode int
+	log              string
+}
 
 func validate_endpoint(t *testing.T, url string, expectedBody string, expectedStatus int) {
 	maxRetries := 10

--- a/tests/integration/compose/docker-compose-internal-auth_test.go
+++ b/tests/integration/compose/docker-compose-internal-auth_test.go
@@ -1,5 +1,5 @@
-//go:build docker || compose || integration || integrationComposeLegacyAuth
-// +build docker compose integration integrationComposeLegacyAuth
+//go:build docker || compose || integration || integrationComposeInternalAuth
+// +build docker compose integration integrationComposeInternalAuth
 
 package integration
 
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	dockerLegacyAuthDir = "../../../docker/legacy-auth"
+	dockerInternalAuthDir = "../../../docker/internal-auth"
 	// Override FIFTYONE_DATABASE_ADMIN to true (until we can override via environment variable)
 	overrideFile = "../../tests/fixtures/docker/compose.override.yaml"
 	// To run the containers on macOS arm64, we need to set the platform
@@ -30,22 +30,22 @@ const (
 	mongodbComposeFile = "../../tests/fixtures/docker/compose.override.mongodb.yaml"
 )
 
-var legacyAuthComposeFile = "compose.yaml"
-var legacyAuthComposePluginsFile = "compose.plugins.yaml"
-var legacyAuthComposeDedicatedPluginsFile = "compose.dedicated-plugins.yaml"
-var legacyAuthEnvTemplateFilePath = filepath.Join(dockerLegacyAuthDir, "env.template")
+var internalAuthComposeFile = "compose.yaml"
+var internalAuthComposePluginsFile = "compose.plugins.yaml"
+var internalAuthComposeDedicatedPluginsFile = "compose.dedicated-plugins.yaml"
+var internalAuthEnvTemplateFilePath = filepath.Join(dockerInternalAuthDir, "env.template")
 
-type commonServicesLegacyAuthDockerComposeUpTest struct {
+type commonServicesInternalAuthDockerComposeUpTest struct {
 	suite.Suite
 	composeFilePath string
 	dotEnvFiles     []string
 	overrideFiles   []string
 }
 
-func TestDockerComposeUpLegacyAuth(t *testing.T) {
+func TestDockerComposeUpInternalAuth(t *testing.T) {
 	t.Parallel()
 
-	_, err := filepath.Abs(dockerLegacyAuthDir)
+	_, err := filepath.Abs(dockerInternalAuthDir)
 	require.NoError(t, err)
 
 	// Set the override files used for the tests
@@ -59,12 +59,12 @@ func TestDockerComposeUpLegacyAuth(t *testing.T) {
 		overrideFiles = append(overrideFiles, darwinOverrideFile)
 	}
 
-	suite.Run(t, &commonServicesLegacyAuthDockerComposeUpTest{
+	suite.Run(t, &commonServicesInternalAuthDockerComposeUpTest{
 		Suite:           suite.Suite{},
-		composeFilePath: dockerLegacyAuthDir,
+		composeFilePath: dockerInternalAuthDir,
 		dotEnvFiles: []string{
-			legacyAuthEnvTemplateFilePath,
-			legacyAuthEnvFixtureFilePath,
+			internalAuthEnvTemplateFilePath,
+			internalAuthFixtureEnvFilePath,
 		},
 		overrideFiles: overrideFiles,
 	})
@@ -78,7 +78,7 @@ type serviceValidations struct {
 	log              string
 }
 
-func (s *commonServicesLegacyAuthDockerComposeUpTest) TestDockerComposeUp() {
+func (s *commonServicesInternalAuthDockerComposeUpTest) TestDockerComposeUp() {
 	testCases := []struct {
 		name          string
 		composeFile   string
@@ -88,7 +88,7 @@ func (s *commonServicesLegacyAuthDockerComposeUpTest) TestDockerComposeUp() {
 	}{
 		{
 			"compose",
-			legacyAuthComposeFile,
+			internalAuthComposeFile,
 			s.overrideFiles,
 			s.dotEnvFiles,
 			[]serviceValidations{
@@ -125,7 +125,7 @@ func (s *commonServicesLegacyAuthDockerComposeUpTest) TestDockerComposeUp() {
 		},
 		{
 			"composePlugins",
-			legacyAuthComposePluginsFile,
+			internalAuthComposePluginsFile,
 			s.overrideFiles,
 			s.dotEnvFiles,
 			[]serviceValidations{
@@ -162,7 +162,7 @@ func (s *commonServicesLegacyAuthDockerComposeUpTest) TestDockerComposeUp() {
 		},
 		{
 			"composeDedicatedPlugins",
-			legacyAuthComposeDedicatedPluginsFile,
+			internalAuthComposeDedicatedPluginsFile,
 			s.overrideFiles,
 			s.dotEnvFiles,
 			[]serviceValidations{
@@ -222,7 +222,7 @@ func (s *commonServicesLegacyAuthDockerComposeUpTest) TestDockerComposeUp() {
 			// ```shell
 			// docker compose \
 			//   -f tests/fixtures/docker/compose.override.mongodb.yaml \
-			//   --env-file tests/fixtures/docker/integration_legacy_auth.env
+			//   --env-file tests/fixtures/docker/integration_internal_auth.env
 
 			//   up -d
 			// ```
@@ -233,7 +233,7 @@ func (s *commonServicesLegacyAuthDockerComposeUpTest) TestDockerComposeUp() {
 
 			dockerOptions := &docker.Options{
 				ProjectName: "fiftyone-" + strings.ToLower(random.UniqueId()),
-				WorkingDir:  dockerLegacyAuthDir,
+				WorkingDir:  dockerInternalAuthDir,
 				EnvVars:     environmentVariables,
 			}
 

--- a/tests/integration/compose/docker-compose-internal-auth_test.go
+++ b/tests/integration/compose/docker-compose-internal-auth_test.go
@@ -23,11 +23,6 @@ import (
 
 const (
 	dockerInternalAuthDir = "../../../docker/internal-auth"
-	// Override FIFTYONE_DATABASE_ADMIN to true (until we can override via environment variable)
-	overrideFile = "../../tests/fixtures/docker/compose.override.yaml"
-	// To run the containers on macOS arm64, we need to set the platform
-	darwinOverrideFile = "../../tests/fixtures/docker/compose.override.darwin.yaml"
-	mongodbComposeFile = "../../tests/fixtures/docker/compose.override.mongodb.yaml"
 )
 
 var internalAuthComposeFile = "compose.yaml"
@@ -68,14 +63,6 @@ func TestDockerComposeUpInternalAuth(t *testing.T) {
 		},
 		overrideFiles: overrideFiles,
 	})
-}
-
-type serviceValidations struct {
-	name             string
-	url              string
-	responsePayload  string
-	httpResponseCode int
-	log              string
 }
 
 func (s *commonServicesInternalAuthDockerComposeUpTest) TestDockerComposeUp() {

--- a/tests/integration/compose/docker-compose-legacy-auth_test.go
+++ b/tests/integration/compose/docker-compose-legacy-auth_test.go
@@ -23,11 +23,6 @@ import (
 
 const (
 	dockerLegacyAuthDir = "../../../docker/legacy-auth"
-	// Override FIFTYONE_DATABASE_ADMIN to true (until we can override via environment variable)
-	overrideFile = "../../tests/fixtures/docker/compose.override.yaml"
-	// To run the containers on macOS arm64, we need to set the platform
-	darwinOverrideFile = "../../tests/fixtures/docker/compose.override.darwin.yaml"
-	mongodbComposeFile = "../../tests/fixtures/docker/compose.override.mongodb.yaml"
 )
 
 var legacyAuthComposeFile = "compose.yaml"
@@ -68,14 +63,6 @@ func TestDockerComposeUpLegacyAuth(t *testing.T) {
 		},
 		overrideFiles: overrideFiles,
 	})
-}
-
-type serviceValidations struct {
-	name             string
-	url              string
-	responsePayload  string
-	httpResponseCode int
-	log              string
 }
 
 func (s *commonServicesLegacyAuthDockerComposeUpTest) TestDockerComposeUp() {

--- a/tests/integration/compose/docker-compose-legacy-auth_test.go
+++ b/tests/integration/compose/docker-compose-legacy-auth_test.go
@@ -1,0 +1,280 @@
+//go:build docker || compose || integration || integrationComposeLegacyAuth
+// +build docker compose integration integrationComposeLegacyAuth
+
+package integration
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+
+	"path/filepath"
+
+	"github.com/gruntwork-io/terratest/modules/docker"
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/random"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/compose-spec/compose-go/v2/dotenv"
+)
+
+const (
+	dockerLegacyAuthDir = "../../../docker/legacy-auth"
+	// Override FIFTYONE_DATABASE_ADMIN to true (until we can override via environment variable)
+	overrideFile = "../../tests/fixtures/docker/compose.override.yaml"
+	// To run the containers on macOS arm64, we need to set the platform
+	darwinOverrideFile = "../../tests/fixtures/docker/compose.override.darwin.yaml"
+	mongodbComposeFile = "../../tests/fixtures/docker/compose.override.mongodb.yaml"
+)
+
+var legacyAuthComposeFile = "compose.yaml"
+var legacyAuthComposePluginsFile = "compose.plugins.yaml"
+var legacyAuthComposeDedicatedPluginsFile = "compose.dedicated-plugins.yaml"
+var legacyAuthEnvTemplateFilePath = filepath.Join(dockerLegacyAuthDir, "env.template")
+
+type commonServicesLegacyAuthDockerComposeUpTest struct {
+	suite.Suite
+	composeFilePath string
+	projectName     string
+	dotEnvFiles     []string
+	overrideFiles   []string
+}
+
+func TestDockerComposeUpLegacyAuth(t *testing.T) {
+	t.Parallel()
+
+	_, err := filepath.Abs(dockerLegacyAuthDir)
+	require.NoError(t, err)
+
+	// Set the override files used for the tests
+	overrideFiles := []string{
+		overrideFile,
+		mongodbComposeFile,
+	}
+
+	// To run the containers on macOS arm64, we need to set the platform
+	if runtime.GOOS == "darwin" {
+		overrideFiles = append(overrideFiles, darwinOverrideFile)
+	}
+
+	suite.Run(t, &commonServicesLegacyAuthDockerComposeUpTest{
+		Suite:           suite.Suite{},
+		composeFilePath: dockerLegacyAuthDir,
+		projectName:     "fiftyone-compose-integration-test",
+		dotEnvFiles: []string{
+			legacyAuthEnvTemplateFilePath,
+			envFixtureFilePath,
+		},
+		overrideFiles: overrideFiles,
+	})
+}
+
+type serviceValidations struct {
+	name             string
+	url              string
+	responsePayload  string
+	httpResponseCode int
+	log              string
+}
+
+func (s *commonServicesLegacyAuthDockerComposeUpTest) TestDockerComposeUp() {
+	testCases := []struct {
+		name          string
+		composeFile   string
+		overrideFiles []string
+		envFiles      []string // file paths to ".env" files with additional environment variable data
+		expected      []serviceValidations
+	}{
+		{
+			"compose",
+			legacyAuthComposeFile,
+			s.overrideFiles,
+			s.dotEnvFiles,
+			[]serviceValidations{
+				{
+					name:             "teams-api",
+					url:              "http://127.0.0.1:8000/health",
+					responsePayload:  `{"status":"available"}`,
+					httpResponseCode: 200,
+					log:              "[INFO] Starting worker",
+				},
+				{
+					name:             "teams-app",
+					url:              "http://127.0.0.1:3000/api/hello",
+					responsePayload:  `{"name":"John Doe"}`,
+					httpResponseCode: 200,
+					log:              "Listening on port 3000",
+				},
+				{
+					name:             "teams-cas",
+					url:              "http://127.0.0.1:3030/cas/api",
+					responsePayload:  `{"status":"available"}`,
+					httpResponseCode: 200,
+					log:              " ✓ Ready in",
+				},
+				// ordering this last to avoid test flakes where testing for log before the container is running
+				{
+					name:             "fiftyone-app",
+					url:              "",
+					responsePayload:  "",
+					httpResponseCode: 200,
+					log:              "[INFO] Running on http://0.0.0.0:5151",
+				},
+			},
+		},
+		{
+			"composePlugins",
+			legacyAuthComposePluginsFile,
+			s.overrideFiles,
+			s.dotEnvFiles,
+			[]serviceValidations{
+				{
+					name:             "teams-api",
+					url:              "http://127.0.0.1:8000/health",
+					responsePayload:  `{"status":"available"}`,
+					httpResponseCode: 200,
+					log:              "[INFO] Starting worker",
+				},
+				{
+					name:             "teams-app",
+					url:              "http://127.0.0.1:3000/api/hello",
+					responsePayload:  `{"name":"John Doe"}`,
+					httpResponseCode: 200,
+					log:              "Listening on port 3000",
+				},
+				{
+					name:             "teams-cas",
+					url:              "http://127.0.0.1:3030/cas/api",
+					responsePayload:  `{"status":"available"}`,
+					httpResponseCode: 200,
+					log:              " ✓ Ready in",
+				},
+				// ordering this last to avoid test flakes where testing for log before the container is running
+				{
+					name:             "fiftyone-app",
+					url:              "",
+					responsePayload:  "",
+					httpResponseCode: 200,
+					log:              "[INFO] Running on http://0.0.0.0:5151",
+				},
+			},
+		},
+		{
+			"composeDedicatedPlugins",
+			legacyAuthComposeDedicatedPluginsFile,
+			s.overrideFiles,
+			s.dotEnvFiles,
+			[]serviceValidations{
+				{
+					name:             "teams-api",
+					url:              "http://127.0.0.1:8000/health",
+					responsePayload:  `{"status":"available"}`,
+					httpResponseCode: 200,
+					log:              "[INFO] Starting worker",
+				},
+				{
+					name:             "teams-app",
+					url:              "http://127.0.0.1:3000/api/hello",
+					responsePayload:  `{"name":"John Doe"}`,
+					httpResponseCode: 200,
+					log:              "Listening on port 3000",
+				},
+				{
+					name:             "teams-cas",
+					url:              "http://127.0.0.1:3030/cas/api",
+					responsePayload:  `{"status":"available"}`,
+					httpResponseCode: 200,
+					log:              " ✓ Ready in",
+				},
+				// ordering this last to avoid test flakes where testing for log before the container is running
+				{
+					name:             "fiftyone-app",
+					url:              "",
+					responsePayload:  "",
+					httpResponseCode: 0,
+					log:              "[INFO] Running on http://0.0.0.0:5151",
+				},
+				{
+					name:             "teams-plugins",
+					url:              "",
+					responsePayload:  "",
+					httpResponseCode: 0,
+					log:              "[INFO] Running on http://0.0.0.0:5151", // same as fiftyone-app since plugins uses or is based on the fiftyone-app image
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		s.Run(testCase.name, func() {
+			subT := s.T()
+			// TODO: If we need parallel, dynamically set mongoDB port and configure the env vars with the custom port
+			// For now, we cannot perform concurrent runs because mongodb will error on port already in use
+			// subT.Parallel()
+
+			// TODO: Should we use `--env-file` instead of the library `dotenv.Read`
+			// to more closely align to real world usage?
+			// Something like
+			//
+			// ```shell
+			// docker compose \
+			//   -f tests/fixtures/docker/compose.override.mongodb.yaml \
+			//   --env-file tests/fixtures/docker/integration_legacy_auth.env
+
+			//   up -d
+			// ```
+			//
+			// Use existing function to get map[string]string of environment variables from .env file(s)
+			environmentVariables, err := dotenv.Read(s.dotEnvFiles...)
+			s.NoError(err)
+
+			dockerOptions := &docker.Options{
+				ProjectName: "fiftyone-" + strings.ToLower(random.UniqueId()),
+				WorkingDir:  dockerLegacyAuthDir,
+				EnvVars:     environmentVariables,
+			}
+
+			// In golang, we cannot mix strings with string slice unpacking.
+			// Let's create a slice that will later be unpacked and used as an argument
+			// to the variadic function `docker.RunDockerCompose` parameter `args`.
+			argsUp := []string{}
+			argsDown := []string{}
+			args := []string{"-f", testCase.composeFile}
+
+			for _, overrideFile := range s.overrideFiles {
+				args = append(args, "-f", overrideFile)
+			}
+
+			argsUp = append(args, "up", "--detach")
+			argsDown = append(args, "down", "--remove-orphans", "--timeout", "2")
+
+			// Run containers
+			output := docker.RunDockerCompose(
+				subT,
+				dockerOptions,
+				argsUp...,
+			)
+			// Delete containers after tests complete
+			defer docker.RunDockerCompose(
+				subT,
+				dockerOptions,
+				argsDown...,
+			)
+
+			// Validate system health
+			for _, expected := range testCase.expected {
+				logger.Log(subT, fmt.Sprintf("Validating service %s...", expected.name))
+				s.Contains(output, fmt.Sprintf("Container %s-%s-1  Started", dockerOptions.ProjectName, expected.name), fmt.Sprintf("%s - %s - docker compose output should contain service container started", testCase.name, expected.name))
+				if expected.url != "" {
+					validate_endpoint(subT, expected.url, expected.responsePayload, expected.httpResponseCode)
+				}
+				s.Contains(get_logs(subT, dockerOptions, expected.name), expected.log, fmt.Sprintf("%s - %s - log should contain matching entry", testCase.name, expected.name))
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Rationale

Let's add some integration tests for Docker Compose. (Helm integration tests will come in a future PR).  These check that the containers can run via docker compose in both authentication modes (legacy and internal).

This includes docker compose configurations for runnning a mongodb for the integration tests. For now, keeping at MVP (with iterative improvements), I disabled the parallelization.  In order to support parallel execution of the tests, we would need to add sophistication to the mongodb service to use a parameterized port for mongodb and dynimcally create that for each test and test case run.  In serial, the tests run in ~25 seconds. Let's not pre-maturely optimize.

For the tests, we validate that the service container started.  Then, chech the service container logs for known working output. Then, if the service supports it, run an http check on an endpoint and validate the response.

## Changes

* Add integration tests for docker compose
  * internal auth mode
  * legacy auth mode
* Update Makefile with new targets

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

No! But in the future, we will add Helm integration tests.

## Testing

<details>
<summary>`make test-integration-compose`</summary>

```
[fiftyone-teams-app-deploy]$ make test-integration-compose
mkdir -p /tmp/mongodb
=== RUN   TestDockerComposeUpInternalAuth
=== PAUSE TestDockerComposeUpInternalAuth
=== CONT  TestDockerComposeUpInternalAuth
=== RUN   TestDockerComposeUpInternalAuth/TestDockerComposeUp
=== RUN   TestDockerComposeUpInternalAuth/TestDockerComposeUp/compose
...
--- PASS: TestDockerComposeUpInternalAuth (25.40s)
    --- PASS: TestDockerComposeUpInternalAuth/TestDockerComposeUp (25.40s)
        --- PASS: TestDockerComposeUpInternalAuth/TestDockerComposeUp/compose (8.49s)
        --- PASS: TestDockerComposeUpInternalAuth/TestDockerComposeUp/composePlugins (8.54s)
        --- PASS: TestDockerComposeUpInternalAuth/TestDockerComposeUp/composeDedicatedPlugins (8.37s)
PASS
ok  	github.com/voxel51/fiftyone-teams-app-deploy/integration/compose	25.552s
=== RUN   TestDockerComposeUpLegacyAuth
=== PAUSE TestDockerComposeUpLegacyAuth
=== CONT  TestDockerComposeUpLegacyAuth
=== RUN   TestDockerComposeUpLegacyAuth/TestDockerComposeUp
=== RUN   TestDockerComposeUpLegacyAuth/TestDockerComposeUp/compose
...
--- PASS: TestDockerComposeUpLegacyAuth (25.26s)
    --- PASS: TestDockerComposeUpLegacyAuth/TestDockerComposeUp (25.26s)
        --- PASS: TestDockerComposeUpLegacyAuth/TestDockerComposeUp/compose (8.33s)
        --- PASS: TestDockerComposeUpLegacyAuth/TestDockerComposeUp/composePlugins (8.41s)
        --- PASS: TestDockerComposeUpLegacyAuth/TestDockerComposeUp/composeDedicatedPlugins (8.53s)
PASS
ok  	github.com/voxel51/fiftyone-teams-app-deploy/integration/compose	25.412s
```

</details>

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
