### PR TITLE
chore: forgot to bump v1.5.8 to v1.5.9 for the release.

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -299,7 +299,7 @@ For example, `compose.override.yaml` might look like:
 ```yaml
 services:
   fiftyone-app:
-    image: voxel51/fiftyone-app-torch:v1.5.8
+    image: voxel51/fiftyone-app-torch:v1.5.9
 ```
 
 For more information, see the docs for
@@ -332,7 +332,7 @@ versions prior to FiftyOne Teams version 1.1.0:
    (see
    [env.template](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/docker/env.template#L17)
    for details)
-1. [Upgrade to FiftyOne Teams version 1.5.8](#deploying-fiftyone-teams)
+1. [Upgrade to FiftyOne Teams version 1.5.9](#deploying-fiftyone-teams)
    with `FIFTYONE_DATABASE_ADMIN=true`
    (this is not the default in the `compose.yaml` for this release).
     - **NOTE:** FiftyOne SDK users will lose access to the
@@ -357,7 +357,7 @@ versions prior to FiftyOne Teams version 1.1.0:
 
 The FiftyOne 0.15.9 SDK is backwards-compatible with
 FiftyOne Teams Database Versions 0.19.0 and later.
-You will not be able to connect to a FiftyOne Teams 1.5.8
+You will not be able to connect to a FiftyOne Teams 1.5.9
 database (version 0.23.8) with any FiftyOne SDK before 0.15.9.
 
 Voxel51 always recommends using the latest version of the
@@ -374,7 +374,7 @@ upgrading from FiftyOne Teams version 1.1.0 or later:
     - set `FIFTYONE_DATABASE_ADMIN=false`
     - `unset FIFTYONE_DATABASE_ADMIN`
         - This should generally be your default
-1. [Upgrade to FiftyOne Teams version 1.5.8](#deploying-fiftyone-teams)
+1. [Upgrade to FiftyOne Teams version 1.5.9](#deploying-fiftyone-teams)
 1. Upgrade FiftyOne Teams SDK users to FiftyOne Teams version 0.15.9
     - Login to the FiftyOne Teams UI
     - To obtain the CLI command to install the FiftyOne SDK associated with

--- a/docker/common-services.yaml
+++ b/docker/common-services.yaml
@@ -1,7 +1,7 @@
 ---
 services:
   teams-api-common:
-    image: voxel51/fiftyone-teams-api:v1.5.8
+    image: voxel51/fiftyone-teams-api:v1.5.9
     environment:
       AUTH0_CLIENT_ID: ${AUTH0_CLIENT_ID}
       AUTH0_AUDIENCE: ${AUTH0_AUDIENCE}
@@ -31,7 +31,7 @@ services:
     restart: always
 
   teams-app-common:
-    image: voxel51/fiftyone-teams-app:v1.5.8
+    image: voxel51/fiftyone-teams-app:v1.5.9
     environment:
       API_URL: ${API_URL}
       AUTH0_AUDIENCE: ${AUTH0_AUDIENCE}
@@ -68,7 +68,7 @@ services:
     restart: always
 
   fiftyone-app-common:
-    image: voxel51/fiftyone-app:v1.5.8
+    image: voxel51/fiftyone-app:v1.5.9
     environment:
       API_URL: ${API_URL}
       FIFTYONE_DATABASE_ADMIN: false
@@ -99,7 +99,7 @@ services:
     restart: always
 
   teams-plugins-common:
-    image: voxel51/fiftyone-app:v1.5.8
+    image: voxel51/fiftyone-app:v1.5.9
     environment:
       API_URL: ${API_URL}
       FIFTYONE_DATABASE_ADMIN: false

--- a/helm/fiftyone-teams-app/Chart.yaml
+++ b/helm/fiftyone-teams-app/Chart.yaml
@@ -4,6 +4,6 @@ name: fiftyone-teams-app
 namespace: fiftyone-teams
 description: FiftyOne Teams is the enterprise version of the open source [FiftyOne](https://github.com/voxel51/fiftyone) project.
 type: application
-version: 1.5.8
-appVersion: "v1.5.8"
+version: 1.5.9
+appVersion: "v1.5.9"
 icon: https://voxel51.com/images/logo/voxel51-logo-horz-color-600dpi.png

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -15,7 +15,7 @@
 # fiftyone-teams-app
 
 <!-- markdownlint-disable line-length -->
-![Version: 1.5.8](https://img.shields.io/badge/Version-1.5.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.5.8](https://img.shields.io/badge/AppVersion-v1.5.8-informational?style=flat-square)
+![Version: 1.5.9](https://img.shields.io/badge/Version-1.5.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.5.9](https://img.shields.io/badge/AppVersion-v1.5.9-informational?style=flat-square)
 
 FiftyOne Teams is the enterprise version of the open source [FiftyOne](https://github.com/voxel51/fiftyone) project.
 <!-- markdownlint-enable line-length -->
@@ -443,7 +443,7 @@ versions prior to FiftyOne Teams version 1.1.0:
 1. In your `values.yaml`, set the required
    [FIFTYONE_ENCRYPTION_KEY](#storage-credentials-and-fiftyone_encryption_key)
    environment variable
-1. [Upgrade to FiftyOne Teams version 1.5.8](#launch-fiftyone-teams)
+1. [Upgrade to FiftyOne Teams version 1.5.9](#launch-fiftyone-teams)
    with `appSettings.env.FIFTYONE_DATABASE_ADMIN: true`
    (this is not the default value in `values.yaml` and must be overridden).
     > **NOTE:** At this step, FiftyOne SDK users will lose access to the
@@ -468,7 +468,7 @@ versions prior to FiftyOne Teams version 1.1.0:
 
 The FiftyOne 0.15.9 SDK is backwards-compatible with
 FiftyOne Teams Database Versions 0.19.0 and later.
-You will not be able to connect to a FiftyOne Teams 1.5.8
+You will not be able to connect to a FiftyOne Teams 1.5.9
 database (version 0.23.8) with any FiftyOne SDK before 0.15.9.
 
 We recommend using the latest version of the FiftyOne SDK
@@ -481,7 +481,7 @@ upgrading from FiftyOne Teams version 1.1.0 or later:
     - set `FIFTYONE_DATABASE_ADMIN=false`
     - `unset FIFTYONE_DATABASE_ADMIN`
         - This should generally be your default
-1. [Upgrade to FiftyOne Teams version 1.5.8](#launch-fiftyone-teams)
+1. [Upgrade to FiftyOne Teams version 1.5.9](#launch-fiftyone-teams)
 1. Upgrade FiftyOne Teams SDK users to FiftyOne Teams version 0.15.9
     - Login to the FiftyOne Teams UI
     - To obtain the CLI command to install the FiftyOne SDK associated with

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -300,7 +300,7 @@ versions prior to FiftyOne Teams version 1.1.0:
 1. In your `values.yaml`, set the required
    [FIFTYONE_ENCRYPTION_KEY](#storage-credentials-and-fiftyone_encryption_key)
    environment variable
-1. [Upgrade to FiftyOne Teams version 1.5.8](#launch-fiftyone-teams)
+1. [Upgrade to FiftyOne Teams version 1.5.9](#launch-fiftyone-teams)
    with `appSettings.env.FIFTYONE_DATABASE_ADMIN: true`
    (this is not the default value in `values.yaml` and must be overridden).
     > **NOTE:** At this step, FiftyOne SDK users will lose access to the
@@ -325,7 +325,7 @@ versions prior to FiftyOne Teams version 1.1.0:
 
 The FiftyOne 0.15.9 SDK is backwards-compatible with
 FiftyOne Teams Database Versions 0.19.0 and later.
-You will not be able to connect to a FiftyOne Teams 1.5.8
+You will not be able to connect to a FiftyOne Teams 1.5.9
 database (version 0.23.8) with any FiftyOne SDK before 0.15.9.
 
 We recommend using the latest version of the FiftyOne SDK
@@ -338,7 +338,7 @@ upgrading from FiftyOne Teams version 1.1.0 or later:
     - set `FIFTYONE_DATABASE_ADMIN=false`
     - `unset FIFTYONE_DATABASE_ADMIN`
         - This should generally be your default
-1. [Upgrade to FiftyOne Teams version 1.5.8](#launch-fiftyone-teams)
+1. [Upgrade to FiftyOne Teams version 1.5.9](#launch-fiftyone-teams)
 1. Upgrade FiftyOne Teams SDK users to FiftyOne Teams version 0.15.9
     - Login to the FiftyOne Teams UI
     - To obtain the CLI command to install the FiftyOne SDK associated with

--- a/helm/gke-example/values.yaml
+++ b/helm/gke-example/values.yaml
@@ -33,7 +33,7 @@ secret:
 
 # appSettings:
 #   env:
-#     # FIFTYONE_DATABASE_ADMIN is set to `false` by default for v1.5.8 installs
+#     # FIFTYONE_DATABASE_ADMIN is set to `false` by default for v1.5.9 installs
 #     # If you are performing a new install or an upgrade from v1.0 or earlier
 #     # you may want to set this value to `true`.
 #     # Please see https://helm.fiftyone.ai/#initial-installation-vs-upgrades for details

--- a/tests/unit/compose/docker-compose_test.go
+++ b/tests/unit/compose/docker-compose_test.go
@@ -139,28 +139,28 @@ func (s *commonServicesDockerComposeTest) TestServiceImage() {
 			"teams-api",
 			[]string{composeFile},
 			s.dotEnvFiles,
-			"voxel51/fiftyone-teams-api:v1.5.8",
+			"voxel51/fiftyone-teams-api:v1.5.9",
 		},
 		{
 			"defaultTeamsApp",
 			"teams-app",
 			[]string{composeFile},
 			s.dotEnvFiles,
-			"voxel51/fiftyone-teams-app:v1.5.8",
+			"voxel51/fiftyone-teams-app:v1.5.9",
 		},
 		{
 			"defaultFiftyoneApp",
 			"fiftyone-app",
 			[]string{composeFile},
 			s.dotEnvFiles,
-			"voxel51/fiftyone-app:v1.5.8",
+			"voxel51/fiftyone-app:v1.5.9",
 		},
 		{
 			"dedicatedPluginsTeamsPlugins",
 			"teams-plugins",
 			[]string{composeDedicatedPluginsFile},
 			s.dotEnvFiles,
-			"voxel51/fiftyone-app:v1.5.8",
+			"voxel51/fiftyone-app:v1.5.9",
 		},
 	}
 


### PR DESCRIPTION
# Rationale

In #115, I accidentally forgot replace the version strings `v1.5.8` with `v1.5.9`.

## Changes

Replace `v1.5.8` with `v1.5.9`.

Checklist

