### PR TITLE
chore(deps): bump actions/checkout from 4.1.6 to 4.1.7

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,7 +11,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.6
+      - uses: actions/checkout@v4.1.7
       - uses: actions/setup-python@v5.1.0
       - name: install asdf & tools
         uses: asdf-vm/actions/install@v3.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.6
+        uses: actions/checkout@v4.1.7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -19,7 +19,7 @@ jobs:
   unit-compose:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.6
+      - uses: actions/checkout@v4.1.7
       - uses: actions/setup-python@v5.1.0
       - name: install asdf & tools
         uses: asdf-vm/actions/install@v3.0.2
@@ -33,7 +33,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.6
+      - uses: actions/checkout@v4.1.7
       - uses: actions/setup-python@v5.1.0
       - name: install asdf & tools
         uses: asdf-vm/actions/install@v3.0.2
@@ -61,7 +61,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.6
+      - uses: actions/checkout@v4.1.7
       - uses: actions/setup-python@v5.1.0
       - name: install asdf & tools
         uses: asdf-vm/actions/install@v3.0.2

--- a/.github/workflows/test-helm.yml
+++ b/.github/workflows/test-helm.yml
@@ -17,7 +17,7 @@ jobs:
   unit-helm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.6
+      - uses: actions/checkout@v4.1.7
       - uses: actions/setup-python@v5.1.0
       - name: install asdf & tools
         uses: asdf-vm/actions/install@v3.0.2


### PR DESCRIPTION
# Rationale

dependabot opened #167, but the PR checks don't run.  After cherry picking the commit into this branch, the PR checks will run.

Bumps [actions/checkout](https://github.com/actions/checkout) from 4.1.6 to 4.1.7.
- [Release notes](https://github.com/actions/checkout/releases)
- [Changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
- [Commits](https://github.com/actions/checkout/compare/v4.1.6...v4.1.7)

---
updated-dependencies:
- dependency-name: actions/checkout dependency-type: direct:production update-type: version-update:semver-patch ...

## Changes

* GitHub Action checkout upgrade from v4.1.6 to v4.1.7

## Testing

This PR's checks

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

## Related

Like https://github.com/voxel51/fiftyone-teams-app-deploy/pull/167 but this will allow the PR checks to run.

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
