### PR TITLE
[AS-143] skaffold v1.7.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,10 +79,10 @@ delete:  ## Delete minikube
 	minikube delete
 
 dev: helm-repos  ## run skaffold dev
-	skaffold dev
+	skaffold dev --kube-context minikube
 
 dev-keep: helm-repos  ## run skaffold dev with keep-runining-on-failure
-	skaffold dev --keep-running-on-failure
+	skaffold dev --keep-running-on-failure --kube-context minikube
 
 port-forward-app:  ## port forward the service `teams-app` on the host port 3000
 	kubectl port-forward --namespace fiftyone-teams svc/teams-app 3000:80 --context minikube
@@ -94,18 +94,21 @@ port-forward-mongo:  ## port forward to service `mongodb` on the host port 27017
 	kubectl port-forward --namespace fiftyone-teams svc/mongodb 27017:27017 --context minikube
 
 run: helm-repos  ## run skaffold run
-	skaffold run
+	skaffold run --kube-context minikube
 
 run-cert-manager: helm-repos  ## run skaffold run
 	skaffold run \
-	  --filename skaffold-cert-manager.yaml
+	  --filename skaffold-cert-manager.yaml \
+	  --kube-context minikube
 
 run-mongodb: helm-repos  ## run skaffold run
 	skaffold run \
-	  --filename skaffold-mongodb.yaml
+	  --filename skaffold-mongodb.yaml \
+	  --kube-context minikube
 
 run-profile-only-fiftyone: helm-repos  ## run skaffold run -p only-fiftyone
-	skaffold run -p only-fiftyone
+	skaffold run -p only-fiftyone \
+	  --kube-context minikube
 
 tunnel:  ## run minikube tunnel to access the k8s ingress via localhost ()
 	sudo minikube tunnel &> /dev/null &

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -48,12 +48,8 @@ deploy:
               # See https://console.cloud.google.com/artifacts/docker/computer-vision-team/us-central1/dev-docker?project=computer-vision-team
               repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-teams-api
               pullPolicy: IfNotPresent
-              tag: v1.7.1rc0
-            service:
-              liveness:
-                initialDelaySeconds: 15
-              readiness:
-                initialDelaySeconds: 15
+              tag: v1.7.1rc5
+
           appSettings:
             env:
               # Only set to true during the initial installation or during a database upgrade
@@ -68,12 +64,8 @@ deploy:
               # See https://console.cloud.google.com/artifacts/docker/computer-vision-team/us-central1/dev-docker?project=computer-vision-team
               repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-app
               pullPolicy: IfNotPresent
-              tag: v1.7.1rc0
-            service:
-              liveness:
-                initialDelaySeconds: 15
-              readiness:
-                initialDelaySeconds: 15
+              tag: v1.7.1rc5
+
           # TODO: Test `minikube addons configure registry-creds` or
           # When using minikube's addon registry-creds, we may also need to create the k8s secret `regcred`
           # See https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -152,12 +144,8 @@ deploy:
               # See https://console.cloud.google.com/artifacts/docker/computer-vision-team/us-central1/dev-docker?project=computer-vision-team
               repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-app
               pullPolicy: IfNotPresent
-              tag: v1.7.1rc0
-            service:
-              liveness:
-                initialDelaySeconds: 15
-              readiness:
-                initialDelaySeconds: 15
+              tag: v1.7.1rc5
+
           teamsAppSettings:
             dnsName: local.fiftyone.ai
             # env:
@@ -174,12 +162,8 @@ deploy:
               # The others are `vW.X.Y.devZ` (note `.devZ` vs `-dev.Z`).
               # This is a byproduct of `npm` versioning versus Python PEP 440.
               pullPolicy: IfNotPresent
-              tag: v1.7.1-rc.0
-            service:
-              liveness:
-                initialDelaySeconds: 15
-              readiness:
-                initialDelaySeconds: 15
+              tag: v1.7.1-rc.4
+
           casSettings:
             env:
               DEBUG: cas:*
@@ -187,10 +171,6 @@ deploy:
               # See https://console.cloud.google.com/artifacts/docker/computer-vision-team/us-central1/dev-docker?project=computer-vision-team
               repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-teams-cas
               pullPolicy: IfNotPresent
-              tag: v1.7.1-rc.0
-            service:
-              liveness:
-                initialDelaySeconds: 15
-              readiness:
-                initialDelaySeconds: 15
+              tag: v1.7.1-rc.4
+
   kubeContext: minikube


### PR DESCRIPTION
# Rationale

In #136, I tried to update skaffold for v1.6.1 but encountered app errors that have since been fixed.  So let's try this again.

## Changes

* skaffold
  * Update chart version for 1.7.1
  * Change image tags to 1.7.1 to rc builds
  * Remove setting the service probes (since those are now chart defaults)
* Makefile
  * Add `--kube-context` to skaffold commands to avoid deploying to the users current kubernetes context

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

No! This is Helm only.

## Testing

1. Deploy the app to k8s

    ```shell
    make delete start dev-keep
    ```

1. Start a minikube tunnel, in another terminal 

    ```shell
    sudo minikube tunnel
    ```

1. Navigate to https://local.fiftyone.ai and login
1. Get redirected to the datasets page 

## Screenshots

See? No infinite redirects!!

![Screenshot 2024-06-05 at 12 05 29 PM](https://github.com/voxel51/fiftyone-teams-app-deploy/assets/56850465/32b89f2f-66d6-45d8-8a68-2bb52df53f74)

## Related

* #136