### PR TITLE
let`s try some cas defaults for docker

### DIFF
--- a/docker/common-services.yaml
+++ b/docker/common-services.yaml
@@ -91,7 +91,7 @@ services:
   teams-cas-common:
     image: voxel51/fiftyone-teams-cas:v1.6.0
     environment:
-      CAS_DATABASE_NAME: ${CAS_DATABASE_NAME:-fiftyone-teams}
+      CAS_DATABASE_NAME: ${CAS_DATABASE_NAME:-cas}
       CAS_DEFAULT_USER_ROLE: ${CAS_DEFAULT_USER_ROLE:-GUEST}
       CAS_MONGODB_URI: ${CAS_MONGO_DB_URI:-$FIFTYONE_DATABASE_URI}
       DEBUG: ${CAS_DEBUG:-cas:*,-cas:*:debug}

--- a/docker/common-services.yaml
+++ b/docker/common-services.yaml
@@ -31,7 +31,7 @@ services:
   teams-api-common:
     image: voxel51/fiftyone-teams-api:v1.6.0
     environment:
-      CAS_BASE_URL: ${CAS_BASE_URL}
+      CAS_BASE_URL: ${CAS_BASE_URL:-'http://teams-cas:3000/cas/api'}
       FIFTYONE_AUTH_SECRET: ${FIFTYONE_AUTH_SECRET}
       FIFTYONE_DATABASE_NAME: ${FIFTYONE_DATABASE_NAME}
       FIFTYONE_DATABASE_URI: ${FIFTYONE_DATABASE_URI}
@@ -91,10 +91,10 @@ services:
   teams-cas-common:
     image: voxel51/fiftyone-teams-cas:v1.6.0
     environment:
-      CAS_DATABASE_NAME: ${CAS_DATABASE_NAME}
-      CAS_DEFAULT_USER_ROLE: ${CAS_DEFAULT_USER_ROLE}
+      CAS_DATABASE_NAME: ${CAS_DATABASE_NAME:-'fiftyone-teams'}
+      CAS_DEFAULT_USER_ROLE: ${CAS_DEFAULT_USER_ROLE:-'GUEST'}
       CAS_MONGODB_URI: ${CAS_MONGO_DB_URI:-$FIFTYONE_DATABASE_URI}
-      DEBUG: ${CAS_DEBUG}
+      DEBUG: ${CAS_DEBUG:-'cas:*,-cas:*:debug'}
       FIFTYONE_AUTH_SECRET: ${FIFTYONE_AUTH_SECRET}
       # If you are routing through a proxy server you will want to set
       #  HTTP_PROXY_URL, HTTPS_PROXY_URL, and NO_PROXY_LIST in your .env

--- a/docker/common-services.yaml
+++ b/docker/common-services.yaml
@@ -31,7 +31,7 @@ services:
   teams-api-common:
     image: voxel51/fiftyone-teams-api:v1.6.0
     environment:
-      CAS_BASE_URL: ${CAS_BASE_URL:-'http://teams-cas:3000/cas/api'}
+      CAS_BASE_URL: ${CAS_BASE_URL:-http://teams-cas:3000/cas/api}
       FIFTYONE_AUTH_SECRET: ${FIFTYONE_AUTH_SECRET}
       FIFTYONE_DATABASE_NAME: ${FIFTYONE_DATABASE_NAME}
       FIFTYONE_DATABASE_URI: ${FIFTYONE_DATABASE_URI}
@@ -91,10 +91,10 @@ services:
   teams-cas-common:
     image: voxel51/fiftyone-teams-cas:v1.6.0
     environment:
-      CAS_DATABASE_NAME: ${CAS_DATABASE_NAME:-'fiftyone-teams'}
-      CAS_DEFAULT_USER_ROLE: ${CAS_DEFAULT_USER_ROLE:-'GUEST'}
+      CAS_DATABASE_NAME: ${CAS_DATABASE_NAME:-fiftyone-teams}
+      CAS_DEFAULT_USER_ROLE: ${CAS_DEFAULT_USER_ROLE:-GUEST}
       CAS_MONGODB_URI: ${CAS_MONGO_DB_URI:-$FIFTYONE_DATABASE_URI}
-      DEBUG: ${CAS_DEBUG:-'cas:*,-cas:*:debug'}
+      DEBUG: ${CAS_DEBUG:-cas:*,-cas:*:debug}
       FIFTYONE_AUTH_SECRET: ${FIFTYONE_AUTH_SECRET}
       # If you are routing through a proxy server you will want to set
       #  HTTP_PROXY_URL, HTTPS_PROXY_URL, and NO_PROXY_LIST in your .env
@@ -111,7 +111,7 @@ services:
       # https_proxy: ${HTTPS_PROXY_URL}
       # no_proxy: ${NO_PROXY_LIST}
     ports:
-      - ${CAS_BIND_ADDRESS}:${CAS_BIND_PORT}:3000
+      - ${CAS_BIND_ADDRESS:-127.0.0.1}:${CAS_BIND_PORT:-3030}:3000
     restart: always
 
   teams-plugins-common:


### PR DESCRIPTION
# Rationale


[This Slack thread](https://voxel51.slack.com/archives/C03Q2JMQNGK/p1714402912327019?thread_ts=1713896144.558929&cid=C03Q2JMQNGK) suggests that we should set CAS defaults so customers don't have to keep up to date with current environment variables in docker-compose.

Seems fine to me.

## Changes

Sets some defaults for CAS environment variables in docker-compose common services

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

No, but Helm already had those settings

## Testing

Remove the CAS configs you don't need:
```
$ diff -uw .env cas.env
--- .env        2024-04-30 11:37:23.293987356 +0000
+++ cas.env     2024-04-30 11:30:12.402909497 +0000
@@ -60,16 +60,16 @@
 APP_BIND_PORT=3500

 # FiftyOne Teams CAS Configuration
-# CAS_BASE_URL=http://teams-cas:3000/cas/api
-# CAS_BIND_ADDRESS=127.0.0.1
+CAS_BASE_URL=http://teams-cas:3000/cas/api
+CAS_BIND_ADDRESS=127.0.0.1
 CAS_BIND_PORT=3530
 CAS_DATABASE_NAME=docker-compose-cas
 # CAS_DEBUG defines what CAS logs to display
 # e.g. `cas:*` - shows all cas logs
 #      `cas:*:info` - shows only CAS INFO logs
 #      `cas:*,-cas:*:debug` - shows all cas logs except DEBUG logs
-# CAS_DEBUG="cas:*,-cas:*:debug"
-# CAS_DEFAULT_USER_ROLE=GUEST
+CAS_DEBUG="cas:*,-cas:*:debug"
+CAS_DEFAULT_USER_ROLE=GUEST

 # The following are docker-compose links and will work in most situations
 FIFTYONE_TEAMS_PROXY_URL=http://fiftyone-app:5151
 ```
 
 (CAS_BIND_PORT and CAS_DATABASE_NAME need to stay unique)

```docker compose -f compose.dedicated-plugins.yaml -f compose.override.yaml -f compose.override.setversion.yaml config > ~/oldconfig
git checkout topher/some-cas-defaults
docker compose -f compose.dedicated-plugins.yaml -f compose.override.yaml -f compose.override.setversion.yaml up -d
docker compose -f compose.dedicated-plugins.yaml -f compose.override.yaml -f compose.override.setversion.yaml config > ~/newconfig
diff -uw ~/newconfig ~/oldconfig
```

Results in no changes

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
