### PR TITLE
docs: `/cas` routing rule - ordering matters [AS-166]

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -558,8 +558,11 @@ to route traffic
 - From the path-based route `/cas` to port `3030`
   on the host running the FiftyOne Teams CAS
 
+  > **NOTE**: the `/cas` route must appear before the `/` route or
+  > an infinite redirect loop will occur.
+
 See
-[./example-nginx-site.conf](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/docker/example-nginx-site.conf)
+[./example-nginx-site.conf](./example-nginx-site.conf)
 for an example Nginx site configuration that forwards
 
 - http traffic to https

--- a/helm/docs/expose-teams-api.md
+++ b/helm/docs/expose-teams-api.md
@@ -99,6 +99,7 @@ To use this chart's ingress object
               pathType: Prefix
               serviceName: teams-cas
               servicePort: 80
+            # Note: the ordering matters. This root path must be last.
             - path: /
               pathType: Prefix
               serviceName: teams-app

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -107,8 +107,8 @@ A brief summary of those changes include
   - `secret.fiftyone`
   - secret specified in `secret.name`
 
-When using path-based routing,
-update your `values.yaml` to include the route
+When using path-based routing, update your `values.yaml`
+to include the rule (add it before the `path: /` rule)
 
 ```yaml
 - path: /cas
@@ -572,7 +572,8 @@ or modify your existing configuration to migrate to a new Auth0 Tenant.
            in the appropriate service pods
     1. `appSettings.env.FIFTYONE_DATABASE_ADMIN: true`
         1. This is not the default value in the Helm Chart and must be overridden
-    1. If you use path based routing, update your ingress with the rule
+    1. When using path-based routing, update your ingress with the rule
+       (add it before the `path: /` rule)
 
         ```yaml
         ingress:

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -109,8 +109,8 @@ A brief summary of those changes include
   - `secret.fiftyone`
   - secret specified in `secret.name`
 
-When using path-based routing,
-update your `values.yaml` to include the route
+When using path-based routing, update your `values.yaml`
+to include the rule (add it before the `path: /` rule)
 
 ```yaml
 - path: /cas
@@ -397,7 +397,8 @@ or modify your existing configuration to migrate to a new Auth0 Tenant.
            in the appropriate service pods
     1. `appSettings.env.FIFTYONE_DATABASE_ADMIN: true`
         1. This is not the default value in the Helm Chart and must be overridden
-    1. If you use path based routing, update your ingress with the rule
+    1. When using path-based routing, update your ingress with the rule
+       (add it before the `path: /` rule)
 
         ```yaml
         ingress:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -101,6 +101,7 @@ deploy:
                 pathType: Prefix
                 serviceName: teams-cas
                 servicePort: 80
+              # Note: the ordering matters. This root path must be last.
               - path: /
                 pathType: Prefix
                 serviceName: teams-app

--- a/tests/fixtures/helm/integration_values.yaml
+++ b/tests/fixtures/helm/integration_values.yaml
@@ -1,3 +1,4 @@
+---
 # Copy of values from `../../../skaffold.yaml`'s `helm.releases[0].overrides`
 # used for integration tests
 apiSettings:
@@ -61,6 +62,7 @@ ingress:
       pathType: Prefix
       serviceName: teams-cas
       servicePort: 80
+    # Note: the ordering matters. This root path must be last.
     - path: /
       pathType: Prefix
       serviceName: teams-app


### PR DESCRIPTION
# Rationale

Today, we learned that ordering for routing rules matter.  Let's instruct users to add the `/cas` rule before the `/` rule.  

## Changes

* Docs
  * compose 
  * helm 

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
