### PR TITLE
serverPathPrefix isn`t used and isn`t useful

### DIFF
--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -600,7 +600,6 @@ appSettings:
 | teamsAppSettings.replicaCount | int | `2` | Number of pods in the teams-app deployment's ReplicaSet. Ignored when `teamsAppSettings.autoscaling.enabled: true`. [Reference][deployment]. |
 | teamsAppSettings.resources | object | `{"limits":{},"requests":{}}` | Container resource requests and limits for teams-app. [Reference][resources]. |
 | teamsAppSettings.securityContext | object | `{}` | Container security configuration for teams-app. [Reference][container-security-context]. |
-| teamsAppSettings.serverPathPrefix | string | `"/"` | Prefix for path-based Ingress routing for teams-app. |
 | teamsAppSettings.service.annotations | object | `{}` | Service annotations for teams-app. [Reference][annotations]. |
 | teamsAppSettings.service.containerPort | int | `3000` | Service container port for teams-app. |
 | teamsAppSettings.service.liveness.initialDelaySeconds | int | `15` | Number of seconds to wait before performing the liveness probe for teams-app. [Reference][probes]. |

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -545,9 +545,6 @@ teamsAppSettings:
     requests: {}
     #   cpu: 500m
     #   memory: 1Gi
-  # TODO: add `serverPathPrefix` to `./templates/_helpers.tpl`. [AS-74]
-  # -- Prefix for path-based Ingress routing for teams-app.
-  serverPathPrefix: /
   service:
     # -- Service annotations for teams-app. [Reference][annotations].
     annotations: {}


### PR DESCRIPTION
# Rationale

`serverPathPrefix` was never actually plumbed into our helpers, and isn't configurable in the context of Teams.

This just removes the unused configuration parameter (and associated TODO) from the `values.yaml` (which also updates the docs)

## Changes

removes unused `teamsAppSettings.serverPathPrefix`

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

## Testing

PR testing below, searched for instances of `serverPathPrefix` after change and none found

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
