### PR TITLE
Remove broken link to internal mode migration

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -113,10 +113,12 @@ documentation before completing your upgrade.
 Voxel51 recommends upgrading your deployment using
 [`legacy` authentication mode](https://docs.voxel51.com/teams/pluggable_auth.html#legacy-mode)
 and
-[migrating](https://docs.voxel51.com/teams/pluggable_auth.html#migrating-from-legacy-to-internal-mode)
+migrating
 to
 [`internal` authentication mode](https://docs.voxel51.com/teams/pluggable_auth.html#internal-mode)
 after confirming your initial upgrade was successful.
+
+Please reach out to your Voxel51 customer success representative for assistance in migrating to internal mode.
 
 The CAS service requires changes to your `.env` files.
 A brief summary of those changes include


### PR DESCRIPTION
# Rationale

Migration from legacy to internal mode may not be in the official documentation with v1.6.0. In that case, we should remove the broken link and add a note to reach out to your CS rep for help.

## Changes

^ That

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

