### PR TITLE
Docs: Add notes for CAS Database name uniqueness for multiple depoyments using same database host

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -189,6 +189,9 @@ A brief summary of those changes include
   - `CAS_DEBUG`
   - `CAS_DEFAULT_USER_ROLE`
 
+> **NOTE**: When multiple deployments use the same database instance,
+> set `CAS_DATABASE_NAME` to a unique value for each deployment.
+
 Please review these changes in the
 [legacy-auth/env.template](legacy-auth/env.template)
 and in the appropriate `legacy-auth/compose*` files.

--- a/docker/legacy-auth/env.template
+++ b/docker/legacy-auth/env.template
@@ -66,6 +66,8 @@ APP_BIND_PORT=3000
 CAS_BASE_URL=http://teams-cas:3000/cas/api
 CAS_BIND_ADDRESS=127.0.0.1
 CAS_BIND_PORT=3030
+# When multiple deployments use the same database instance,
+# set `CAS_DATABASE_NAME` to a unique value for each deployment.
 CAS_DATABASE_NAME=fiftyone-cas
 # CAS_DEBUG defines what CAS logs to display
 # e.g. `cas:*` - shows all cas logs

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -486,7 +486,7 @@ appSettings:
 | appSettings.volumes | list | `[]` | Volumes for fiftyone-app. [Reference][volumes]. |
 | casSettings.affinity | object | `{}` | Affinity and anti-affinity for teams-cas. [Reference][affinity]. |
 | casSettings.enable_invitations | bool | `true` | Allow ADMINs to invite users by email NOTE: This is currently not supported when `FIFTYONE_AUTH_MODE: internal` |
-| casSettings.env.CAS_DATABASE_NAME | string | `"cas"` | Provide the name for the CAS database |
+| casSettings.env.CAS_DATABASE_NAME | string | `"cas"` | Provide the name for the CAS database. When multiple deployments use the same database instance, set `CAS_DATABASE_NAME` to a unique value for each deployment. |
 | casSettings.env.CAS_DEFAULT_USER_ROLE | string | `"GUEST"` | Set the default user role for new users One of `GUEST`, `COLLABORATOR`, `MEMBER`, `ADMIN` |
 | casSettings.env.CAS_MONGODB_URI_KEY | string | `"mongodbConnectionString"` | The key from `secret.fiftyone.name` that contains the CAS MongoDB Connection String. |
 | casSettings.env.DEBUG | string | `"cas:*,-cas:*:debug"` | Set the log level for CAS examples: `DEBUG: cas:*` - shows all CAS logs `DEBUG: cas:*:info` - shows all CAS INFO logs `DEBUG: cas:*,-cas:*:debug` - shows all CAS logs except DEBUG logs |

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -365,7 +365,6 @@ To configure this, set the following environment variables on
 1. The deployments based on the `fiftyone-teams-app` (`teamsAppSettings.env`) or
    `fiftyone-teams-cas` (`casSettings.env`) images
 
-
     ```yaml
     GLOBAL_AGENT_HTTP_PROXY: http://proxy.yourcompany.tld:3128
     GLOBAL_AGENT_HTTPS_PROXY: https://proxy.yourconpay.tld:3128
@@ -382,7 +381,6 @@ To configure this, set the following environment variables on
     > **NOTE**: If you have overridden your service names with `*.service.name`
     > you will need to include the override service names in your
     > `GLOBAL_AGENT_NO_PROXY` configuration instead
-
 
 The `NO_PROXY`, `no_proxy`, and `GLOBAL_AGENT_NO_PROXY` values must include the
 Kubernetes service names that may communicate without going through a proxy

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -193,7 +193,9 @@ casSettings:
   enable_invitations: true
   # Environment Variables are passed to the teams-cas containers
   env:
-    # -- Provide the name for the CAS database
+    # -- Provide the name for the CAS database.
+    # When multiple deployments use the same database instance,
+    # set `CAS_DATABASE_NAME` to a unique value for each deployment.
     CAS_DATABASE_NAME: cas
     # -- Set the default user role for new users
     # One of `GUEST`, `COLLABORATOR`, `MEMBER`, `ADMIN`


### PR DESCRIPTION
# Rationale

A customer encountered redirect URL mismatch when upgrading their second deployment (using the same database host/instance).  In this scenario, the second deployment used the same CAS database.  The resolution was to set a unique value for `CAS_DATABASE_NAME` for the second deployment.  Let's document this

## Changes

* Add notes about colocating multiple deployments on the same database host requires setting unique values for `CAS_DATABASE_NAME`

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

## Testing

N/A - Docs only update.

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
