### PR TITLE
test: update helm integration test to dynamically create licensefile …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,13 @@ clean-unit-helm:  ## delete helm unit test output and reports
 	rm -rf tests/unit/helm/test_output || true
 	rm tests/unit/helm/test_output.log || true
 
+copy-license-file-docker:
+	gcloud storage cp gs://voxel51-test/licenses/299a423b/1/license.key ./docker/legacy-license.key
+	gcloud storage cp gs://voxel51-test/licenses/299a423b/1/license.key ./docker/internal-license.key
+
+copy-license-file-helm:
+	gcloud storage cp gs://voxel51-test/licenses/299a423b/1/license.key tests/fixtures/helm/internal-license.key
+
 dependencies-integration-compose:  ## create a (temporary) directory for mongodb container
 	mkdir -p /tmp/mongodb
 

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/voxel51/fiftyone-teams-app-deploy
 
-go 1.21.6
+go 1.22.3
 
 require (
 	github.com/compose-spec/compose-go/v2 v2.0.2

--- a/tests/integration/helm/common_test.go
+++ b/tests/integration/helm/common_test.go
@@ -6,7 +6,9 @@ package integration
 import (
 	"crypto/tls"
 
+	"encoding/base64"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -19,6 +21,7 @@ import (
 const (
 	chartPath         = "../../../helm/fiftyone-teams-app/"
 	integrationValues = "../../fixtures/helm/integration_values.yaml"
+	licenseFile       = "../../fixtures/helm/internal-license.key"
 	// for minikube, where node count is 1, we don't need ReadWriteMany and NFS
 	persistentVolumeYaml = `---
     apiVersion: v1
@@ -48,6 +51,16 @@ const (
         requests:
           storage: 100Mi
 `
+
+	// License File Secret
+	licenseFileSecretTemplateYaml = `---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: fiftyonelicense
+    type: Opaque
+    data:
+      license: `
 )
 
 type serviceValidations struct {
@@ -88,4 +101,13 @@ func makeLabels(labels map[string]string) string {
 		out = append(out, fmt.Sprintf("%s=%s", key, value))
 	}
 	return strings.Join(out, ",")
+}
+
+func getBase64EncodedStringOfFile(filePath string) string {
+	b, err := os.ReadFile(filePath)
+	if err != nil {
+		fmt.Print(err)
+	}
+	sEnc := base64.StdEncoding.EncodeToString(b)
+	return sEnc
 }

--- a/tests/integration/helm/helm-internal-auth_test.go
+++ b/tests/integration/helm/helm-internal-auth_test.go
@@ -231,6 +231,11 @@ func (s *internalAuthHelmTest) TestHelmInstall() {
 				k8s.KubectlApplyFromString(subT, kubectlOptions, persistentVolumeClaimYaml)
 			}
 
+			// create licensefile secret
+			base64EncodedLicenseFile := getBase64EncodedStringOfFile(licenseFile)
+			defer k8s.KubectlDeleteFromString(subT, kubectlOptions, licenseFileSecretTemplateYaml+base64EncodedLicenseFile)
+			k8s.KubectlApplyFromString(subT, kubectlOptions, licenseFileSecretTemplateYaml+base64EncodedLicenseFile)
+
 			helmOptions := &helm.Options{
 				KubectlOptions: kubectlOptions,
 				SetValues:      testCase.values,
@@ -250,8 +255,20 @@ func (s *internalAuthHelmTest) TestHelmInstall() {
 
 				// get deployment
 				deployment := k8s.GetDeployment(subT, kubectlOptions, expected.name)
+
+				waitTime := 5 * time.Second
+				retries := 72
+
+				// `teams-api` pod does not start successfully on the first attempt.
+				// extend the timeout to allow for it to be recreated and successfully start
+				if expected.name == "teams-api" {
+					waitTime = 60 * time.Second
+					retries = 6
+				}
+
 				// when pulling images for the first time, it may take longer than 90s
-				k8s.WaitUntilDeploymentAvailable(subT, kubectlOptions, deployment.Name, 72, 5*time.Second) // 360 seconds of retries. Pods typically ready in ~51 seconds if the image is already pulled.
+				// 360 seconds of retries. Pods typically ready in ~51 seconds if the image is already pulled.
+				k8s.WaitUntilDeploymentAvailable(subT, kubectlOptions, deployment.Name, retries, waitTime)
 
 				// get deployment match labels
 				selectorLabelsPods := makeLabels(deployment.Spec.Selector.MatchLabels)

--- a/tests/testing.md
+++ b/tests/testing.md
@@ -121,15 +121,12 @@ See
 ### Running Docker Compose Integration Tests
 
 1. Have Docker desktop running
-1. Copy the 'Voxel51 GitHub Legacy' license file to `docker/legacy-license.key`
-   You can retrieve this from the
-   [Voxel51 License Management](https://computer-vision-team.uc.r.appspot.com/)
-   UI
-1. Copy the 'Voxel51 GitHub Internal' license file to
-   `docker/internal-license.key`
-   You can retrieve this from the
-   [Voxel51 License Management](https://computer-vision-team.uc.r.appspot.com/)
-   UI
+1. Copy License files from Google Cloud Storage
+
+    ```shell
+    make copy-license-file-docker
+    ```
+
 1. Run tests
 
     ```shell
@@ -154,20 +151,18 @@ See
    (to expose the services within minikube outside of minikube)
 
     ```shell
-    make tunnel
+    sudo make tunnel
     ```
 
     > **NOTE**: This command will prompt for sudo permission
     > on systems where 80 and 443 are privileged ports
 
-1. Copy the 'Voxel51 GitHub Internal' license file and convert it to a
-   kubernetes secret
+1. Copy the 'Voxel51 GitHub Internal' license file for use by
+   integration tests that convert it to a kubernetes secret
+   in each ephemeral namespace created for each test case.
 
    ```shell
-   gcloud storage cp gs://voxel51-test/licenses/299a423b/1/license.key \
-     internal-license.key
-   kubectl --namespace your-namepace create secret generic fiftyonelicense \
-     --from-file=license=./internal-license.key
+   make copy-license-file-helm
    ```
 
 1. Run tests


### PR DESCRIPTION
# Rationale

PR #177 didn't account for our helm integration tests (that do not have PR checks).  The integration tests create an ephemeral namespace per test case.  The licensefile secret needs to be added to each namespace so it can be mounted as a volume.  So let's add a helper function to take the "secret" licencefile, base64 encode that file and create a secret with that being the value (using the terratest functions already in use).

While here, I noticed an difference in the `teams-api` deployment startup behavior and need to account for it by adjusting our delays and retries for it. After ~51 seconds the first attempt of the `teams-api` fails and gets a respawn.

## Changes

* Update `tests/go.mod` version from `1.21.6` to `1.22.3`
* Add constant for the helm fixture license file path (provided by the make targets)
* Add `os` and `encoding/base64` imports to support new function that reads local file returns a base64 encoded string
* Helm integration tests
  * Update to create secret (for each test case run) of the licensefile
  * For the `teams-api`, adjust the `waitTime` and `retries` to allow tests to pass
* Update `tests/testing.md` to be more instructive and less interpreted

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

N/A. It brings parity to Helm integration tests.

## Testing

Both compose and helm integration tests pass

<details>
<summary>Helm Integration Internal</summary>

```
$ make test-integration-helm-internal
=== RUN   TestHelmInternalAuth
=== PAUSE TestHelmInternalAuth
=== CONT  TestHelmInternalAuth
=== RUN   TestHelmInternalAuth/TestHelmInstall
=== RUN   TestHelmInternalAuth/TestHelmInstall/builtinPlugins
...
--- PASS: TestHelmInternalAuth (284.60s)
    --- PASS: TestHelmInternalAuth/TestHelmInstall (284.60s)
        --- PASS: TestHelmInternalAuth/TestHelmInstall/builtinPlugins (75.18s)
        --- PASS: TestHelmInternalAuth/TestHelmInstall/sharedPlugins (115.37s)
        --- PASS: TestHelmInternalAuth/TestHelmInstall/dedicatedPlugins (94.05s)
PASS
ok  	github.com/voxel51/fiftyone-teams-app-deploy/integration/helm	285.058s
```

</details>


<details>
<summary>Helm Integration Legacy</summary>

```
$ make test-integration-helm-legacy
=== RUN   TestHelmLegacyAuth
=== PAUSE TestHelmLegacyAuth
=== CONT  TestHelmLegacyAuth
=== RUN   TestHelmLegacyAuth/TestHelmInstall
=== RUN   TestHelmLegacyAuth/TestHelmInstall/builtinPlugins
...
--- PASS: TestHelmLegacyAuth (285.51s)
    --- PASS: TestHelmLegacyAuth/TestHelmInstall (285.51s)
        --- PASS: TestHelmLegacyAuth/TestHelmInstall/builtinPlugins (75.17s)
        --- PASS: TestHelmLegacyAuth/TestHelmInstall/sharedPlugins (115.89s)
        --- PASS: TestHelmLegacyAuth/TestHelmInstall/dedicatedPlugins (94.45s)
PASS
ok  	github.com/voxel51/fiftyone-teams-app-deploy/integration/helm	285.955s
```

</details>


<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
