### PR TITLE
SDK/Database update instructions for upgrading to v1.7.1 from v1.6.0 or later

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -612,11 +612,16 @@ modify your existing configuration to migrate to a new Auth0 Tenant.
         ```
 
 1. [Upgrade to FiftyOne Teams version 1.7.1](#deploying-fiftyone-teams)
-1. Upgrade FiftyOne Teams SDK users to FiftyOne Teams version 0.17.1
+1. If desired, upgrade FiftyOne Teams SDK users to FiftyOne Teams version 0.17.1
     - Login to the FiftyOne Teams UI
     - To obtain the CLI command to install the FiftyOne SDK associated with
       your FiftyOne Teams version, navigate to `Account > Install FiftyOne`
-1. Have the admin run this to upgrade all datasets
+1. Check your database and dataset compatibility versions:
+
+    ```shell
+    fiftyone migrate --info
+    ```
+1. If desired, have an admin run this to upgrade all datasets to compatibility version 0.24.0
 
     ```shell
     FIFTYONE_DATABASE_ADMIN=true fiftyone migrate --all
@@ -625,11 +630,6 @@ modify your existing configuration to migrate to a new Auth0 Tenant.
     - **NOTE** Any FiftyOne SDK less than 0.17.0 will lose database connectivity
       at this point.
 
-1. To ensure that all datasets are now at version 0.24.0, run
-
-    ```shell
-    fiftyone migrate --info
-    ```
 
 ## Deploying FiftyOne Teams
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -612,7 +612,8 @@ modify your existing configuration to migrate to a new Auth0 Tenant.
         ```
 
 1. [Upgrade to FiftyOne Teams version 1.7.1](#deploying-fiftyone-teams)
-1. If desired, upgrade FiftyOne Teams SDK users to FiftyOne Teams version 0.17.1
+1. (Recommended to [stay up to date](https://docs.voxel51.com/release-notes.html#fiftyone-teams-1-7-1))
+   Upgrade FiftyOne Teams SDK users to FiftyOne Teams version 0.17.1
     - Login to the FiftyOne Teams UI
     - To obtain the CLI command to install the FiftyOne SDK associated with
       your FiftyOne Teams version, navigate to `Account > Install FiftyOne`
@@ -622,7 +623,8 @@ modify your existing configuration to migrate to a new Auth0 Tenant.
     fiftyone migrate --info
     ```
 
-1. If desired, have an admin run this to upgrade all datasets to compatibility version 0.24.0
+1. (Optional, Recommended) If your database is listed with a version prior to 0.24.0,
+   have an admin run this to upgrade all datasets to compatibility version 0.24.0
 
     ```shell
     FIFTYONE_DATABASE_ADMIN=true fiftyone migrate --all

--- a/docker/README.md
+++ b/docker/README.md
@@ -621,6 +621,7 @@ modify your existing configuration to migrate to a new Auth0 Tenant.
     ```shell
     fiftyone migrate --info
     ```
+
 1. If desired, have an admin run this to upgrade all datasets to compatibility version 0.24.0
 
     ```shell
@@ -629,7 +630,6 @@ modify your existing configuration to migrate to a new Auth0 Tenant.
 
     - **NOTE** Any FiftyOne SDK less than 0.17.0 will lose database connectivity
       at this point.
-
 
 ## Deploying FiftyOne Teams
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -622,8 +622,8 @@ modify your existing configuration to migrate to a new Auth0 Tenant.
     FIFTYONE_DATABASE_ADMIN=true fiftyone migrate --all
     ```
 
-    - **NOTE** Any FiftyOne SDK less than 0.17.1 will lose database connectivity
-      at this point. Upgrading to `fiftyone==0.17.1` is required
+    - **NOTE** Any FiftyOne SDK less than 0.17.0 will lose database connectivity
+      at this point.
 
 1. To ensure that all datasets are now at version 0.24.0, run
 

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -771,24 +771,25 @@ or modify your existing configuration to migrate to a new Auth0 Tenant.
         ```
 
 1. [Upgrade to FiftyOne Teams version 1.7.1](#deploying-fiftyone-teams)
-1. Upgrade FiftyOne Teams SDK users to FiftyOne Teams version 0.17.1
+1. If desired, upgrade FiftyOne Teams SDK users to FiftyOne Teams version 0.17.1
     - Login to the FiftyOne Teams UI
     - To obtain the CLI command to install the FiftyOne SDK associated with
       your FiftyOne Teams version, navigate to `Account > Install FiftyOne`
-1. Upgrade all the datasets
-    > **NOTE** Any FiftyOne SDK less than 0.17.1
-    > will lose connectivity at this point.
-    > Upgrading to `fiftyone==0.17.1` is required.
+1. Check your database and dataset compatibility versions:
+
+    ```shell
+    fiftyone migrate --info
+    ```
+1. If desired, have an admin run this to upgrade all datasets to compatibility version 0.24.0
 
     ```shell
     FIFTYONE_DATABASE_ADMIN=true fiftyone migrate --all
     ```
 
-1. Validate that all datasets are now at version 0.24.0
+    - **NOTE** Any FiftyOne SDK less than 0.17.0 will lose database connectivity
+      at this point.
 
-    ```shell
-    fiftyone migrate --info
-    ```
+
 
 ## Deploying FiftyOne Teams
 

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -771,7 +771,8 @@ or modify your existing configuration to migrate to a new Auth0 Tenant.
         ```
 
 1. [Upgrade to FiftyOne Teams version 1.7.1](#deploying-fiftyone-teams)
-1. If desired, upgrade FiftyOne Teams SDK users to FiftyOne Teams version 0.17.1
+1. (Recommended to [stay up to date](https://docs.voxel51.com/release-notes.html#fiftyone-teams-1-7-1))
+   Upgrade FiftyOne Teams SDK users to FiftyOne Teams version 0.17.1
     - Login to the FiftyOne Teams UI
     - To obtain the CLI command to install the FiftyOne SDK associated with
       your FiftyOne Teams version, navigate to `Account > Install FiftyOne`
@@ -781,7 +782,8 @@ or modify your existing configuration to migrate to a new Auth0 Tenant.
     fiftyone migrate --info
     ```
 
-1. If desired, have an admin run this to upgrade all datasets to compatibility version 0.24.0
+1. (Optional, Recommended) If your database is listed with a version prior to 0.24.0,
+   have an admin run this to upgrade all datasets to compatibility version 0.24.0
 
     ```shell
     FIFTYONE_DATABASE_ADMIN=true fiftyone migrate --all

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -780,6 +780,7 @@ or modify your existing configuration to migrate to a new Auth0 Tenant.
     ```shell
     fiftyone migrate --info
     ```
+
 1. If desired, have an admin run this to upgrade all datasets to compatibility version 0.24.0
 
     ```shell
@@ -788,8 +789,6 @@ or modify your existing configuration to migrate to a new Auth0 Tenant.
 
     - **NOTE** Any FiftyOne SDK less than 0.17.0 will lose database connectivity
       at this point.
-
-
 
 ## Deploying FiftyOne Teams
 

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -595,24 +595,23 @@ or modify your existing configuration to migrate to a new Auth0 Tenant.
         ```
 
 1. [Upgrade to FiftyOne Teams version 1.7.1](#deploying-fiftyone-teams)
-1. Upgrade FiftyOne Teams SDK users to FiftyOne Teams version 0.17.1
+1. If desired, upgrade FiftyOne Teams SDK users to FiftyOne Teams version 0.17.1
     - Login to the FiftyOne Teams UI
     - To obtain the CLI command to install the FiftyOne SDK associated with
       your FiftyOne Teams version, navigate to `Account > Install FiftyOne`
-1. Upgrade all the datasets
-    > **NOTE** Any FiftyOne SDK less than 0.17.1
-    > will lose connectivity at this point.
-    > Upgrading to `fiftyone==0.17.1` is required.
+1. Check your database and dataset compatibility versions:
+
+    ```shell
+    fiftyone migrate --info
+    ```
+1. If desired, have an admin run this to upgrade all datasets to compatibility version 0.24.0
 
     ```shell
     FIFTYONE_DATABASE_ADMIN=true fiftyone migrate --all
     ```
 
-1. Validate that all datasets are now at version 0.24.0
-
-    ```shell
-    fiftyone migrate --info
-    ```
+    - **NOTE** Any FiftyOne SDK less than 0.17.0 will lose database connectivity
+      at this point.
 
 ## Deploying FiftyOne Teams
 

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -595,7 +595,8 @@ or modify your existing configuration to migrate to a new Auth0 Tenant.
         ```
 
 1. [Upgrade to FiftyOne Teams version 1.7.1](#deploying-fiftyone-teams)
-1. If desired, upgrade FiftyOne Teams SDK users to FiftyOne Teams version 0.17.1
+1. (Recommended to [stay up to date](https://docs.voxel51.com/release-notes.html#fiftyone-teams-1-7-1))
+   Upgrade FiftyOne Teams SDK users to FiftyOne Teams version 0.17.1
     - Login to the FiftyOne Teams UI
     - To obtain the CLI command to install the FiftyOne SDK associated with
       your FiftyOne Teams version, navigate to `Account > Install FiftyOne`
@@ -604,7 +605,9 @@ or modify your existing configuration to migrate to a new Auth0 Tenant.
     ```shell
     fiftyone migrate --info
     ```
-1. If desired, have an admin run this to upgrade all datasets to compatibility version 0.24.0
+
+1. (Optional, Recommended) If your database is listed with a version prior to 0.24.0,
+   have an admin run this to upgrade all datasets to compatibility version 0.24.0
 
     ```shell
     FIFTYONE_DATABASE_ADMIN=true fiftyone migrate --all


### PR DESCRIPTION
# Rationale
Attempting to be more precise and practically relevant in describing SDK/DB compatibility and upgrade instructions.

## Changes

- When upgrading from v1.6.0 or later to v1.7.1, the DB compatibility version is not changing; so SDK upgrades are optional. 
- When upgrading from v1.6.0 or later to v1.7.1, DB/dataset migrations are also optional.
- Specify correct lower-bound SDK version (0.17.0) below which connectivity will be lost with DB compatibility version 0.24.0 

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

## Testing
## Screenshots
## To Do
## Notes
## Related