### PR TITLE
Fix `legacy-auth-mode` link in documentation

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -760,4 +760,4 @@ for an example Nginx site configuration that forwards
 
 <!-- Reference Links -->
 [internal-auth-mode]: https://docs.voxel51.com/teams/pluggable_auth.html#internal-mode
-[legacy-auth-mode]: topher/document-install-modal-override
+[legacy-auth-mode]: https://docs.voxel51.com/teams/pluggable_auth.html#legacy-mode

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -836,7 +836,7 @@ A minimal example `values.yaml` may be found
 [ingress]: https://kubernetes.io/docs/concepts/services-networking/ingress/
 [internal-auth-mode]: https://docs.voxel51.com/teams/pluggable_auth.html#internal-mode
 [labels-and-selectors]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-[legacy-auth-mode]: topher/document-install-modal-override
+[legacy-auth-mode]: https://docs.voxel51.com/teams/pluggable_auth.html#legacy-mode
 [node-selector]: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
 [ports]: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
 [probes]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -660,7 +660,7 @@ A minimal example `values.yaml` may be found
 [ingress]: https://kubernetes.io/docs/concepts/services-networking/ingress/
 [internal-auth-mode]: https://docs.voxel51.com/teams/pluggable_auth.html#internal-mode
 [labels-and-selectors]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-[legacy-auth-mode]: topher/document-install-modal-override
+[legacy-auth-mode]: https://docs.voxel51.com/teams/pluggable_auth.html#legacy-mode
 [node-selector]: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
 [ports]: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
 [probes]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/


### PR DESCRIPTION
# Rationale

Not sure where that other link came from, but I did a great job of putting the same weird link everywhere!
## Changes

fixes legacy-auth-mode link

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
