### PR TITLE
Clarify Docker CAS changes

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -142,6 +142,7 @@ To upgrade from versions prior to FiftyOne Teams v1.6
 - Update your `.env` file, adding the variables listed above
 - Update your `compose.override.yaml` with `teams-cas` changes (if necessary)
 - Run `docker compose` commands from the `legacy-auth` directory
+- (If using path-based routing) Configure the path-based route `/cas` to port 3030
 
 ### Snapshot Archival
 
@@ -453,6 +454,7 @@ create a new IdP or modify your existing configuration.
 1. In the `.env` file, set the required environment variables
     - `FIFTYONE_API_URI`
     - `FIFTYONE_AUTH_SECRET`
+    - The `CAS_*` variables referenced [here](#central-authentication-service) in case they were overwritten when copying your `.env` file
 1. Ensure all FiftyOne SDK users either
     - set `FIFTYONE_DATABASE_ADMIN=false`
     - `unset FIFTYONE_DATABASE_ADMIN`

--- a/docker/README.md
+++ b/docker/README.md
@@ -142,7 +142,7 @@ To upgrade from versions prior to FiftyOne Teams v1.6
 - Update your `.env` file, adding the variables listed above
 - Update your `compose.override.yaml` with `teams-cas` changes (if necessary)
 - Run `docker compose` commands from the `legacy-auth` directory
-- (If using path-based routing) Configure the path-based route `/cas` to port 3030
+- When using path-based routing, configure a `/cas` route to value of the `CAS_BIND_PORT`
 
 ### Snapshot Archival
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -454,7 +454,16 @@ create a new IdP or modify your existing configuration.
 1. In the `.env` file, set the required environment variables
     - `FIFTYONE_API_URI`
     - `FIFTYONE_AUTH_SECRET`
-    - The `CAS_*` variables referenced [here](#central-authentication-service) in case they were overwritten when copying your `.env` file
+    - `CAS_BASE_URL`
+    - `CAS_BIND_ADDRESS`
+    - `CAS_BIND_PORT`
+    - `CAS_DATABASE_NAME`
+    - `CAS_DEBUG`
+    - `CAS_DEFAULT_USER_ROLE`
+
+    > **Note**: For the `CAS_*` variables, consider using
+    > the seed values from the `.env.template` file
+
 1. Ensure all FiftyOne SDK users either
     - set `FIFTYONE_DATABASE_ADMIN=false`
     - `unset FIFTYONE_DATABASE_ADMIN`


### PR DESCRIPTION
# Rationale

Ran into two things that weren't completely clear when attempting to upgrade.

## Changes

Adds:
* A note in the v1.1.0 -> v1.6.0 upgrade section about the additional `.env` variables that may have been overwritten if just copying the `.env` file to the `legacy-auth` directory.
* A note in the CAS section about needing to configure path based routing if applicable

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm (not relevant ?)


<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
