### PR TITLE
WIP: [AS-143] skaffold v1.6.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,7 +76,7 @@ repos:
       - id: detect-secrets
         args:
           - --exclude-secrets
-          - '(password|REPLACEME|fiftyone-teams-tls-secret|3-9XjJ-gUV?vp\^e\(WUk>LD&lAjh7yEji|btv8BiFCaPIayWU3IU3a_Lm_EMIIk-t6H_yN1ORV45o=|5b32118032bfd50b64b3cc7c0e0821f4e84f63ad517a9687ac2b6ce6ab261976|test-*|/api/proxy/fiftyone-teams|/opt/plugins)'
+          - '(password|REPLACEME|fiftyone-teams-tls-secret|3-9XjJ-gUV?vp\^e\(WUk>LD&lAjh7yEji|btv8BiFCaPIayWU3IU3a_Lm_EMIIk-t6H_yN1ORV45o=|5b32118032bfd50b64b3cc7c0e0821f4e84f63ad517a9687ac2b6ce6ab261976|aGM4\?s&t-n;\!\*U96oA#bdo,\+JU\)ac1T7|test-*|/api/proxy/fiftyone-teams|/opt/plugins)'
   - repo: https://github.com/dnephin/pre-commit-golang
     rev: v0.5.1
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,12 @@ port-forward-api:  ## port forward to service `teams-api` on the host port 8000
 port-forward-mongo:  ## port forward to service `mongodb` on the host port 27017
 	kubectl port-forward --namespace fiftyone-teams svc/mongodb 27017:27017 --context minikube
 
+run: helm-repos  ## run skaffold run
+	skaffold run
+
+run-profile-only-fiftyone: helm-repos  ## run skaffold run -p only-fiftyone
+	skaffold run -p only-fiftyone
+
 tunnel:  ## run minikube tunnel to access the k8s ingress via localhost ()
 	minikube tunnel
 

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -36,7 +36,7 @@ deploy:
     releases:
       - name: fiftyone-teams
         chartPath: helm/fiftyone-teams-app
-        version: 1.5.10
+        version: 1.6.0
         createNamespace: true
         namespace: fiftyone-teams
         overrides:
@@ -48,6 +48,7 @@ deploy:
               # See https://console.cloud.google.com/artifacts/docker/computer-vision-team/us-central1/dev-docker?project=computer-vision-team
               repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-teams-api
               pullPolicy: IfNotPresent
+              tag: v1.6.0rc15
           appSettings:
             env:
               # Only set to true during the initial installation or during a database upgrade
@@ -62,6 +63,7 @@ deploy:
               # See https://console.cloud.google.com/artifacts/docker/computer-vision-team/us-central1/dev-docker?project=computer-vision-team
               repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-app
               pullPolicy: IfNotPresent
+              tag: v1.6.0rc18
           # TODO: Test `minikube addons configure registry-creds` or
           # When using minikube's addon registry-creds, we may also need to create the k8s secret `regcred`
           # See https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -95,6 +97,10 @@ deploy:
                 pathType: Prefix
                 serviceName: teams-api
                 servicePort: 80
+              - path: /cas
+                pathType: Prefix
+                serviceName: teams-cas
+                servicePort: 80
               - path: /
                 pathType: Prefix
                 serviceName: teams-app
@@ -107,7 +113,7 @@ deploy:
               # configured for running the app locally with https
               auth0Domain: "dev-fiftyone.us.auth0.com"
 
-              # # Set values for the `fiftyone-dev-api (Test Application)` application
+              # Set values for the `fiftyone-dev-api (Test Application)` application
               apiClientId: ""
               apiClientSecret: ""
 
@@ -120,16 +126,22 @@ deploy:
 
               fiftyoneDatabaseName: fiftyone-internal
               # This password is randomly generated and is only used to initialize a local (ephemeral) MongoDB in `./skaffold-mongodb.yaml`
-              mongodbConnectionString: mongodb://root:3-9XjJ-gUV?vp^e(WUk>LD&lAjh7yEji@mongodb.fiftyone-teams.svc.cluster.local/?authSource=admin
+              # URL encoded to overcome errors with unencoded characters
+              mongodbConnectionString: mongodb://root:3-9XjJ-gUV%3Fvp%5Ee%28WUk%3ELD%26lAjh7yEji@mongodb.fiftyone-teams.svc.cluster.local/?authSource=admin  # pragma: allowlist secret
 
               # randomly generated value
               cookieSecret: 5b32118032bfd50b64b3cc7c0e0821f4e84f63ad517a9687ac2b6ce6ab261976
               # randomly generated value
               encryptionKey: btv8BiFCaPIayWU3IU3a_Lm_EMIIk-t6H_yN1ORV45o=
+
+              # randomly generated value
+              fiftyoneAuthSecret: "aGM4?s&t-n;!*U96oA#bdo,+JU)ac1T7"
           pluginsSettings:
             image:
               # See https://console.cloud.google.com/artifacts/docker/computer-vision-team/us-central1/dev-docker?project=computer-vision-team
               repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-app
+              pullPolicy: IfNotPresent
+              tag: v1.6.0rc18
           teamsAppSettings:
             dnsName: local.fiftyone.ai
             # env:
@@ -146,4 +158,13 @@ deploy:
               # The others are `vW.X.Y.devZ` (note `.devZ` vs `-dev.Z`).
               # This is a byproduct of `npm` versioning versus Python PEP 440.
               pullPolicy: IfNotPresent
+              tag: v1.6.0-rc.13
+          casSettings:
+            env:
+              DEBUG: cas:*
+            image:
+              # See https://console.cloud.google.com/artifacts/docker/computer-vision-team/us-central1/dev-docker?project=computer-vision-team
+              repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-teams-cas
+              pullPolicy: IfNotPresent
+              tag: v1.6.0-rc.13
   kubeContext: minikube

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -48,7 +48,7 @@ deploy:
               # See https://console.cloud.google.com/artifacts/docker/computer-vision-team/us-central1/dev-docker?project=computer-vision-team
               repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-teams-api
               pullPolicy: IfNotPresent
-              tag: v1.6.0rc15
+              tag: v1.6.1rc2
           appSettings:
             env:
               # Only set to true during the initial installation or during a database upgrade
@@ -63,7 +63,7 @@ deploy:
               # See https://console.cloud.google.com/artifacts/docker/computer-vision-team/us-central1/dev-docker?project=computer-vision-team
               repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-app
               pullPolicy: IfNotPresent
-              tag: v1.6.0rc18
+              tag: v1.6.1rc2
           # TODO: Test `minikube addons configure registry-creds` or
           # When using minikube's addon registry-creds, we may also need to create the k8s secret `regcred`
           # See https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -141,7 +141,7 @@ deploy:
               # See https://console.cloud.google.com/artifacts/docker/computer-vision-team/us-central1/dev-docker?project=computer-vision-team
               repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-app
               pullPolicy: IfNotPresent
-              tag: v1.6.0rc18
+              tag: v1.6.1rc2
           teamsAppSettings:
             dnsName: local.fiftyone.ai
             # env:
@@ -158,7 +158,7 @@ deploy:
               # The others are `vW.X.Y.devZ` (note `.devZ` vs `-dev.Z`).
               # This is a byproduct of `npm` versioning versus Python PEP 440.
               pullPolicy: IfNotPresent
-              tag: v1.6.0-rc.13
+              tag: v1.6.1-rc.1
           casSettings:
             env:
               DEBUG: cas:*
@@ -166,5 +166,5 @@ deploy:
               # See https://console.cloud.google.com/artifacts/docker/computer-vision-team/us-central1/dev-docker?project=computer-vision-team
               repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-teams-cas
               pullPolicy: IfNotPresent
-              tag: v1.6.0-rc.13
+              tag: v1.6.1-rc.1
   kubeContext: minikube


### PR DESCRIPTION
# Rationale

For v1.6.1, we need to update skaffold configs. What could go wrong?  Well.... it turns out, that v1.6.1 CAS breaks our ability to the app in the containers locally via skaffold. The containers start, but the app doesn't function.

But at least we learned that we need to instruct path based routing customers to update their ingress paths?

## Changes

* skaffold
  * Update chart version for 1.6.1
  * Change image versions for 1.6.1 to rc builds (that actually exist because what's currently in release/v1.6.1 don't)
    * The v1.6.0 containers won't run on macOS arm64 systems, but the rc images will?
  * Add ingress path for CAS
  * Add the new and required auth secret

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

In a v1.5.0 configuration, I can login to the UI.  
In a v1.6.0/1 configuration, I cannot.

<details>
<summary>cas containers emits errors:</summary>
</details>

```txt
2024-04-24T16:05:13.226Z cas:parseFn:debug Parsing JS string...
2024-04-24T16:05:13.226Z cas:parseFn:debug Successfully parsed JS string
2024-04-24T16:05:13.226Z cas:executeJSHook:debug Checking if JavaScript hook exists...
2024-04-24T16:05:13.226Z cas:executeJSHook:debug JavaScript hook is not configured
2024-04-24T16:05:13.227Z cas:MongoDBRepository<authentication_config>:debug Using database "cas"
2024-04-24T16:05:13.228Z cas:MongoDBRepository<sessions>:debug Using database "cas"
2024-04-24T16:05:13.228Z cas:MongoDBRepository<tokens>:debug Using database "cas"
2024-04-24T16:05:13.228Z cas:MongoDBRepository<accounts>:debug Using database "cas"
2024-04-24T16:05:13.228Z cas:MongoDBRepository<api_keys>:debug Using database "cas"
2024-04-24T16:05:13.230Z cas:executeJSHook:debug Checking if JavaScript hook exists...
2024-04-24T16:05:13.230Z cas:executeJSHook:debug JavaScript hook is not configured
Failed to fetch data: FetchError: request to https://local.fiftyone.ai/cas/api/auth/csrf failed, reason: connect ECONNREFUSED 127.0.0.1:443
    at ClientRequest.<anonymous> (file:///cas/node_modules/node-fetch/src/index.js:108:11)
    at ClientRequest.emit (node:events:517:28)
    at ClientRequest.emit (node:domain:489:12)
    at TLSSocket.socketErrorListener (node:_http_client:501:9)
    at TLSSocket.emit (node:events:517:28)
    at TLSSocket.emit (node:domain:489:12)
    at emitErrorNT (node:internal/streams/destroy:151:8)
    at emitErrorCloseNT (node:internal/streams/destroy:116:3)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  type: 'system',
  errno: 'ECONNREFUSED',
  code: 'ECONNREFUSED',
  erroredSysCall: 'connect'
}
```

</details>


It's strange that an internal service would be trying to reach itself via the public endpoint.  This would cause the container to egress to the endpoint.  topher suggested that this may be a security concern? And that it may also be a requirement to the fun that is JWTs.


topher and I tried setting, either or both


```yaml
          casSettings:
            env:
              CAS_URL: http://teams-cas.svc.cluster.local
              NEXTAUTH_URL: http://teams-cas.svc.cluster.local/cas/api/auth
```

but it still fails. We get a near infinite rediect loop in https://local.fiftyone.ai/cas/auth/signin?callbackUrl=%2Fdatasets

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

## Related

* https://github.com/voxel51/voxel-hub/pull/1218

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
