### PR TITLE
chore(deps): bump docker/login-action from 3.1.0 to 3.2.0

### DIFF
--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -46,7 +46,7 @@ jobs:
           token_format: access_token
           workload_identity_provider: ${{ secrets.ORG_GOOGLE_WORKLOAD_IDP }}
       - name: Login to GAR
-        uses: docker/login-action@v3.1.0
+        uses: docker/login-action@v3.2.0
         with:
           registry: us-central1-docker.pkg.dev
           username: oauth2accesstoken
@@ -74,7 +74,7 @@ jobs:
           token_format: access_token
           workload_identity_provider: ${{ secrets.ORG_GOOGLE_WORKLOAD_IDP }}
       - name: Login to GAR
-        uses: docker/login-action@v3.1.0
+        uses: docker/login-action@v3.2.0
         with:
           registry: us-central1-docker.pkg.dev
           username: oauth2accesstoken


### PR DESCRIPTION
# Rationale

Like #157 created by dependabot, but, hopefully the pr checks tests will pass.

## Changes

Bumps [docker/login-action](https://github.com/docker/login-action) from 3.1.0 to 3.2.0.
- [Release notes](https://github.com/docker/login-action/releases)
- [Commits](https://github.com/docker/login-action/compare/v3.1.0...v3.2.0)

---
updated-dependencies:
- dependency-name: docker/login-action dependency-type: direct:production update-type: version-update:semver-minor ...

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
