### PR TITLE
feat: in Helm chart, reduce the `initialDelaySeconds` from `45` to `15` [AS-70]

### DIFF
--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -388,11 +388,11 @@ appSettings:
 | apiSettings.securityContext | object | `{}` | Container security configuration for teams-api. [Reference][container-security-context]. |
 | apiSettings.service.annotations | object | `{}` | Service annotations for teams-api. [Reference][annotations]. |
 | apiSettings.service.containerPort | int | `8000` | Service container port for teams-api. |
-| apiSettings.service.liveness.initialDelaySeconds | int | `45` | Number of seconds to wait before performing the liveness probe for teams-api. [Reference][probes]. |
+| apiSettings.service.liveness.initialDelaySeconds | int | `15` | Number of seconds to wait before performing the liveness probe for teams-api. [Reference][probes]. |
 | apiSettings.service.name | string | `"teams-api"` | Service name. |
 | apiSettings.service.nodePort | int | `nil` | Service nodePort set only when `apiSettings.service.type: NodePort` for teams-api. |
 | apiSettings.service.port | int | `80` | Service port for teams-api. |
-| apiSettings.service.readiness.initialDelaySeconds | int | `45` | Number of seconds to wait before performing the readiness probe for teams-api. [Reference][probes]. |
+| apiSettings.service.readiness.initialDelaySeconds | int | `15` | Number of seconds to wait before performing the readiness probe for teams-api. [Reference][probes]. |
 | apiSettings.service.shortname | string | `"teams-api"` | Port name (maximum length is 15 characters) for teams-api. [Reference][ports]. |
 | apiSettings.service.type | string | `"ClusterIP"` | Service type for teams-api. [Reference][service-type]. |
 | apiSettings.tolerations | list | `[]` | Allow the k8s scheduler to schedule pods with matching taints for teams-api. [Reference][taints-and-tolerations]. |
@@ -419,11 +419,11 @@ appSettings:
 | appSettings.securityContext | object | `{}` | Container security configuration for fiftyone-app. [Reference][container-security-context]. |
 | appSettings.service.annotations | object | `{}` | Service annotations for fiftyone-app. [Reference][annotations]. |
 | appSettings.service.containerPort | int | `5151` | Service container port for fiftyone-app. |
-| appSettings.service.liveness.initialDelaySeconds | int | `45` | Number of seconds to wait before performing the liveness probe for fiftyone-app. [Reference][probes]. |
+| appSettings.service.liveness.initialDelaySeconds | int | `15` | Number of seconds to wait before performing the liveness probe for fiftyone-app. [Reference][probes]. |
 | appSettings.service.name | string | `"fiftyone-app"` | Service name. |
 | appSettings.service.nodePort | int | `nil` | Service nodePort set only when `appSettings.service.type: NodePort` for fiftyone-app. |
 | appSettings.service.port | int | `80` | Service port. |
-| appSettings.service.readiness.initialDelaySeconds | int | `45` | Number of seconds to wait before performing the readiness probe for fiftyone-app. [Reference][probes]. |
+| appSettings.service.readiness.initialDelaySeconds | int | `15` | Number of seconds to wait before performing the readiness probe for fiftyone-app. [Reference][probes]. |
 | appSettings.service.shortname | string | `"fiftyone-app"` | Port name (maximum length is 15 characters) for fiftyone-app. [Reference][ports]. |
 | appSettings.service.type | string | `"ClusterIP"` | Service type for fiftyone-app. [Reference][service-type]. |
 | appSettings.tolerations | list | `[]` | Allow the k8s scheduler to schedule fiftyone-app pods with matching taints. [Reference][taints-and-tolerations]. |
@@ -497,11 +497,11 @@ appSettings:
 | pluginsSettings.securityContext | object | `{}` | Container security configuration for teams-plugins. [Reference][container-security-context]. |
 | pluginsSettings.service.annotations | object | `{}` | Service annotations for teams-plugins. [Reference][annotations]. |
 | pluginsSettings.service.containerPort | int | `5151` | Service container port for teams-plugins. |
-| pluginsSettings.service.liveness.initialDelaySeconds | int | `45` | Number of seconds to wait before performing the liveness probe teams-plugins. [Reference][probes]. |
+| pluginsSettings.service.liveness.initialDelaySeconds | int | `15` | Number of seconds to wait before performing the liveness probe teams-plugins. [Reference][probes]. |
 | pluginsSettings.service.name | string | `"teams-plugins"` | Service name. |
 | pluginsSettings.service.nodePort | int | `nil` | Service nodePort set only when `pluginsSettings.service.type: NodePort` for teams-plugins. |
 | pluginsSettings.service.port | int | `80` | Service port. |
-| pluginsSettings.service.readiness.initialDelaySeconds | int | `45` | Number of seconds to wait before performing the readiness probe for teams-plugins. [Reference][probes]. |
+| pluginsSettings.service.readiness.initialDelaySeconds | int | `15` | Number of seconds to wait before performing the readiness probe for teams-plugins. [Reference][probes]. |
 | pluginsSettings.service.shortname | string | `"teams-plugins"` | Port name (maximum length is 15 characters) for teams-plugins. [Reference][ports]. |
 | pluginsSettings.service.type | string | `"ClusterIP"` | Service type for teams-plugins. [Reference][service-type]. |
 | pluginsSettings.tolerations | list | `[]` | Allow the k8s scheduler to schedule teams-plugins pods with matching taints. [Reference][taints-and-tolerations]. |
@@ -548,11 +548,11 @@ appSettings:
 | teamsAppSettings.serverPathPrefix | string | `"/"` | Prefix for path-based Ingress routing for teams-app. |
 | teamsAppSettings.service.annotations | object | `{}` | Service annotations for teams-app. [Reference][annotations]. |
 | teamsAppSettings.service.containerPort | int | `3000` | Service container port for teams-app. |
-| teamsAppSettings.service.liveness.initialDelaySeconds | int | `45` | Number of seconds to wait before performing the liveness probe for teams-app. [Reference][probes]. |
+| teamsAppSettings.service.liveness.initialDelaySeconds | int | `15` | Number of seconds to wait before performing the liveness probe for teams-app. [Reference][probes]. |
 | teamsAppSettings.service.name | string | `"teams-app"` | Service name. |
 | teamsAppSettings.service.nodePort | int | `nil` | Service nodePort set only when `teamsAppSettings.service.type: NodePort` for teams-app. |
 | teamsAppSettings.service.port | int | `80` | Service port. |
-| teamsAppSettings.service.readiness.initialDelaySeconds | int | `45` | Number of seconds to wait before performing the readiness probe for teams-app. [Reference][probes]. |
+| teamsAppSettings.service.readiness.initialDelaySeconds | int | `15` | Number of seconds to wait before performing the readiness probe for teams-app. [Reference][probes]. |
 | teamsAppSettings.service.shortname | string | `"teams-app"` | Port name (maximum length is 15 characters) for teams-app. [Reference][ports]. |
 | teamsAppSettings.service.type | string | `"ClusterIP"` | Service type for teams-app. [Reference][service-type]. |
 | teamsAppSettings.tolerations | list | `[]` | Allow the k8s scheduler to schedule teams-app pods with matching taints. [Reference][taints-and-tolerations]. |

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -51,7 +51,7 @@ apiSettings:
     containerPort: 8000
     liveness:
       # -- Number of seconds to wait before performing the liveness probe for teams-api. [Reference][probes].
-      initialDelaySeconds: 45
+      initialDelaySeconds: 15
     # -- Service name.
     name: teams-api
     # -- (int) Service nodePort set only when `apiSettings.service.type: NodePort` for teams-api.
@@ -60,7 +60,7 @@ apiSettings:
     port: 80
     readiness:
       # -- Number of seconds to wait before performing the readiness probe for teams-api. [Reference][probes].
-      initialDelaySeconds: 45
+      initialDelaySeconds: 15
     # TODO: Kevin/topher - Consider changing name from `shortname` to `portName`.
     # -- Port name (maximum length is 15 characters) for teams-api. [Reference][ports].
     shortname: teams-api
@@ -150,7 +150,7 @@ appSettings:
     containerPort: 5151
     liveness:
       # -- Number of seconds to wait before performing the liveness probe for fiftyone-app. [Reference][probes].
-      initialDelaySeconds: 45
+      initialDelaySeconds: 15
     # -- Service name.
     name: fiftyone-app
     # -- (int) Service nodePort set only when `appSettings.service.type: NodePort` for fiftyone-app.
@@ -159,7 +159,7 @@ appSettings:
     port: 80
     readiness:
       # -- Number of seconds to wait before performing the readiness probe for fiftyone-app. [Reference][probes].
-      initialDelaySeconds: 45
+      initialDelaySeconds: 15
     # TODO: Kevin/topher - Consider changing name from `shortname` to `portName`.
     # -- Port name (maximum length is 15 characters) for fiftyone-app. [Reference][ports].
     shortname: fiftyone-app
@@ -392,7 +392,7 @@ pluginsSettings:
     containerPort: 5151
     liveness:
       # -- Number of seconds to wait before performing the liveness probe teams-plugins. [Reference][probes].
-      initialDelaySeconds: 45
+      initialDelaySeconds: 15
     # -- Service name.
     name: teams-plugins
     # -- (int) Service nodePort set only when `pluginsSettings.service.type: NodePort` for teams-plugins.
@@ -401,7 +401,7 @@ pluginsSettings:
     port: 80
     readiness:
       # -- Number of seconds to wait before performing the readiness probe for teams-plugins. [Reference][probes].
-      initialDelaySeconds: 45
+      initialDelaySeconds: 15
     # TODO: Kevin/topher - Consider changing name from `shortname` to `portName`.
     # -- Port name (maximum length is 15 characters) for teams-plugins. [Reference][ports].
     shortname: teams-plugins
@@ -553,7 +553,7 @@ teamsAppSettings:
     containerPort: 3000
     liveness:
       # -- Number of seconds to wait before performing the liveness probe for teams-app. [Reference][probes].
-      initialDelaySeconds: 45
+      initialDelaySeconds: 15
     # -- Service name.
     name: teams-app
     # -- (int) Service nodePort set only when `teamsAppSettings.service.type: NodePort` for teams-app.
@@ -562,7 +562,7 @@ teamsAppSettings:
     port: 80
     readiness:
       # -- Number of seconds to wait before performing the readiness probe for teams-app. [Reference][probes].
-      initialDelaySeconds: 45
+      initialDelaySeconds: 15
     # TODO: Kevin/topher - Consider changing name from `shortname` to `portName`.
     # -- Port name (maximum length is 15 characters) for teams-app. [Reference][ports].
     shortname: teams-app


### PR DESCRIPTION
# Rationale

In [#138 ](https://github.com/voxel51/fiftyone-teams-app-deploy/commit/d6493bfe376a8b41d3137ac1f60b6dc51d8dcaf9) I experimented with reducing our `initialDelaySeconds` from `45` to `15`.  It lead to a startup time reduction from speed 232s to 154s in my skaffold/minikube environment.

## Changes

* `initialDelaySeconds` from `45` to `15`

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

No ^. This is a Helm only change.

## Testing

This was validated during the the development of our Helm integration tests and its runs.

## Related

* #144 - closed in favor of this PR whose base branch is `release/v1.7.0` (instead of main)