### PR TITLE
Add Integration Tests for Helm [AS-105]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,7 +76,7 @@ repos:
       - id: detect-secrets
         args:
           - --exclude-secrets
-          - '(password|REPLACEME|fiftyone-teams-tls-secret|3-9XjJ-gUV?vp\^e\(WUk>LD&lAjh7yEji|btv8BiFCaPIayWU3IU3a_Lm_EMIIk-t6H_yN1ORV45o=|5b32118032bfd50b64b3cc7c0e0821f4e84f63ad517a9687ac2b6ce6ab261976|test-*|/api/proxy/fiftyone-teams|/opt/plugins)'
+          - '(password|REPLACEME|fiftyone-teams-tls-secret|3-9XjJ-gUV?vp\^e\(WUk>LD&lAjh7yEji|btv8BiFCaPIayWU3IU3a_Lm_EMIIk-t6H_yN1ORV45o=|5b32118032bfd50b64b3cc7c0e0821f4e84f63ad517a9687ac2b6ce6ab261976|aGM4\?s&t-n;\!\*U96oA#bdo,\+JU\)ac1T7|test-*|/api/proxy/fiftyone-teams|/opt/plugins)'
   - repo: https://github.com/dnephin/pre-commit-golang
     rev: v0.5.1
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,14 @@ port-forward-mongo:  ## port forward to service `mongodb` on the host port 27017
 run: helm-repos  ## run skaffold run
 	skaffold run
 
+run-cert-manager: helm-repos  ## run skaffold run
+	skaffold run \
+	  --filename skaffold-cert-manager.yaml
+
+run-mongodb: helm-repos  ## run skaffold run
+	skaffold run \
+	  --filename skaffold-mongodb.yaml
+
 run-profile-only-fiftyone: helm-repos  ## run skaffold run -p only-fiftyone
 	skaffold run -p only-fiftyone
 
@@ -175,6 +183,28 @@ test-integration-compose-interleaved-legacy: install-terratest-log-parser depend
 	@cd tests/integration/compose; \
 	rm -rf test_output_legacy/*; \
 	go test -count=1 -timeout=10m -v -tags integrationComposeLegacyAuth | tee test_output_legacy.log; \
+	${ASDF}/packages/bin/terratest_log_parser -testlog test_output_legacy.log -outputdir test_output_legacy
+
+test-integration-helm: test-integration-helm-internal test-integration-helm-legacy ## run go test on the tests/integration/helm directory for both internal and legacy auth modes
+
+test-integration-helm-internal:  ## run go test on the tests/integration/helm directory for internal auth mode
+	@cd tests/integration/helm; \
+	go test -count=1 -timeout=10m -v -tags integrationHelmInternalAuth
+
+test-integration-helm-legacy:  ## run go test on the tests/integration/helm directory for legacy auth mode
+	@cd tests/integration/helm; \
+	go test -count=1 -timeout=10m -v -tags integrationHelmLegacyAuth
+
+test-integration-helm-interleaved-internal:  ## run go test on the tests/integration/helm directory for internal auth mode
+	@cd tests/integration/helm; \
+	rm -rf test_output_internal/*; \
+	go test -count=1 -timeout=10m -v -tags integrationHelmInternalAuth | tee test_output_internal.log; \
+	${ASDF}/packages/bin/terratest_log_parser -testlog test_output_internal.log -outputdir test_output_internal
+
+test-integration-helm-interleaved-legacy:  ## run go test on the tests/integration/helm directory for legacy auth mode
+	@cd tests/integration/helm; \
+	rm -rf test_output_legacy/*; \
+	go test -count=1 -timeout=10m -v -tags integrationHelmLegacyAuth | tee test_output_legacy.log; \
 	${ASDF}/packages/bin/terratest_log_parser -testlog test_output_legacy.log -outputdir test_output_legacy
 
 install-terratest-log-parser:  ## install terratest_log_parser

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,12 @@ port-forward-api:  ## port forward to service `teams-api` on the host port 8000
 port-forward-mongo:  ## port forward to service `mongodb` on the host port 27017
 	kubectl port-forward --namespace fiftyone-teams svc/mongodb 27017:27017 --context minikube
 
+run: helm-repos  ## run skaffold run
+	skaffold run
+
+run-profile-only-fiftyone: helm-repos  ## run skaffold run -p only-fiftyone
+	skaffold run -p only-fiftyone
+
 tunnel:  ## run minikube tunnel to access the k8s ingress via localhost ()
 	minikube tunnel
 

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -95,11 +95,12 @@ documentation before completing your upgrade.
 
 Voxel51 recommends upgrading your deployment using
 [`legacy` authentication mode](https://docs.voxel51.com/teams/pluggable_auth.html#legacy-mode)
-and
-[migrating](https://docs.voxel51.com/teams/pluggable_auth.html#migrating-from-legacy-to-internal-mode)
-to
+and migrating to
 [`internal` authentication mode](https://docs.voxel51.com/teams/pluggable_auth.html#internal-mode)
 after confirming your initial upgrade was successful.
+
+Please contact your Voxel51 customer success
+representative for assistance in migrating to internal mode.
 
 The CAS service requires changes to your `values.yaml` files.
 A brief summary of those changes include

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -36,7 +36,7 @@ deploy:
     releases:
       - name: fiftyone-teams
         chartPath: helm/fiftyone-teams-app
-        version: 1.5.10
+        version: 1.6.0
         createNamespace: true
         namespace: fiftyone-teams
         overrides:
@@ -48,6 +48,7 @@ deploy:
               # See https://console.cloud.google.com/artifacts/docker/computer-vision-team/us-central1/dev-docker?project=computer-vision-team
               repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-teams-api
               pullPolicy: IfNotPresent
+              tag: v1.6.0rc15
           appSettings:
             env:
               # Only set to true during the initial installation or during a database upgrade
@@ -62,6 +63,7 @@ deploy:
               # See https://console.cloud.google.com/artifacts/docker/computer-vision-team/us-central1/dev-docker?project=computer-vision-team
               repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-app
               pullPolicy: IfNotPresent
+              tag: v1.6.0rc18
           # TODO: Test `minikube addons configure registry-creds` or
           # When using minikube's addon registry-creds, we may also need to create the k8s secret `regcred`
           # See https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -95,6 +97,10 @@ deploy:
                 pathType: Prefix
                 serviceName: teams-api
                 servicePort: 80
+              - path: /cas
+                pathType: Prefix
+                serviceName: teams-cas
+                servicePort: 80
               - path: /
                 pathType: Prefix
                 serviceName: teams-app
@@ -107,7 +113,7 @@ deploy:
               # configured for running the app locally with https
               auth0Domain: "dev-fiftyone.us.auth0.com"
 
-              # # Set values for the `fiftyone-dev-api (Test Application)` application
+              # Set values for the `fiftyone-dev-api (Test Application)` application
               apiClientId: ""
               apiClientSecret: ""
 
@@ -120,16 +126,22 @@ deploy:
 
               fiftyoneDatabaseName: fiftyone-internal
               # This password is randomly generated and is only used to initialize a local (ephemeral) MongoDB in `./skaffold-mongodb.yaml`
-              mongodbConnectionString: mongodb://root:3-9XjJ-gUV?vp^e(WUk>LD&lAjh7yEji@mongodb.fiftyone-teams.svc.cluster.local/?authSource=admin
+              # URL encoded to overcome errors with unencoded characters
+              mongodbConnectionString: mongodb://root:3-9XjJ-gUV%3Fvp%5Ee%28WUk%3ELD%26lAjh7yEji@mongodb.fiftyone-teams.svc.cluster.local/?authSource=admin  # pragma: allowlist secret
 
               # randomly generated value
               cookieSecret: 5b32118032bfd50b64b3cc7c0e0821f4e84f63ad517a9687ac2b6ce6ab261976
               # randomly generated value
               encryptionKey: btv8BiFCaPIayWU3IU3a_Lm_EMIIk-t6H_yN1ORV45o=
+
+              # randomly generated value
+              fiftyoneAuthSecret: "aGM4?s&t-n;!*U96oA#bdo,+JU)ac1T7"
           pluginsSettings:
             image:
               # See https://console.cloud.google.com/artifacts/docker/computer-vision-team/us-central1/dev-docker?project=computer-vision-team
               repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-app
+              pullPolicy: IfNotPresent
+              tag: v1.6.0rc18
           teamsAppSettings:
             dnsName: local.fiftyone.ai
             # env:
@@ -146,4 +158,13 @@ deploy:
               # The others are `vW.X.Y.devZ` (note `.devZ` vs `-dev.Z`).
               # This is a byproduct of `npm` versioning versus Python PEP 440.
               pullPolicy: IfNotPresent
+              tag: v1.6.0-rc.13
+          casSettings:
+            env:
+              DEBUG: cas:*
+            image:
+              # See https://console.cloud.google.com/artifacts/docker/computer-vision-team/us-central1/dev-docker?project=computer-vision-team
+              repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-teams-cas
+              pullPolicy: IfNotPresent
+              tag: v1.6.0-rc.13
   kubeContext: minikube

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -48,7 +48,7 @@ deploy:
               # See https://console.cloud.google.com/artifacts/docker/computer-vision-team/us-central1/dev-docker?project=computer-vision-team
               repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-teams-api
               pullPolicy: IfNotPresent
-              tag: v1.6.0rc15
+              tag: v1.6.1rc2
           appSettings:
             env:
               # Only set to true during the initial installation or during a database upgrade
@@ -63,7 +63,7 @@ deploy:
               # See https://console.cloud.google.com/artifacts/docker/computer-vision-team/us-central1/dev-docker?project=computer-vision-team
               repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-app
               pullPolicy: IfNotPresent
-              tag: v1.6.0rc18
+              tag: v1.6.1rc2
           # TODO: Test `minikube addons configure registry-creds` or
           # When using minikube's addon registry-creds, we may also need to create the k8s secret `regcred`
           # See https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -141,7 +141,7 @@ deploy:
               # See https://console.cloud.google.com/artifacts/docker/computer-vision-team/us-central1/dev-docker?project=computer-vision-team
               repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-app
               pullPolicy: IfNotPresent
-              tag: v1.6.0rc18
+              tag: v1.6.1rc2
           teamsAppSettings:
             dnsName: local.fiftyone.ai
             # env:
@@ -158,7 +158,7 @@ deploy:
               # The others are `vW.X.Y.devZ` (note `.devZ` vs `-dev.Z`).
               # This is a byproduct of `npm` versioning versus Python PEP 440.
               pullPolicy: IfNotPresent
-              tag: v1.6.0-rc.13
+              tag: v1.6.1-rc.1
           casSettings:
             env:
               DEBUG: cas:*
@@ -166,5 +166,5 @@ deploy:
               # See https://console.cloud.google.com/artifacts/docker/computer-vision-team/us-central1/dev-docker?project=computer-vision-team
               repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-teams-cas
               pullPolicy: IfNotPresent
-              tag: v1.6.0-rc.13
+              tag: v1.6.1-rc.1
   kubeContext: minikube

--- a/tests/fixtures/helm/integration_values.yaml
+++ b/tests/fixtures/helm/integration_values.yaml
@@ -1,0 +1,130 @@
+# Copy of values from `../../../skaffold.yaml`'s `helm.releases[0].overrides`
+# used for integration tests
+apiSettings:
+  env:
+    LOGGING_LEVEL: DEBUG
+    FIFTYONE_ENV: development
+  image:
+    # See https://console.cloud.google.com/artifacts/docker/computer-vision-team/us-central1/dev-docker?project=computer-vision-team
+    repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-teams-api
+    pullPolicy: IfNotPresent
+    tag: v1.6.1rc2
+appSettings:
+  env:
+    # Only set to true during the initial installation or during a database upgrade
+    # FIFTYONE_DATABASE_ADMIN: false
+    FIFTYONE_DATABASE_ADMIN: true
+    # For local development without TLS certs, set `APP_USE_HTTPS=false` to
+    # prohibit the app from setting Redirect URL protocol to `https`.
+    # Must be set in both `appSettings.env` and `teamsAppSettings.env`.
+    # Can be true, when using cert-manager with self-signed certificates
+    # APP_USE_HTTPS: false
+  image:
+    # See https://console.cloud.google.com/artifacts/docker/computer-vision-team/us-central1/dev-docker?project=computer-vision-team
+    repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-app
+    pullPolicy: IfNotPresent
+    tag: v1.6.1rc2
+# TODO: Test `minikube addons configure registry-creds` or
+# When using minikube's addon registry-creds, we may also need to create the k8s secret `regcred`
+# See https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+# imagePullSecrets:
+#   - name: regcred
+
+ingress:
+  annotations:
+    # For using the nginx-ingress controller with cert-manager self signed certificates
+    cert-manager.io/cluster-issuer: selfsigned-issuer
+    # Configure nginx-ingress controller proxy buffers for the app
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 256k
+    # Configure nginx-ingress controller proxy buffers for the app
+    nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
+  # For using the nginx-ingress controller
+  className: nginx
+  paths:
+    - path: /_pymongo
+      pathType: Prefix
+      serviceName: teams-api
+      servicePort: 80
+    - path: /health
+      pathType: Prefix
+      serviceName: teams-api
+      servicePort: 80
+    - path: /graphql/v1
+      pathType: Prefix
+      serviceName: teams-api
+      servicePort: 80
+    - path: /file
+      pathType: Prefix
+      serviceName: teams-api
+      servicePort: 80
+    - path: /cas
+      pathType: Prefix
+      serviceName: teams-cas
+      servicePort: 80
+    - path: /
+      pathType: Prefix
+      serviceName: teams-app
+      servicePort: 80
+  tlsEnabled: true
+secret:
+  fiftyone:
+    # In the `dev-fiftyone` Auth0 Tenant, the `local-dev` and
+    # `fiftyone-dev-api (Test Application)` applications are
+    # configured for running the app locally with https
+    auth0Domain: dev-fiftyone.us.auth0.com
+
+    # Set values for the `fiftyone-dev-api (Test Application)` application
+    apiClientId: ""
+    apiClientSecret: ""
+
+    # Set values for the `local-dev` application
+    clientId: ""
+    clientSecret: ""
+
+    # Set to the Identifier of the `fiftyone-demo` organization
+    organizationId: ""
+
+    fiftyoneDatabaseName: fiftyone-internal
+    # This password is randomly generated and is only used to initialize a local (ephemeral) MongoDB in `./skaffold-mongodb.yaml`
+    # URL encoded to overcome errors with unencoded characters
+    mongodbConnectionString: mongodb://root:3-9XjJ-gUV%3Fvp%5Ee%28WUk%3ELD%26lAjh7yEji@mongodb.fiftyone-teams.svc.cluster.local/?authSource=admin  # pragma: allowlist secret
+
+    # randomly generated value
+    cookieSecret: 5b32118032bfd50b64b3cc7c0e0821f4e84f63ad517a9687ac2b6ce6ab261976
+    # randomly generated value
+    encryptionKey: btv8BiFCaPIayWU3IU3a_Lm_EMIIk-t6H_yN1ORV45o=
+
+    # randomly generated value
+    fiftyoneAuthSecret: "aGM4?s&t-n;!*U96oA#bdo,+JU)ac1T7"
+pluginsSettings:
+  image:
+    # See https://console.cloud.google.com/artifacts/docker/computer-vision-team/us-central1/dev-docker?project=computer-vision-team
+    repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-app
+    pullPolicy: IfNotPresent
+    tag: v1.6.1rc2
+teamsAppSettings:
+  dnsName: local.fiftyone.ai
+  # env:
+  #   # For local development without TLS certs, set `APP_USE_HTTPS=false` to
+  #   # prohibit the app from setting Redirect URL protocol to `https`.
+  #   # Must be set in both `appSettings.env` and `teamsAppSettings.env`.
+  #   # Can be true, when using cert-manager with self-signed certificates
+  #   APP_USE_HTTPS: false
+  image:
+    # See https://console.cloud.google.com/artifacts/docker/computer-vision-team/us-central1/dev-docker?project=computer-vision-team
+    repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-teams-app
+    # Note: the naming convention for the image `fiftyone-teams-app` differs from
+    # the other images (`fiftyone-app`, `fiftyone-app` and `fiftyone-teams-api`).
+    # The others are `vW.X.Y.devZ` (note `.devZ` vs `-dev.Z`).
+    # This is a byproduct of `npm` versioning versus Python PEP 440.
+    pullPolicy: IfNotPresent
+    tag: v1.6.1-rc.1
+casSettings:
+  env:
+    DEBUG: cas:*
+    FIFTYONE_AUTH_MODE: internal
+  image:
+    # See https://console.cloud.google.com/artifacts/docker/computer-vision-team/us-central1/dev-docker?project=computer-vision-team
+    repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-teams-cas
+    pullPolicy: IfNotPresent
+    tag: v1.6.1-rc.1

--- a/tests/integration/compose/docker-compose-legacy-auth_test.go
+++ b/tests/integration/compose/docker-compose-legacy-auth_test.go
@@ -275,10 +275,19 @@ func (s *commonServicesLegacyAuthDockerComposeUpTest) TestDockerComposeUp() {
 			for _, expected := range testCase.expected {
 				logger.Log(subT, fmt.Sprintf("Validating service %s...", expected.name))
 				s.Contains(output, fmt.Sprintf("Container %s-%s-1  Started", dockerOptions.ProjectName, expected.name), fmt.Sprintf("%s - %s - docker compose output should contain service container started", testCase.name, expected.name))
+
+				// Validate endpoint response
+				// Skip fiftyone-app and teams-plugins because they do not have callable endpoints that return a response payload.
 				if expected.url != "" {
 					validate_endpoint(subT, expected.url, expected.responsePayload, expected.httpResponseCode)
 				}
-				s.Contains(get_logs(subT, dockerOptions, expected.name), expected.log, fmt.Sprintf("%s - %s - log should contain matching entry", testCase.name, expected.name))
+
+				// Validate log output is expected
+				s.Contains(
+					get_logs(subT, dockerOptions, expected.name),
+					expected.log,
+					fmt.Sprintf("%s - %s - log should contain matching entry", testCase.name, expected.name),
+				)
 			}
 		})
 	}

--- a/tests/integration/helm/common_test.go
+++ b/tests/integration/helm/common_test.go
@@ -1,0 +1,91 @@
+//go:build docker || helm || integration || integrationHelmInternalAuth || integrationHelmLegacyAuth
+// +build docker helm integration integrationHelmInternalAuth integrationHelmLegacyAuth
+
+package integration
+
+import (
+	"crypto/tls"
+
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	chartPath         = "../../../helm/fiftyone-teams-app/"
+	integrationValues = "../../fixtures/helm/integration_values.yaml"
+	// for minikube, where node count is 1, we don't need ReadWriteMany and NFS
+	persistentVolumeYaml = `---
+    apiVersion: v1
+    kind: PersistentVolume
+    metadata:
+      name: pv0001
+    spec:
+      accessModes:
+        - ReadWriteOnce
+        - ReadOnlyMany
+      capacity:
+        storage: 100Mi
+      hostPath:
+        path: /data/pv0001/
+`
+	// for minikube, where node count is 1, we don't need ReadWriteMany and NFS
+	persistentVolumeClaimYaml = `---
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: pv0001claim
+    spec:
+      accessModes:
+        - ReadWriteOnce
+        - ReadOnlyMany
+      resources:
+        requests:
+          storage: 100Mi
+`
+)
+
+type serviceValidations struct {
+	name             string
+	url              string
+	responsePayload  string
+	httpResponseCode int
+	log              string
+}
+
+func validate_endpoint(t *testing.T, url string, expectedBody string, expectedStatus int) {
+	maxRetries := 10
+	timeBetweenRetries := 3 * time.Second
+	http_helper.HttpGetWithRetry(
+		t,
+		url,
+		&tls.Config{
+			InsecureSkipVerify: true, // Skip verify because we use self-signed certificates created with cert-manager
+		},
+		expectedStatus,
+		expectedBody,
+		maxRetries,
+		timeBetweenRetries,
+	)
+}
+
+// This wrapper is used for test consistency between compose tests
+func get_logs(t *testing.T, options *k8s.KubectlOptions, pod *corev1.Pod, containerName string) string {
+	output := k8s.GetPodLogs(t, options, pod, containerName)
+	return output
+}
+
+// Reused from https://github.com/gruntwork-io/terratest/blob/df790dab719e1120f14b4e82c1c8d1150537c026/modules/k8s/tunnel.go#L55-L62
+// makeLabels is a helper to format a map of label key and value pairs into a single string for use as a selector.
+func makeLabels(labels map[string]string) string {
+	out := []string{}
+	for key, value := range labels {
+		out = append(out, fmt.Sprintf("%s=%s", key, value))
+	}
+	return strings.Join(out, ",")
+}

--- a/tests/integration/helm/helm-internal-auth_test.go
+++ b/tests/integration/helm/helm-internal-auth_test.go
@@ -1,0 +1,283 @@
+//go:build kubeall || helm || integration || integrationHelmInternalAuth
+// +build kubeall helm integration integrationHelmInternalAuth
+
+package integration
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"path/filepath"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/random"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type internalAuthHelmTest struct {
+	suite.Suite
+	chartPath   string
+	namespace   string
+	context     string
+	valuesFiles []string
+}
+
+func TestHelmInternalAuth(t *testing.T) {
+	t.Parallel()
+
+	helmChartPath, err := filepath.Abs(chartPath)
+	require.NoError(t, err)
+
+	integrationValuesPath, err := filepath.Abs(integrationValues)
+
+	suite.Run(t, &internalAuthHelmTest{
+		Suite:     suite.Suite{},
+		chartPath: helmChartPath,
+		namespace: "fiftyone-" + strings.ToLower(random.UniqueId()),
+		context:   "minikube", // hardcoding to minikube k8s cluster context avoid accessing another k8s cluster
+		valuesFiles: []string{
+			integrationValuesPath, // Copy of values from `skaffold.yaml`'s `helm.releases[0].overrides`
+		},
+	})
+}
+
+func (s *internalAuthHelmTest) TestHelmInstall() {
+	testCases := []struct {
+		name     string
+		values   map[string]string
+		expected []serviceValidations
+	}{
+		{
+			"builtinPlugins",
+			map[string]string{
+				"casSettings.env.FIFTYONE_AUTH_MODE": "internal",
+			},
+			[]serviceValidations{
+				{
+					name:             "teams-api",
+					url:              "https://local.fiftyone.ai/health",
+					responsePayload:  `{"status":"available"}`,
+					httpResponseCode: 200,
+					log:              "[INFO] Starting worker",
+				},
+				{
+					name:             "teams-app",
+					url:              "https://local.fiftyone.ai/api/hello",
+					responsePayload:  `{"name":"John Doe"}`,
+					httpResponseCode: 200,
+					log:              "Listening on port 3000",
+				},
+				{
+					name:             "teams-cas",
+					url:              "https://local.fiftyone.ai/cas/api",
+					responsePayload:  `{"status":"available"}`,
+					httpResponseCode: 200,
+					log:              " ✓ Ready in",
+				},
+				// ordering this last to avoid test flakes where testing for log before the container is running
+				{
+					name:             "fiftyone-app",
+					url:              "",
+					responsePayload:  "",
+					httpResponseCode: 200,
+					log:              "[INFO] Running on http://0.0.0.0:5151",
+				},
+			},
+		},
+		{
+			"sharedPlugins", // plugins run in fiftyone-app deployment
+			map[string]string{
+				"casSettings.env.FIFTYONE_AUTH_MODE":                     "internal",
+				"apiSettings.env.FIFTYONE_PLUGINS_DIR":                   "/opt/plugins",
+				"apiSettings.volumes[0].name":                            "plugins-vol",
+				"apiSettings.volumes[0].persistentVolumeClaim.claimName": "pv0001claim",
+				"apiSettings.volumeMounts[0].name":                       "plugins-vol",
+				"apiSettings.volumeMounts[0].mountPath":                  "/opt/plugins",
+				"appSettings.env.FIFTYONE_PLUGINS_DIR":                   "/opt/plugins",
+				"appSettings.volumes[0].name":                            "plugins-vol-ro",
+				"appSettings.volumes[0].persistentVolumeClaim.claimName": "pv0001claim",
+				"appSettings.volumes[0].persistentVolumeClaim.readOnly":  "true",
+				"appSettings.volumeMounts[0].name":                       "plugins-vol-ro",
+				"appSettings.volumeMounts[0].mountPath":                  "/opt/plugins",
+			},
+			[]serviceValidations{
+				{
+					name:             "teams-api",
+					url:              "https://local.fiftyone.ai/health",
+					responsePayload:  `{"status":"available"}`,
+					httpResponseCode: 200,
+					log:              "[INFO] Starting worker",
+				},
+				{
+					name:             "teams-app",
+					url:              "https://local.fiftyone.ai/api/hello",
+					responsePayload:  `{"name":"John Doe"}`,
+					httpResponseCode: 200,
+					log:              "Listening on port 3000",
+				},
+				{
+					name:             "teams-cas",
+					url:              "https://local.fiftyone.ai/cas/api",
+					responsePayload:  `{"status":"available"}`,
+					httpResponseCode: 200,
+					log:              " ✓ Ready in",
+				},
+				// ordering this last to avoid test flakes where testing for log before the container is running
+				{
+					name:             "fiftyone-app",
+					url:              "",
+					responsePayload:  "",
+					httpResponseCode: 200,
+					log:              "[INFO] Running on http://0.0.0.0:5151",
+				},
+			},
+		},
+		{
+			"dedicatedPlugins", // plugins run in plugins deployment
+			map[string]string{
+				"apiSettings.env.FIFTYONE_PLUGINS_DIR":                       "/opt/plugins",
+				"apiSettings.volumes[0].name":                                "plugins-vol",
+				"apiSettings.volumes[0].persistentVolumeClaim.claimName":     "pv0001claim",
+				"apiSettings.volumeMounts[0].name":                           "plugins-vol",
+				"apiSettings.volumeMounts[0].mountPath":                      "/opt/plugins",
+				"casSettings.env.FIFTYONE_AUTH_MODE":                         "internal",
+				"pluginsSettings.enabled":                                    "true",
+				"pluginsSettings.env.FIFTYONE_PLUGINS_DIR":                   "/opt/plugins",
+				"pluginsSettings.volumes[0].name":                            "plugins-vol-ro",
+				"pluginsSettings.volumes[0].persistentVolumeClaim.claimName": "pv0001claim",
+				"pluginsSettings.volumes[0].persistentVolumeClaim.readOnly":  "true",
+				"pluginsSettings.volumeMounts[0].name":                       "plugins-vol-ro",
+				"pluginsSettings.volumeMounts[0].mountPath":                  "/opt/plugins",
+			},
+			[]serviceValidations{
+				{
+					name:             "teams-api",
+					url:              "https://local.fiftyone.ai/health",
+					responsePayload:  `{"status":"available"}`,
+					httpResponseCode: 200,
+					log:              "[INFO] Starting worker",
+				},
+				{
+					name:             "teams-app",
+					url:              "https://local.fiftyone.ai/api/hello",
+					responsePayload:  `{"name":"John Doe"}`,
+					httpResponseCode: 200,
+					log:              "Listening on port 3000",
+				},
+				{
+					name:             "teams-cas",
+					url:              "https://local.fiftyone.ai/cas/api",
+					responsePayload:  `{"status":"available"}`,
+					httpResponseCode: 200,
+					log:              " ✓ Ready in",
+				},
+				// ordering this last to avoid test flakes where testing for log before the container is running
+				{
+					name:             "fiftyone-app",
+					url:              "",
+					responsePayload:  "",
+					httpResponseCode: 200,
+					log:              "[INFO] Running on http://0.0.0.0:5151",
+				},
+				{
+					name:             "teams-plugins",
+					url:              "",
+					responsePayload:  "",
+					httpResponseCode: 0,
+					log:              "[INFO] Running on http://0.0.0.0:5151", // same as fiftyone-app since plugins uses or is based on the fiftyone-app image
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		s.Run(testCase.name, func() {
+			subT := s.T()
+			// Disabling parallelization until we configure discrete databases
+			// subT.Parallel()
+
+			// Create namespace name for the test case
+			namespace := fmt.Sprintf(
+				"%s-%s",
+				s.namespace,
+				strings.ToLower(testCase.name),
+			)
+			//  Add namespace to helm values map
+			testCase.values["namespace.name"] = namespace
+
+			// Add namespace to kubectl options
+			kubectlOptions := k8s.NewKubectlOptions(s.context, "", namespace)
+			// Create namespace
+			defer k8s.DeleteNamespace(subT, kubectlOptions, namespace)
+			k8s.CreateNamespace(subT, kubectlOptions, namespace)
+
+			// create persistent volume, when necessary
+			needsPersistentVolume := []string{"sharedPlugins", "dedicatedPlugins"}
+			if slices.Contains(needsPersistentVolume, testCase.name) {
+				defer k8s.KubectlDeleteFromString(subT, kubectlOptions, persistentVolumeYaml)
+				k8s.KubectlApplyFromString(subT, kubectlOptions, persistentVolumeYaml)
+				defer k8s.KubectlDeleteFromString(subT, kubectlOptions, persistentVolumeClaimYaml)
+				k8s.KubectlApplyFromString(subT, kubectlOptions, persistentVolumeClaimYaml)
+			}
+
+			helmOptions := &helm.Options{
+				KubectlOptions: kubectlOptions,
+				SetValues:      testCase.values,
+				ValuesFiles:    s.valuesFiles,
+			}
+			releaseName := fmt.Sprintf(
+				"%s-internal-%s",
+				strings.ToLower(testCase.name),
+				strings.ToLower(random.UniqueId()),
+			)
+			defer helm.Delete(subT, helmOptions, releaseName, true)
+			helm.Install(subT, helmOptions, s.chartPath, releaseName)
+
+			// Validate system health
+			for _, expected := range testCase.expected {
+				logger.Log(subT, fmt.Sprintf("Validating service %s...", expected.name))
+
+				// get deployment
+				deployment := k8s.GetDeployment(subT, kubectlOptions, expected.name)
+				k8s.WaitUntilDeploymentAvailable(subT, kubectlOptions, deployment.Name, 18, 5*time.Second) // 90 seconds of retries. Pods typically ready in ~51 seconds.
+
+				// get deployment match labels
+				selectorLabelsPods := makeLabels(deployment.Spec.Selector.MatchLabels)
+
+				// use deployment match labels to get the associated pods
+				listOptions := metav1.ListOptions{LabelSelector: selectorLabelsPods}
+				pods := k8s.ListPods(subT, kubectlOptions, listOptions)
+
+				// Validate log output is expected
+				for _, pod := range pods {
+					s.Contains(
+						get_logs(subT, kubectlOptions, &pod, ""),
+						expected.log,
+						fmt.Sprintf("%s - %s - log should contain matching entry", testCase.name, expected.name),
+					)
+				}
+
+				// Validate that k8s service is ready (pods are started and in service)
+				k8s.WaitUntilServiceAvailable(subT, kubectlOptions, expected.name, 10, 1*time.Second)
+
+				// Validate endpoint response
+				// Skip fiftyone-app and teams-plugins because they do not have callable endpoints that return a response payload.
+				if expected.url != "" {
+					// Validate url endpoint response is expected
+					validate_endpoint(subT, expected.url, expected.responsePayload, expected.httpResponseCode)
+				}
+			}
+		})
+	}
+}

--- a/tests/integration/helm/helm-legacy-auth_test.go
+++ b/tests/integration/helm/helm-legacy-auth_test.go
@@ -1,0 +1,283 @@
+//go:build kubeall || helm || integration || integrationHelmLegacyAuth
+// +build kubeall helm integration integrationHelmLegacyAuth
+
+package integration
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"path/filepath"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/random"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type legacyAuthHelmTest struct {
+	suite.Suite
+	chartPath   string
+	namespace   string
+	context     string
+	valuesFiles []string
+}
+
+func TestHelmLegacyAuth(t *testing.T) {
+	t.Parallel()
+
+	helmChartPath, err := filepath.Abs(chartPath)
+	require.NoError(t, err)
+
+	integrationValuesPath, err := filepath.Abs(integrationValues)
+
+	suite.Run(t, &legacyAuthHelmTest{
+		Suite:     suite.Suite{},
+		chartPath: helmChartPath,
+		namespace: "fiftyone-" + strings.ToLower(random.UniqueId()),
+		context:   "minikube", // hardcoding to minikube k8s cluster context avoid accessing another k8s cluster
+		valuesFiles: []string{
+			integrationValuesPath, // Copy of values from `skaffold.yaml`'s `helm.releases[0].overrides`
+		},
+	})
+}
+
+func (s *legacyAuthHelmTest) TestHelmInstall() {
+	testCases := []struct {
+		name     string
+		values   map[string]string
+		expected []serviceValidations
+	}{
+		{
+			"builtinPlugins",
+			map[string]string{
+				"casSettings.env.FIFTYONE_AUTH_MODE": "legacy",
+			},
+			[]serviceValidations{
+				{
+					name:             "teams-api",
+					url:              "https://local.fiftyone.ai/health",
+					responsePayload:  `{"status":"available"}`,
+					httpResponseCode: 200,
+					log:              "[INFO] Starting worker",
+				},
+				{
+					name:             "teams-app",
+					url:              "https://local.fiftyone.ai/api/hello",
+					responsePayload:  `{"name":"John Doe"}`,
+					httpResponseCode: 200,
+					log:              "Listening on port 3000",
+				},
+				{
+					name:             "teams-cas",
+					url:              "https://local.fiftyone.ai/cas/api",
+					responsePayload:  `{"status":"available"}`,
+					httpResponseCode: 200,
+					log:              " ✓ Ready in",
+				},
+				// ordering this last to avoid test flakes where testing for log before the container is running
+				{
+					name:             "fiftyone-app",
+					url:              "",
+					responsePayload:  "",
+					httpResponseCode: 200,
+					log:              "[INFO] Running on http://0.0.0.0:5151",
+				},
+			},
+		},
+		{
+			"sharedPlugins", // plugins run in fiftyone-app deployment
+			map[string]string{
+				"casSettings.env.FIFTYONE_AUTH_MODE":                     "legacy",
+				"apiSettings.env.FIFTYONE_PLUGINS_DIR":                   "/opt/plugins",
+				"apiSettings.volumes[0].name":                            "plugins-vol",
+				"apiSettings.volumes[0].persistentVolumeClaim.claimName": "pv0001claim",
+				"apiSettings.volumeMounts[0].name":                       "plugins-vol",
+				"apiSettings.volumeMounts[0].mountPath":                  "/opt/plugins",
+				"appSettings.env.FIFTYONE_PLUGINS_DIR":                   "/opt/plugins",
+				"appSettings.volumes[0].name":                            "plugins-vol-ro",
+				"appSettings.volumes[0].persistentVolumeClaim.claimName": "pv0001claim",
+				"appSettings.volumes[0].persistentVolumeClaim.readOnly":  "true",
+				"appSettings.volumeMounts[0].name":                       "plugins-vol-ro",
+				"appSettings.volumeMounts[0].mountPath":                  "/opt/plugins",
+			},
+			[]serviceValidations{
+				{
+					name:             "teams-api",
+					url:              "https://local.fiftyone.ai/health",
+					responsePayload:  `{"status":"available"}`,
+					httpResponseCode: 200,
+					log:              "[INFO] Starting worker",
+				},
+				{
+					name:             "teams-app",
+					url:              "https://local.fiftyone.ai/api/hello",
+					responsePayload:  `{"name":"John Doe"}`,
+					httpResponseCode: 200,
+					log:              "Listening on port 3000",
+				},
+				{
+					name:             "teams-cas",
+					url:              "https://local.fiftyone.ai/cas/api",
+					responsePayload:  `{"status":"available"}`,
+					httpResponseCode: 200,
+					log:              " ✓ Ready in",
+				},
+				// ordering this last to avoid test flakes where testing for log before the container is running
+				{
+					name:             "fiftyone-app",
+					url:              "",
+					responsePayload:  "",
+					httpResponseCode: 200,
+					log:              "[INFO] Running on http://0.0.0.0:5151",
+				},
+			},
+		},
+		{
+			"dedicatedPlugins", // plugins run in plugins deployment
+			map[string]string{
+				"apiSettings.env.FIFTYONE_PLUGINS_DIR":                       "/opt/plugins",
+				"apiSettings.volumes[0].name":                                "plugins-vol",
+				"apiSettings.volumes[0].persistentVolumeClaim.claimName":     "pv0001claim",
+				"apiSettings.volumeMounts[0].name":                           "plugins-vol",
+				"apiSettings.volumeMounts[0].mountPath":                      "/opt/plugins",
+				"casSettings.env.FIFTYONE_AUTH_MODE":                         "legacy",
+				"pluginsSettings.enabled":                                    "true",
+				"pluginsSettings.env.FIFTYONE_PLUGINS_DIR":                   "/opt/plugins",
+				"pluginsSettings.volumes[0].name":                            "plugins-vol-ro",
+				"pluginsSettings.volumes[0].persistentVolumeClaim.claimName": "pv0001claim",
+				"pluginsSettings.volumes[0].persistentVolumeClaim.readOnly":  "true",
+				"pluginsSettings.volumeMounts[0].name":                       "plugins-vol-ro",
+				"pluginsSettings.volumeMounts[0].mountPath":                  "/opt/plugins",
+			},
+			[]serviceValidations{
+				{
+					name:             "teams-api",
+					url:              "https://local.fiftyone.ai/health",
+					responsePayload:  `{"status":"available"}`,
+					httpResponseCode: 200,
+					log:              "[INFO] Starting worker",
+				},
+				{
+					name:             "teams-app",
+					url:              "https://local.fiftyone.ai/api/hello",
+					responsePayload:  `{"name":"John Doe"}`,
+					httpResponseCode: 200,
+					log:              "Listening on port 3000",
+				},
+				{
+					name:             "teams-cas",
+					url:              "https://local.fiftyone.ai/cas/api",
+					responsePayload:  `{"status":"available"}`,
+					httpResponseCode: 200,
+					log:              " ✓ Ready in",
+				},
+				// ordering this last to avoid test flakes where testing for log before the container is running
+				{
+					name:             "fiftyone-app",
+					url:              "",
+					responsePayload:  "",
+					httpResponseCode: 200,
+					log:              "[INFO] Running on http://0.0.0.0:5151",
+				},
+				{
+					name:             "teams-plugins",
+					url:              "",
+					responsePayload:  "",
+					httpResponseCode: 0,
+					log:              "[INFO] Running on http://0.0.0.0:5151", // same as fiftyone-app since plugins uses or is based on the fiftyone-app image
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		s.Run(testCase.name, func() {
+			subT := s.T()
+			// Disabling parallelization until we configure discrete databases
+			// subT.Parallel()
+
+			// Create namespace name for the test case
+			namespace := fmt.Sprintf(
+				"%s-%s",
+				s.namespace,
+				strings.ToLower(testCase.name),
+			)
+			//  Add namespace to helm values map
+			testCase.values["namespace.name"] = namespace
+
+			// Add namespace to kubectl options
+			kubectlOptions := k8s.NewKubectlOptions(s.context, "", namespace)
+			// Create namespace
+			defer k8s.DeleteNamespace(subT, kubectlOptions, namespace)
+			k8s.CreateNamespace(subT, kubectlOptions, namespace)
+
+			// create persistent volume, when necessary
+			needsPersistentVolume := []string{"sharedPlugins", "dedicatedPlugins"}
+			if slices.Contains(needsPersistentVolume, testCase.name) {
+				defer k8s.KubectlDeleteFromString(subT, kubectlOptions, persistentVolumeYaml)
+				k8s.KubectlApplyFromString(subT, kubectlOptions, persistentVolumeYaml)
+				defer k8s.KubectlDeleteFromString(subT, kubectlOptions, persistentVolumeClaimYaml)
+				k8s.KubectlApplyFromString(subT, kubectlOptions, persistentVolumeClaimYaml)
+			}
+
+			helmOptions := &helm.Options{
+				KubectlOptions: kubectlOptions,
+				SetValues:      testCase.values,
+				ValuesFiles:    s.valuesFiles,
+			}
+			releaseName := fmt.Sprintf(
+				"%s-legacy-%s",
+				strings.ToLower(testCase.name),
+				strings.ToLower(random.UniqueId()),
+			)
+			defer helm.Delete(subT, helmOptions, releaseName, true)
+			helm.Install(subT, helmOptions, s.chartPath, releaseName)
+
+			// Validate system health
+			for _, expected := range testCase.expected {
+				logger.Log(subT, fmt.Sprintf("Validating service %s...", expected.name))
+
+				// get deployment
+				deployment := k8s.GetDeployment(subT, kubectlOptions, expected.name)
+				k8s.WaitUntilDeploymentAvailable(subT, kubectlOptions, deployment.Name, 18, 5*time.Second) // 90 seconds of retries. Pods typically ready in ~51 seconds.
+
+				// get deployment match labels
+				selectorLabelsPods := makeLabels(deployment.Spec.Selector.MatchLabels)
+
+				// use deployment match labels to get the associated pods
+				listOptions := metav1.ListOptions{LabelSelector: selectorLabelsPods}
+				pods := k8s.ListPods(subT, kubectlOptions, listOptions)
+
+				// Validate log output is expected
+				for _, pod := range pods {
+					s.Contains(
+						get_logs(subT, kubectlOptions, &pod, ""),
+						expected.log,
+						fmt.Sprintf("%s - %s - log should contain matching entry", testCase.name, expected.name),
+					)
+				}
+
+				// Validate that k8s service is ready (pods are started and in service)
+				k8s.WaitUntilServiceAvailable(subT, kubectlOptions, expected.name, 10, 1*time.Second)
+
+				// Validate endpoint response
+				// Skip fiftyone-app and teams-plugins because they do not have callable endpoints that return a response payload.
+				if expected.url != "" {
+					// Validate url endpoint response is expected
+					validate_endpoint(subT, expected.url, expected.responsePayload, expected.httpResponseCode)
+				}
+			}
+		})
+	}
+}

--- a/tests/testing.md
+++ b/tests/testing.md
@@ -116,6 +116,47 @@ Either write
 See
 [Debugging interleaved test output](https://terratest.gruntwork.io/docs/testing-best-practices/debugging-interleaved-test-output/#installing-the-utility-binaries).
 
+## Integration Tests
+
+### Running Docker Compose Integration Tests
+
+1. Have Docker desktop running
+1. tests/integration/compose/docker-compose-legacy-auth_test.goRun tests
+
+    ```shell
+    make test-integration-compose
+    ```
+
+### Running Helm Integration Tests
+
+1. Start minikube
+
+    ```shell
+    make start run-cert-manager run-mongodb
+    ```
+
+1. Install cert-manager and mongodb into minikube
+
+    ```shell
+    make run-cert-manager run-mongodb
+    ```
+
+1. In another terminal, run `minikube tunnel`
+   (to expose the services within minikube outside of minikube)
+
+    ```shell
+    make tunnel
+    ```
+
+    > **NOTE**: This command will prompt for sudo permission
+    > on systems where 80 and 443 are privileged ports
+
+1. Run tests
+
+    ```shell
+    make test-integration-helm
+    ```
+
 ## Additional Links
 
 * [Automated Testing for Kubernetes and Helm Charts using Terratest](https://github.com/gruntwork-io/terratest-helm-testing-example)


### PR DESCRIPTION
# Rationale

As promised in #113, here is the addition of integration tests for Helm.  These check that the containers can run via docker compose in both authentication modes (legacy and internal).

This includes Helm configurations for running a mongodb for the integration tests. For now, keeping at MVP (with iterative improvements), I disabled the parallelization. In order to support parallel execution of the tests, we would need to add sophistication to the mongodb installation to use a parameterized port for mongodb and dynamically create that for each test and test case run. In serial, each tests run in 1 minute.

For the tests, we validate that the service container started. Then, check the service container logs for known working output. Then, if the service supports it, run an http check on an endpoint and validate the response. Because we are using self-signed certificates, I disabled the TLS validation.  If/when we move to running these test in a real cluster (not minikube) we can use a valid TLS cert and re-enable TLS validation.

## Changes

* Makefile
  * Add make targets `helm run`
  * Add make targets helm integration tests
* Update `skaffold.yaml` values for 1.6.0
  * These are "reused" as our helm integration test values
* Add Helm integration tests

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

No ^, but it brings that parity...

## Testing

<!-- Describe the way the changes were tested. -->

<details>
<summary>`make test-integration-helm` </summary>

```
$ make test-integration-helm
=== RUN   TestHelmInternalAuth
=== PAUSE TestHelmInternalAuth
=== CONT  TestHelmInternalAuth
=== RUN   TestHelmInternalAuth/TestHelmInstall
=== RUN   TestHelmInternalAuth/TestHelmInstall/builtinPlugins
TestHelmInternalAuth/TestHelmInstall/builtinPlugins 2024-05-07T12:15:19-07:00 client.go:45: Configuring Kubernetes client using config file /Users/kevin/.kube/config with context minikube
TestHelmInternalAuth/TestHelmInstall/builtinPlugins 2024-05-07T12:15:19-07:00 logger.go:66: Running command helm with args [install --kube-context minikube --namespace fiftyone-k5i9wm-builtinplugins --set casSettings.env.FIFTYONE_AUTH_MODE=internal --set namespace.name=fiftyone-k5i9wm-builtinplugins -f /Users/kevin/projects/voxel51/fiftyone-teams-app-deploy/tests/fixtures/helm/integration_values.yaml builtinplugins-internal-avmhmn /Users/kevin/projects/voxel51/fiftyone-teams-app-deploy/helm/fiftyone-teams-app]

...

--- PASS: TestHelmInternalAuth (235.54s)
    --- PASS: TestHelmInternalAuth/TestHelmInstall (235.54s)
        --- PASS: TestHelmInternalAuth/TestHelmInstall/builtinPlugins (57.73s)
        --- PASS: TestHelmInternalAuth/TestHelmInstall/sharedPlugins (88.58s)
        --- PASS: TestHelmInternalAuth/TestHelmInstall/dedicatedPlugins (89.23s)
PASS
ok  	github.com/voxel51/fiftyone-teams-app-deploy/integration/helm	235.950s


=== RUN   TestHelmLegacyAuth
=== PAUSE TestHelmLegacyAuth
=== CONT  TestHelmLegacyAuth
=== RUN   TestHelmLegacyAuth/TestHelmInstall
=== RUN   TestHelmLegacyAuth/TestHelmInstall/builtinPlugins
TestHelmLegacyAuth/TestHelmInstall/builtinPlugins 2024-05-07T12:19:18-07:00 client.go:45: Configuring Kubernetes client using config file /Users/kevin/.kube/config with context minikube
TestHelmLegacyAuth/TestHelmInstall/builtinPlugins 2024-05-07T12:19:18-07:00 logger.go:66: Running command helm with args [install --kube-context minikube --namespace fiftyone-xf4g8q-builtinplugins --set casSettings.env.FIFTYONE_AUTH_MODE=legacy --set namespace.name=fiftyone-xf4g8q-builtinplugins -f /Users/kevin/projects/voxel51/fiftyone-teams-app-deploy/tests/fixtures/helm/integration_values.yaml builtinplugins-legacy-mbsjnp /Users/kevin/projects/voxel51/fiftyone-teams-app-deploy/helm/fiftyone-teams-app]

...

--- PASS: TestHelmLegacyAuth (233.81s)
    --- PASS: TestHelmLegacyAuth/TestHelmInstall (233.81s)
        --- PASS: TestHelmLegacyAuth/TestHelmInstall/builtinPlugins (57.61s)
        --- PASS: TestHelmLegacyAuth/TestHelmInstall/sharedPlugins (88.52s)
        --- PASS: TestHelmLegacyAuth/TestHelmInstall/dedicatedPlugins (87.68s)
PASS
ok  	github.com/voxel51/fiftyone-teams-app-deploy/integration/helm	234.230s
```

</details>

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
