### PR TITLE
Document `FIFTYONE_APP_INSTALL_FIFTYONE_OVERRIDE`

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -12,6 +12,8 @@
 
 ## Known Issue for FiftyOne Teams v1.6.0 and Above
 
+### "Install Fiftyone" Instructions Missing PyPI Token
+
 FiftyOne Teams v1.6 introduces the Central Authentication Service (CAS), which
 introduces an abstraction layer between FiftyOne Teams and Auth0.  This
 abstraction layer makes it possible to deploy FiftyOne Teams without using Auth0
@@ -38,6 +40,28 @@ teams-app:
 
 If you need your PyPI token, please contact your Customer Success representative
 and they will provide it to you.
+
+### Invitations Disabled for Internal Authentication Mode
+
+FiftyOne Teams v1.6 introduces the Central Authentication Service (CAS), which
+includes both
+[`legacy` authentication mode][legacy-auth-mode]
+and
+[`internal` authentication mode][internal-auth-mode]
+
+Inviting users to join your FiftyOne Teams instance is not currently supported
+when `FIFTYONE_AUTH_MODE` is set to `internal`.
+
+### Super Admin UI Disabled for Legacy Authentication Mode
+
+FiftyOne Teams v1.6 introduces the Central Authentication Service (CAS), which
+includes a new
+[Super Admin UI](https://docs.voxel51.com/teams/pluggable_auth.html#super-admin-ui)
+for deployment-wide authentication configurations when using
+[`internal` authentication mode][internal-auth-mode].
+
+The FiftyOne Teams Super Admin UI is disabled when `FIFTYONE_AUTH_MODE` is set
+to `legacy`.
 
 <!-- toc -->
 
@@ -144,9 +168,9 @@ Please review these notes, and the
 documentation before completing your upgrade.
 
 Voxel51 recommends upgrading your deployment using
-[`legacy` authentication mode](https://docs.voxel51.com/teams/pluggable_auth.html#legacy-mode)
+[`legacy` authentication mode][legacy-auth-mode]
 and migrating to
-[`internal` authentication mode](https://docs.voxel51.com/teams/pluggable_auth.html#internal-mode)
+[`internal` authentication mode][internal-auth-mode]
 after confirming your initial upgrade was successful.
 
 Please contact your Voxel51 customer success
@@ -731,3 +755,7 @@ for an example Nginx site configuration that forwards
 | `HTTP_PROXY_URL`                             | The URL for your environment http proxy                                                                                                                                                                                                                                        | No                        |
 | `HTTPS_PROXY_URL`                            | The URL for your environment https proxy                                                                                                                                                                                                                                       | No                        |
 | `NO_PROXY_LIST`                              | The list of servers that should bypass the proxy; if a proxy is in use this must include the list of FiftyOne services (`fiftyone-app, teams-api,teams-app,teams-cas` must be included, `teams-plugins` should be included for dedicated plugins configurations)               | No                        |
+
+<!-- Reference Links -->
+[internal-auth-mode]: https://docs.voxel51.com/teams/pluggable_auth.html#internal-mode
+[legacy-auth-mode]: topher/document-install-modal-override

--- a/docker/README.md
+++ b/docker/README.md
@@ -10,6 +10,35 @@
 </div>
 <!-- markdownlint-enable no-inline-html line-length -->
 
+## Known Issue for FiftyOne Teams v1.6.0 and Above
+
+FiftyOne Teams v1.6 introduces the Central Authentication Service (CAS), which
+introduces an abstraction layer between FiftyOne Teams and Auth0.  This
+abstraction layer makes it possible to deploy FiftyOne Teams without using Auth0
+as an Identity Service Provider.
+
+However, metadata that used to be provided to FiftyOne Teams by Auth0 is no
+longer available; which has resulted in an incomplete set of instructions in the
+[Install FiftyOne](https://docs.voxel51.com/teams/installation.html#python-sdk)
+instructions for bash.
+
+Specifically, you will see the word `TOKEN` where your Voxel51 PyPI token used
+to appear.
+
+While Voxel51 works to address this issue, you can override the install
+instructions by setting the `FIFTYONE_APP_INSTALL_FIFTYONE_OVERRIDE` environment
+value for the `teams-app` deployment.  This can be accomplished by adding
+something like the following to your `compose.override.yaml`:
+
+```yaml
+teams-app:
+  environment:
+    FIFTYONE_APP_INSTALL_FIFTYONE_OVERRIDE: pip install -U --index-url https://<your PyPI Token>@pypi.fiftyone.ai fiftyone==0.17.0
+```
+
+If you need your PyPI token, please contact your Customer Success representative
+and they will provide it to you.
+
 <!-- toc -->
 
 - [Deploying FiftyOne Teams App with Docker Compose](#deploying-fiftyone-teams-app-with-docker-compose)

--- a/docker/README.md
+++ b/docker/README.md
@@ -57,11 +57,12 @@ when `FIFTYONE_AUTH_MODE` is set to `internal`.
 FiftyOne Teams v1.6 introduces the Central Authentication Service (CAS), which
 includes a new
 [Super Admin UI](https://docs.voxel51.com/teams/pluggable_auth.html#super-admin-ui)
-for deployment-wide authentication configurations when using
-[`internal` authentication mode][internal-auth-mode].
+for deployment-wide authentication configurations.
 
 The FiftyOne Teams Super Admin UI is disabled when `FIFTYONE_AUTH_MODE` is set
 to `legacy`.
+
+## Table of Contents
 
 <!-- toc -->
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -47,7 +47,7 @@ FiftyOne Teams v1.6 introduces the Central Authentication Service (CAS), which
 includes both
 [`legacy` authentication mode][legacy-auth-mode]
 and
-[`internal` authentication mode][internal-auth-mode]
+[`internal` authentication mode][internal-auth-mode].
 
 Inviting users to join your FiftyOne Teams instance is not currently supported
 when `FIFTYONE_AUTH_MODE` is set to `internal`.

--- a/docker/README.md
+++ b/docker/README.md
@@ -27,7 +27,7 @@ to appear.
 
 While Voxel51 works to address this issue, you can override the install
 instructions by setting the `FIFTYONE_APP_INSTALL_FIFTYONE_OVERRIDE` environment
-value for the `teams-app` deployment.  This can be accomplished by adding
+value for the `teams-app` service.  This can be accomplished by adding
 something like the following to your `compose.override.yaml`:
 
 ```yaml

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -24,6 +24,8 @@ Please contact Voxel51 for more information regarding Fiftyone Teams.
 
 ## Known Issue for FiftyOne Teams v1.6.0 and Above
 
+### "Install Fiftyone" Instructions Missing PyPI Token
+
 FiftyOne Teams v1.6 introduces the Central Authentication Service (CAS), which
 introduces an abstraction layer between FiftyOne Teams and Auth0.  This
 abstraction layer makes it possible to deploy FiftyOne Teams without using Auth0
@@ -50,6 +52,28 @@ teamsAppSettings:
 
 If you need your PyPI token, please contact your Customer Success representative
 and they will provide it to you.
+
+### Invitations Disabled for Internal Authentication Mode
+
+FiftyOne Teams v1.6 introduces the Central Authentication Service (CAS), which
+includes both
+[`legacy` authentication mode][legacy-auth-mode]
+and
+[`internal` authentication mode][internal-auth-mode]
+
+Inviting users to join your FiftyOne Teams instance is not currently supported
+when `FIFTYONE_AUTH_MODE` is set to `internal`.
+
+### Super Admin UI Disabled for Legacy Authentication Mode
+
+FiftyOne Teams v1.6 introduces the Central Authentication Service (CAS), which
+includes a new
+[Super Admin UI](https://docs.voxel51.com/teams/pluggable_auth.html#super-admin-ui)
+for deployment-wide authentication configurations when using
+[`internal` authentication mode][internal-auth-mode].
+
+The FiftyOne Teams Super Admin UI is disabled when `FIFTYONE_AUTH_MODE` is set
+to `legacy`.
 
 <!-- toc -->
 
@@ -125,9 +149,9 @@ Please review these notes, and the
 documentation before completing your upgrade.
 
 Voxel51 recommends upgrading your deployment using
-[`legacy` authentication mode](https://docs.voxel51.com/teams/pluggable_auth.html#legacy-mode)
+[`legacy` authentication mode][legacy-auth-mode]
 and migrating to
-[`internal` authentication mode](https://docs.voxel51.com/teams/pluggable_auth.html#internal-mode)
+[`internal` authentication mode][internal-auth-mode]
 after confirming your initial upgrade was successful.
 
 Please contact your Voxel51 customer success
@@ -808,7 +832,9 @@ A minimal example `values.yaml` may be found
 [ingress-default-ingress-class]: https://kubernetes.io/docs/concepts/services-networking/ingress/#default-ingress-class
 [ingress-rules]: https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
 [ingress]: https://kubernetes.io/docs/concepts/services-networking/ingress/
+[internal-auth-mode]: https://docs.voxel51.com/teams/pluggable_auth.html#internal-mode
 [labels-and-selectors]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+[legacy-auth-mode]: topher/document-install-modal-override
 [node-selector]: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
 [ports]: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
 [probes]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -22,6 +22,35 @@ FiftyOne Teams is the enterprise version of the open source [FiftyOne](https://g
 
 Please contact Voxel51 for more information regarding Fiftyone Teams.
 
+## Known Issue for FiftyOne Teams v1.6.0 and Above
+
+FiftyOne Teams v1.6 introduces the Central Authentication Service (CAS), which
+introduces an abstraction layer between FiftyOne Teams and Auth0.  This
+abstraction layer makes it possible to deploy FiftyOne Teams without using Auth0
+as an Identity Service Provider.
+
+However, metadata that used to be provided to FiftyOne Teams by Auth0 is no
+longer available; which has resulted in an incomplete set of instructions in the
+[Install FiftyOne](https://docs.voxel51.com/teams/installation.html#python-sdk)
+instructions for bash.
+
+Specifically, you will see the word `TOKEN` where your Voxel51 PyPI token used
+to appear.
+
+While Voxel51 works to address this issue, you can override the install
+instructions by setting the `FIFTYONE_APP_INSTALL_FIFTYONE_OVERRIDE` environment
+value for the `teams-app` deployment.  This can be accomplished by adding
+something like the following to your `values.yaml`:
+
+```yaml
+teamsAppSettings:
+  env:
+    FIFTYONE_APP_INSTALL_FIFTYONE_OVERRIDE: pip install -U --index-url https://<your PyPI Token>@pypi.fiftyone.ai fiftyone==0.17.0
+```
+
+If you need your PyPI token, please contact your Customer Success representative
+and they will provide it to you.
+
 <!-- toc -->
 
 - [Initial Installation vs. Upgrades](#initial-installation-vs-upgrades)

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -69,11 +69,12 @@ when `FIFTYONE_AUTH_MODE` is set to `internal`.
 FiftyOne Teams v1.6 introduces the Central Authentication Service (CAS), which
 includes a new
 [Super Admin UI](https://docs.voxel51.com/teams/pluggable_auth.html#super-admin-ui)
-for deployment-wide authentication configurations when using
-[`internal` authentication mode][internal-auth-mode].
+for deployment-wide authentication configurations.
 
 The FiftyOne Teams Super Admin UI is disabled when `FIFTYONE_AUTH_MODE` is set
 to `legacy`.
+
+## Table of Contents
 
 <!-- toc -->
 

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -59,7 +59,7 @@ FiftyOne Teams v1.6 introduces the Central Authentication Service (CAS), which
 includes both
 [`legacy` authentication mode][legacy-auth-mode]
 and
-[`internal` authentication mode][internal-auth-mode]
+[`internal` authentication mode][internal-auth-mode].
 
 Inviting users to join your FiftyOne Teams instance is not currently supported
 when `FIFTYONE_AUTH_MODE` is set to `internal`.

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -61,7 +61,7 @@ FiftyOne Teams v1.6 introduces the Central Authentication Service (CAS), which
 includes both
 [`legacy` authentication mode][legacy-auth-mode]
 and
-[`internal` authentication mode][internal-auth-mode]
+[`internal` authentication mode][internal-auth-mode].
 
 Inviting users to join your FiftyOne Teams instance is not currently supported
 when `FIFTYONE_AUTH_MODE` is set to `internal`.

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -26,6 +26,8 @@ Please contact Voxel51 for more information regarding Fiftyone Teams.
 
 ## Known Issue for FiftyOne Teams v1.6.0 and Above
 
+### "Install Fiftyone" Instructions Missing PyPI Token
+
 FiftyOne Teams v1.6 introduces the Central Authentication Service (CAS), which
 introduces an abstraction layer between FiftyOne Teams and Auth0.  This
 abstraction layer makes it possible to deploy FiftyOne Teams without using Auth0
@@ -52,6 +54,28 @@ teamsAppSettings:
 
 If you need your PyPI token, please contact your Customer Success representative
 and they will provide it to you.
+
+### Invitations Disabled for Internal Authentication Mode
+
+FiftyOne Teams v1.6 introduces the Central Authentication Service (CAS), which
+includes both
+[`legacy` authentication mode][legacy-auth-mode]
+and
+[`internal` authentication mode][internal-auth-mode]
+
+Inviting users to join your FiftyOne Teams instance is not currently supported
+when `FIFTYONE_AUTH_MODE` is set to `internal`.
+
+### Super Admin UI Disabled for Legacy Authentication Mode
+
+FiftyOne Teams v1.6 introduces the Central Authentication Service (CAS), which
+includes a new
+[Super Admin UI](https://docs.voxel51.com/teams/pluggable_auth.html#super-admin-ui)
+for deployment-wide authentication configurations when using
+[`internal` authentication mode][internal-auth-mode].
+
+The FiftyOne Teams Super Admin UI is disabled when `FIFTYONE_AUTH_MODE` is set
+to `legacy`.
 
 <!-- toc -->
 
@@ -127,9 +151,9 @@ Please review these notes, and the
 documentation before completing your upgrade.
 
 Voxel51 recommends upgrading your deployment using
-[`legacy` authentication mode](https://docs.voxel51.com/teams/pluggable_auth.html#legacy-mode)
+[`legacy` authentication mode][legacy-auth-mode]
 and migrating to
-[`internal` authentication mode](https://docs.voxel51.com/teams/pluggable_auth.html#internal-mode)
+[`internal` authentication mode][internal-auth-mode]
 after confirming your initial upgrade was successful.
 
 Please contact your Voxel51 customer success
@@ -633,7 +657,9 @@ A minimal example `values.yaml` may be found
 [ingress-default-ingress-class]: https://kubernetes.io/docs/concepts/services-networking/ingress/#default-ingress-class
 [ingress-rules]: https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
 [ingress]: https://kubernetes.io/docs/concepts/services-networking/ingress/
+[internal-auth-mode]: https://docs.voxel51.com/teams/pluggable_auth.html#internal-mode
 [labels-and-selectors]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+[legacy-auth-mode]: topher/document-install-modal-override
 [node-selector]: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
 [ports]: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
 [probes]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -24,6 +24,35 @@
 
 Please contact Voxel51 for more information regarding Fiftyone Teams.
 
+## Known Issue for FiftyOne Teams v1.6.0 and Above
+
+FiftyOne Teams v1.6 introduces the Central Authentication Service (CAS), which
+introduces an abstraction layer between FiftyOne Teams and Auth0.  This
+abstraction layer makes it possible to deploy FiftyOne Teams without using Auth0
+as an Identity Service Provider.
+
+However, metadata that used to be provided to FiftyOne Teams by Auth0 is no
+longer available; which has resulted in an incomplete set of instructions in the
+[Install FiftyOne](https://docs.voxel51.com/teams/installation.html#python-sdk)
+instructions for bash.
+
+Specifically, you will see the word `TOKEN` where your Voxel51 PyPI token used
+to appear.
+
+While Voxel51 works to address this issue, you can override the install
+instructions by setting the `FIFTYONE_APP_INSTALL_FIFTYONE_OVERRIDE` environment
+value for the `teams-app` deployment.  This can be accomplished by adding
+something like the following to your `values.yaml`:
+
+```yaml
+teamsAppSettings:
+  env:
+    FIFTYONE_APP_INSTALL_FIFTYONE_OVERRIDE: pip install -U --index-url https://<your PyPI Token>@pypi.fiftyone.ai fiftyone==0.17.0
+```
+
+If you need your PyPI token, please contact your Customer Success representative
+and they will provide it to you.
+
 <!-- toc -->
 
 - [Initial Installation vs. Upgrades](#initial-installation-vs-upgrades)

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -71,11 +71,12 @@ when `FIFTYONE_AUTH_MODE` is set to `internal`.
 FiftyOne Teams v1.6 introduces the Central Authentication Service (CAS), which
 includes a new
 [Super Admin UI](https://docs.voxel51.com/teams/pluggable_auth.html#super-admin-ui)
-for deployment-wide authentication configurations when using
-[`internal` authentication mode][internal-auth-mode].
+for deployment-wide authentication configurations.
 
 The FiftyOne Teams Super Admin UI is disabled when `FIFTYONE_AUTH_MODE` is set
 to `legacy`.
+
+## Table of Contents
 
 <!-- toc -->
 


### PR DESCRIPTION
 The changes in this PR involve updates to the documentation for FiftyOne Teams v1.6.0 and above. Specifically, it addresses a known issue related to the Central Authentication Service (CAS) and the incomplete instructions for installing FiftyOne.

The issue arises because metadata previously provided by Auth0 is no longer available, resulting in the absence of the Voxel51 PyPI token in the installation instructions. To resolve this, users can override the installation instructions by setting the `FIFTYONE_APP_INSTALL_FIFTYONE_OVERRIDE` environment value.

The PR provides detailed instructions on how to set this environment value in both Docker Compose and Helm deployments. It also includes information on obtaining the PyPI token from the Customer Success representative.

In summary, this PR updates the documentation to address the issue of missing PyPI token in the installation instructions for FiftyOne Teams v1.6.0 and above.