### PR TITLE
chore(deps): bump actions/setup-python from 5.1.0 to 5.1.1

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.7
-      - uses: actions/setup-python@v5.1.0
+      - uses: actions/setup-python@v5.1.1
       - name: install asdf & tools
         uses: asdf-vm/actions/install@v3.0.2
       - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.7
-      - uses: actions/setup-python@v5.1.0
+      - uses: actions/setup-python@v5.1.1
       - name: install asdf & tools
         uses: asdf-vm/actions/install@v3.0.2
       - name: Run unit tests
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.7
-      - uses: actions/setup-python@v5.1.0
+      - uses: actions/setup-python@v5.1.1
       - name: install asdf & tools
         uses: asdf-vm/actions/install@v3.0.2
       - name: Authenticate to Google Cloud
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.7
-      - uses: actions/setup-python@v5.1.0
+      - uses: actions/setup-python@v5.1.1
       - name: install asdf & tools
         uses: asdf-vm/actions/install@v3.0.2
       - name: Authenticate to Google Cloud

--- a/.github/workflows/test-helm.yml
+++ b/.github/workflows/test-helm.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.7
-      - uses: actions/setup-python@v5.1.0
+      - uses: actions/setup-python@v5.1.1
       - name: install asdf & tools
         uses: asdf-vm/actions/install@v3.0.2
       - name: Run unit tests


### PR DESCRIPTION
# Rationale

bumps actions/setup-python from 5.1.0 to 5.1.1

This is a replacement for [PR 172](https://github.com/voxel51/fiftyone-teams-app-deploy/pull/172) to allow integration tests to run

## Changes

bumps actions/setup-python from 5.1.0 to 5.1.1

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

## Testing

GitHub Actions running on this PR

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
