### PR TITLE
Add dependabot github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
# Rationale

Since we use GitHub Actions, let's enable dependabot alerts for action updates.

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot

## Changes

* added .github/dependabot.yml
  * set `package-ecosystem` to "github-actions"

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

n/a ^

## Testing

Will be performed in the future

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
