### PR TITLE
In the future there may be multiple license files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,9 +137,6 @@ clean-unit-helm:  ## delete helm unit test output and reports
 	rm -rf tests/unit/helm/test_output || true
 	rm tests/unit/helm/test_output.log || true
 
-dependencies-integration-compose:  ## create a (temporary) directory for mongodb container
-	mkdir -p /tmp/mongodb
-
 login:  ## Docker login to Google Artifact Registry (for accessing internal gcr.io container images)
 	gcloud auth print-access-token | \
 	  docker login -u oauth2accesstoken \
@@ -167,11 +164,11 @@ test-unit-helm-interleaved: install-terratest-log-parser  ## run go test on the 
 
 test-integration-compose: test-integration-compose-internal test-integration-compose-legacy ## run go test on the tests/integration/compose directory for both internal and legacy auth modes
 
-test-integration-compose-internal: dependencies-integration-compose ## run go test on the tests/integration/compose directory for internal auth mode
+test-integration-compose-internal: ## run go test on the tests/integration/compose directory for internal auth mode
 	@cd tests/integration/compose; \
 	go test -count=1 -timeout=15m -v -tags integrationComposeInternalAuth
 
-test-integration-compose-legacy: dependencies-integration-compose ## run go test on the tests/integration/compose directory for legacy auth mode
+test-integration-compose-legacy: ## run go test on the tests/integration/compose directory for legacy auth mode
 	@cd tests/integration/compose; \
 	go test -count=1 -timeout=15m -v -tags integrationComposeLegacyAuth
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -21,12 +21,15 @@ previously provided through environment variables; you may remove those secrets
 from your `.env` and from any secrets created outside of the Voxel51
 install process.
 
-Copy the license file to your FiftyOne Teams docker compose host and set the
-`LOCAL_LICENSE_FILE_PATH` value in your `.env` to point at the license file.
+Set the `LOCAL_LICENSE_FILE_DIR` value in your .env file and copy the license
+file to the `LOCAL_LICENSE_FILE_DIR` directory on your FiftyOne Teams docker
+compose host.
 e.g.:
 
 ```shell
-LOCAL_LICENSE_FILE_PATH=/opt/fiftyone/license.key
+. .env
+mkdir -p "${LOCAL_LICENSE_FILE_DIR}"
+mv license.key "${LOCAL_LICENSE_FILE_DIR}/license"
 ```
 
 ## Known Issues for FiftyOne Teams v1.6.0 and Above
@@ -499,9 +502,17 @@ existing configuration to migrate to a new Auth0 Tenant.
     - `FIFTYONE_ENCRYPTION_KEY`
     - `FIFTYONE_API_URI`
     - `FIFTYONE_AUTH_SECRET`
-1. Copy the license file to your FiftyOne Teams docker compose host and set the
-   `LOCAL_LICENSE_FILE_PATH` value in your `.env` to point at the license file.
-    e.g.: `LOCAL_LICENSE_FILE_PATH=/opt/fiftyone/license.key`
+1. Set the `LOCAL_LICENSE_FILE_DIR` value in your .env file and copy the
+   license file to the `LOCAL_LICENSE_FILE_DIR` directory on your FiftyOne
+   Teams docker compose host.
+
+
+   ```shell
+   . .env
+   mkdir -p "${LOCAL_LICENSE_FILE_DIR}"
+   mv license.key "${LOCAL_LICENSE_FILE_DIR}/license"
+   ```
+
 1. Ensure your web server routes are updated to include routing
    `/cas/*` traffic to the `teams-cas` service.
    Example nginx configurations can be found
@@ -577,9 +588,16 @@ existing configuration to migrate to a new Auth0 Tenant.
     > the seed values from the `.env.template` file.
     > See
     > [Central Authentication Service](#central-authentication-service)
-1. Copy the license file to your FiftyOne Teams docker compose host and set the
-   `LOCAL_LICENSE_FILE_PATH` value in your `.env` to point at the license file.
-    e.g.: `LOCAL_LICENSE_FILE_PATH=/opt/fiftyone/license.key`
+1. Set the `LOCAL_LICENSE_FILE_DIR` value in your .env file and copy the
+   license file to the `LOCAL_LICENSE_FILE_DIR` directory on your FiftyOne
+   Teams docker compose host.
+
+   ```shell
+   . .env
+   mkdir -p "${LOCAL_LICENSE_FILE_DIR}"
+   mv license.key "${LOCAL_LICENSE_FILE_DIR}/license"
+   ```
+
 1. Ensure all FiftyOne SDK users either
     - Set the `FIFTYONE_DATABASE_ADMIN` to `false`
 
@@ -641,9 +659,16 @@ existing configuration to migrate to a new Auth0 Tenant.
         unset FIFTYONE_DATABASE_ADMIN
         ```
 
-1. Copy the license file to your FiftyOne Teams docker compose host and set the
-   `LOCAL_LICENSE_FILE_PATH` value in your `.env` to point at the license file.
-    e.g.: `LOCAL_LICENSE_FILE_PATH=/opt/fiftyone/license.key`
+1. Set the `LOCAL_LICENSE_FILE_DIR` value in your .env file and copy the
+   license file to the `LOCAL_LICENSE_FILE_DIR` directory on your FiftyOne
+   Teams docker compose host.
+
+   ```shell
+   . .env
+   mkdir -p "${LOCAL_LICENSE_FILE_DIR}"
+   mv license.key "${LOCAL_LICENSE_FILE_DIR}/license"
+   ```
+
 1. [Upgrade to FiftyOne Teams version 2.0.0](#deploying-fiftyone-teams)
 1. Upgrade FiftyOne Teams SDK users to FiftyOne Teams version 2.0.0
     - Login to the FiftyOne Teams UI
@@ -772,7 +797,7 @@ for the FiftyOne Teams API service.
 | `GRAPHQL_DEFAULT_LIMIT`                      | Default GraphQL limit for results                                                                                                                                                                                                                                              | No                        |
 | `HTTP_PROXY_URL`                             | The URL for your environment http proxy                                                                                                                                                                                                                                        | No                        |
 | `HTTPS_PROXY_URL`                            | The URL for your environment https proxy                                                                                                                                                                                                                                       | No                        |
-| `LOCAL_LICENSE_FILE_PATH`                    | Location of the FiftyOne Teams license file on the local server.                                                                                                                                                                                                               | Yes                          |
+| `LOCAL_LICENSE_FILE_DIR`                    | Location of the directory that contains the FiftyOne Teams license file on the local server.                                                                                                                                                                                                               | Yes                          |
 | `NO_PROXY_LIST`                              | The list of servers that should bypass the proxy; if a proxy is in use this must include the list of FiftyOne services (`fiftyone-app, teams-api,teams-app,teams-cas` must be included, `teams-plugins` should be included for dedicated plugins configurations)               | No                        |
 
 <!-- Reference Links -->

--- a/docker/README.md
+++ b/docker/README.md
@@ -506,7 +506,6 @@ existing configuration to migrate to a new Auth0 Tenant.
    license file to the `LOCAL_LICENSE_FILE_DIR` directory on your FiftyOne
    Teams docker compose host.
 
-
    ```shell
    . .env
    mkdir -p "${LOCAL_LICENSE_FILE_DIR}"

--- a/docker/common-services.yaml
+++ b/docker/common-services.yaml
@@ -98,7 +98,7 @@ services:
       CAS_MONGODB_URI: ${CAS_MONGO_DB_URI:-$FIFTYONE_DATABASE_URI}
       DEBUG: ${CAS_DEBUG:-cas:*,-cas:*:debug}
       FIFTYONE_AUTH_SECRET: ${FIFTYONE_AUTH_SECRET}
-      LICENSE_KEY_FILE_PATHS: /opt/fiftyone/license
+      LICENSE_KEY_FILE_PATHS: ${LICENSE_KEY_FILE_PATHS:-/opt/fiftyone/licenses/license}
       # If you are routing through a proxy server you will want to set
       #  HTTP_PROXY_URL, HTTPS_PROXY_URL, and NO_PROXY_LIST in your .env
       #  then add the following environment variables to your
@@ -118,8 +118,8 @@ services:
     restart: always
     volumes:
       - type: bind
-        source: ${LOCAL_LICENSE_FILE_PATH}
-        target: /opt/fiftyone/license
+        source: ${LOCAL_LICENSE_FILE_DIR}
+        target: /opt/fiftyone/licenses
         read_only: true
 
   teams-plugins-common:

--- a/docker/internal-auth/env.template
+++ b/docker/internal-auth/env.template
@@ -29,8 +29,13 @@ FIFTYONE_AUTH_SECRET=
 #
 FIFTYONE_ENCRYPTION_KEY=
 
-# The path to the FiftyOne license file
-LOCAL_LICENSE_FILE_PATH=/opt/fiftyone/license
+# The path to a local directory holding FiftyOne Teams license file(s)
+LOCAL_LICENSE_FILE_DIR=/some/directory/with/licenses/
+
+# An environment variable pointing to the FiftyOne Teams license file
+# If you name your license file `license` in the LOCAL_LICENSE_FILE_DIR
+#  defined above, you do not need to set this environment variable.
+# LICENSE_KEY_FILE_PATHS="/opt/fiftyone/licenses/license"
 
 # FiftyOne Teams API container configuration
 API_BIND_ADDRESS=127.0.0.1

--- a/docker/legacy-auth/env.template
+++ b/docker/legacy-auth/env.template
@@ -32,8 +32,13 @@ FIFTYONE_AUTH_SECRET=
 #
 FIFTYONE_ENCRYPTION_KEY=
 
-# The path to the FiftyOne license file
-LOCAL_LICENSE_FILE_PATH=/opt/fiftyone/license
+# The path to a local directory holding FiftyOne Teams license file(s)
+LOCAL_LICENSE_FILE_DIR=/some/directory/with/licenses/
+
+# An environment variable pointing to the FiftyOne Teams license file
+# If you name your license file `license` in the LOCAL_LICENSE_FILE_DIR
+#  defined above, you do not need to set this environment variable.
+# LICENSE_KEY_FILE_PATHS="/opt/fiftyone/licenses/license"
 
 # FiftyOne Teams API container configuration
 API_BIND_ADDRESS=127.0.0.1

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -37,8 +37,9 @@ Use the license file provided by the Voxel51 Customer Success Team to create
 a new license file secret:
 
 ```shell
-kubectl --namespace your-namepace create secret generic fiftyonelicense \
+kubectl --namespace your-namepace create secret generic fiftyone-license \
   --from-file=license=./your-license-file
+```
 
 ## Known Issues for FiftyOne Teams v1.6.0 and Above
 
@@ -491,7 +492,7 @@ appSettings:
 | casSettings.tolerations | list | `[]` | Allow the k8s scheduler to schedule teams-cas pods with matching taints. [Reference][taints-and-tolerations]. |
 | casSettings.volumeMounts | list | `[]` | Volume mounts for teams-cas. [Reference][volumes]. |
 | casSettings.volumes | list | `[]` | Volumes for teams-cas. [Reference][volumes]. |
-| fiftyoneLicenseSecrets | list | `["fiftyone-license"]` | Secret name for FiftyOne license |
+| fiftyoneLicenseSecrets | list | `["fiftyone-license"]` | List of secrets for FiftyOne Teams Licenses (one per org) |
 | imagePullSecrets | list | `[]` | Container image registry keys. [Reference][image-pull-secrets]. |
 | ingress.annotations | object | `{}` | Ingress annotations. [Reference][annotations]. |
 | ingress.api | object | `{"path":"/*","pathType":"ImplementationSpecific"}` | The ingress rule values for teams-api, when `apiSettings.dnsName` is not empty. [Reference][ingress-rules]. |
@@ -664,7 +665,7 @@ or modify your existing configuration to migrate to a new Auth0 Tenant.
    a new kubernetes secret:
 
     ```shell
-    kubectl --namespace your-namepace create secret generic fiftyonelicense \
+    kubectl --namespace your-namepace create secret generic fiftyone-license \
       --from-file=license=./your-license-file
     ```
 
@@ -736,7 +737,7 @@ or modify your existing configuration to migrate to a new Auth0 Tenant.
    a new kubernetes secret:
 
     ```shell
-    kubectl --namespace your-namepace create secret generic fiftyonelicense \
+    kubectl --namespace your-namepace create secret generic fiftyone-license \
       --from-file=license=./your-license-file
     ```
 
@@ -808,7 +809,7 @@ or modify your existing configuration to migrate to a new Auth0 Tenant.
    a new kubernetes secret:
 
     ```shell
-    kubectl --namespace your-namepace create secret generic fiftyonelicense \
+    kubectl --namespace your-namepace create secret generic fiftyone-license \
       --from-file=license=./your-license-file
     ```
 

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -491,7 +491,7 @@ appSettings:
 | casSettings.tolerations | list | `[]` | Allow the k8s scheduler to schedule teams-cas pods with matching taints. [Reference][taints-and-tolerations]. |
 | casSettings.volumeMounts | list | `[]` | Volume mounts for teams-cas. [Reference][volumes]. |
 | casSettings.volumes | list | `[]` | Volumes for teams-cas. [Reference][volumes]. |
-| fiftyoneLicenseSecret | string | `"fiftyonelicense"` | Secret name for FiftyOne license |
+| fiftyoneLicenseSecrets | list | `["fiftyone-license"]` | Secret name for FiftyOne license |
 | imagePullSecrets | list | `[]` | Container image registry keys. [Reference][image-pull-secrets]. |
 | ingress.annotations | object | `{}` | Ingress annotations. [Reference][annotations]. |
 | ingress.api | object | `{"path":"/*","pathType":"ImplementationSpecific"}` | The ingress rule values for teams-api, when `apiSettings.dnsName` is not empty. [Reference][ingress-rules]. |

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -39,8 +39,9 @@ Use the license file provided by the Voxel51 Customer Success Team to create
 a new license file secret:
 
 ```shell
-kubectl --namespace your-namepace create secret generic fiftyonelicense \
+kubectl --namespace your-namepace create secret generic fiftyone-license \
   --from-file=license=./your-license-file
+```
 
 ## Known Issues for FiftyOne Teams v1.6.0 and Above
 
@@ -492,7 +493,7 @@ or modify your existing configuration to migrate to a new Auth0 Tenant.
    a new kubernetes secret:
 
     ```shell
-    kubectl --namespace your-namepace create secret generic fiftyonelicense \
+    kubectl --namespace your-namepace create secret generic fiftyone-license \
       --from-file=license=./your-license-file
     ```
 
@@ -564,7 +565,7 @@ or modify your existing configuration to migrate to a new Auth0 Tenant.
    a new kubernetes secret:
 
     ```shell
-    kubectl --namespace your-namepace create secret generic fiftyonelicense \
+    kubectl --namespace your-namepace create secret generic fiftyone-license \
       --from-file=license=./your-license-file
     ```
 
@@ -636,7 +637,7 @@ or modify your existing configuration to migrate to a new Auth0 Tenant.
    a new kubernetes secret:
 
     ```shell
-    kubectl --namespace your-namepace create secret generic fiftyonelicense \
+    kubectl --namespace your-namepace create secret generic fiftyone-license \
       --from-file=license=./your-license-file
     ```
 

--- a/helm/fiftyone-teams-app/templates/_helpers.tpl
+++ b/helm/fiftyone-teams-app/templates/_helpers.tpl
@@ -275,8 +275,9 @@ Create a string that contains all license files to be created in the
 {{- if $i }}
 {{- $licensePaths = print $licensePaths "," }}
 {{- end }}
-{{- $licensePaths = print "/opt/fiftyone/licenses/" $name }}
+{{- $licensePaths = print $licensePaths "/opt/fiftyone/licenses/" $name }}
 {{- end }}
+{{- print $licensePaths }}
 {{- end }}
 
 {{/*

--- a/helm/fiftyone-teams-app/templates/_helpers.tpl
+++ b/helm/fiftyone-teams-app/templates/_helpers.tpl
@@ -266,6 +266,20 @@ Create a merged list of environment variables for fiftyone-app
 {{- end -}}
 
 {{/*
+Create a string that contains all license files to be created in the
+`teams-cas` deployment
+*/}}
+{{- define "teams-cas.license-key-file-paths" }}
+{{- $licensePaths := "" }}
+{{- range $i, $name := .Values.fiftyoneLicenseSecrets }}
+{{- if $i }}
+{{- $licensePaths = print $licensePaths "," }}
+{{- end }}
+{{- $licensePaths = print "/opt/fiftyone/licenses/" $name }}
+{{- end }}
+{{- end }}
+
+{{/*
 Create a merged list of environment variables for fiftyone-teams-cas
 */}}
 {{- define "teams-cas.env-vars-list" -}}
@@ -283,7 +297,7 @@ Create a merged list of environment variables for fiftyone-teams-cas
       name: {{ $secretName }}
       key: fiftyoneAuthSecret
 - name: LICENSE_KEY_FILE_PATHS
-  value: "/opt/fiftyone/license"
+  value: {{ include "teams-cas.license-key-file-paths" . | quote }}
 - name: NEXTAUTH_URL
   value: {{ printf "https://%s/cas/api/auth" .Values.teamsAppSettings.dnsName | quote }}
 {{- if eq .Values.casSettings.env.FIFTYONE_AUTH_MODE "legacy" }}

--- a/helm/fiftyone-teams-app/templates/cas-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/cas-deployment.yaml
@@ -53,9 +53,11 @@ spec:
           resources:
             {{- toYaml .Values.casSettings.resources | nindent 12 }}
           volumeMounts:
-            - name: fiftyonelicensefile
-              mountPath: /opt/fiftyone
+            {{- range $name := .Values.fiftyoneLicenseSecrets }}
+            - name: {{ print $name }}
+              mountPath: /opt/fiftyone/licenses
               readOnly: true
+            {{- end }}
               {{- with .Values.casSettings.volumeMounts }}
               {{- toYaml . | nindent 12 }}
               {{- end }}
@@ -72,12 +74,14 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
-        - name: fiftyonelicensefile
+        {{- range $name := .Values.fiftyoneLicenseSecrets }}
+        - name: {{ print $name }}
           secret:
-            secretName: {{ .Values.fiftyoneLicenseSecret }}
+            secretName: {{ print $name }}
             items:
               - key: license
-                path: license
+                path: {{ print $name }}
+        {{- end }}
         {{- with .Values.casSettings.volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -278,7 +278,8 @@ casSettings:
   volumes: []
 
 # -- Secret name for FiftyOne license
-fiftyoneLicenseSecret: fiftyonelicense
+fiftyoneLicenseSecrets:
+  - fiftyone-license
 
 # -- Container image registry keys. [Reference][image-pull-secrets].
 imagePullSecrets: []

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -277,7 +277,7 @@ casSettings:
   # -- Volumes for teams-cas. [Reference][volumes].
   volumes: []
 
-# -- Secret name for FiftyOne license
+# -- List of secrets for FiftyOne Teams Licenses (one per org)
 fiftyoneLicenseSecrets:
   - fiftyone-license
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -14,10 +14,10 @@
 # # to create a fiftyoneLicenseSecret:
 # #
 # # ```shell
-# #  kubectl --namespace your-namepace create secret generic fiftyonelicense \
+# #  kubectl --namespace your-namepace create secret generic fiftyone-license \
 # #    --from-file=license=./your-license-file
 # # ```
-# # Then set the name of your license file secret here:
+# # Then set the name(s) of your license file secret(s) here (one per org):
 fiftyoneLicenseSecrets:
   - fiftyone-license
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -18,7 +18,8 @@
 # #    --from-file=license=./your-license-file
 # # ```
 # # Then set the name of your license file secret here:
-fiftyoneLicenseSecret: fiftyonelicense
+fiftyoneLicenseSecrets:
+  - fiftyone-license
 
 secret:
   fiftyone:

--- a/tests/fixtures/docker/compose.override.mongodb.yaml
+++ b/tests/fixtures/docker/compose.override.mongodb.yaml
@@ -20,6 +20,6 @@ services:
       - MONGO_INITDB_ROOT_PASSWORD=${MONGODB_PASSWORD}
       - MONGO_INITDB_ROOT_USERNAME=${MONGODB_USERNAME}
     volumes:
-      - type: bind
-        source: ${MONGODB_DIR}
-        target: /data/db
+      - mongodbvol:/data/db
+volumes:
+  mongodbvol:

--- a/tests/fixtures/docker/integration_internal_auth.env
+++ b/tests/fixtures/docker/integration_internal_auth.env
@@ -4,8 +4,13 @@
 FIFTYONE_DATABASE_URI='mongodb://root:3-9XjJ-gUV%3Fvp%5Ee%28WUk%3ELD%26lAjh7yEji@mongodb/?authSource=admin'  # This is a randomly generated password # pragma: allowlist secret
 FIFTYONE_ENCRYPTION_KEY="btv8BiFCaPIayWU3IU3a_Lm_EMIIk-t6H_yN1ORV45o=" # This is a randomly generated string # pragma: allowlist secret
 
-# The path to the FiftyOne license file
-LOCAL_LICENSE_FILE_PATH=./internal-license.key
+# The path to a local directory holding FiftyOne Teams license file(s)
+LOCAL_LICENSE_FILE_DIR=./
+
+# An environment variable pointing to the FiftyOne Teams license file
+# If you name your license file `license` in the LOCAL_LICENSE_FILE_DIR
+#  defined above, you do not need to set this environment variable.
+LICENSE_KEY_FILE_PATHS="/opt/fiftyone/licenses/internal-license.key"# The path to the FiftyOne license file
 
 # Internal Auth
 FIFTYONE_AUTH_SECRET="test-fiftyone-auth-secret"
@@ -13,7 +18,6 @@ FIFTYONE_AUTH_SECRET="test-fiftyone-auth-secret"
 # MongoDB
 MONGODB_PASSWORD='3-9XjJ-gUV?vp^e(WUk>LD&lAjh7yEji' # This is a randomly generated string  # pragma: allowlist secret
 MONGODB_USERNAME=root
-MONGODB_DIR=/tmp/mongodb
 MONGODB_BIND_ADDRESS=127.0.0.1
 
 

--- a/tests/fixtures/docker/integration_legacy_auth.env
+++ b/tests/fixtures/docker/integration_legacy_auth.env
@@ -13,8 +13,13 @@ AUTH0_BASE_URL=http://local.fiftyone.ai
 FIFTYONE_DATABASE_URI='mongodb://root:3-9XjJ-gUV%3Fvp%5Ee%28WUk%3ELD%26lAjh7yEji@mongodb/?authSource=admin'  # This is a randomly generated password # pragma: allowlist secret
 FIFTYONE_ENCRYPTION_KEY="btv8BiFCaPIayWU3IU3a_Lm_EMIIk-t6H_yN1ORV45o=" # This is a randomly generated string # pragma: allowlist secret
 
-# The path to the FiftyOne license file
-LOCAL_LICENSE_FILE_PATH=./legacy-license.key
+# The path to a local directory holding FiftyOne Teams license file(s)
+LOCAL_LICENSE_FILE_DIR=./
+
+# An environment variable pointing to the FiftyOne Teams license file
+# If you name your license file `license` in the LOCAL_LICENSE_FILE_DIR
+#  defined above, you do not need to set this environment variable.
+LICENSE_KEY_FILE_PATHS="/opt/fiftyone/licenses/legacy-license.key"
 
 # Internal Auth
 FIFTYONE_AUTH_SECRET="test-fiftyone-auth-secret"
@@ -22,7 +27,6 @@ FIFTYONE_AUTH_SECRET="test-fiftyone-auth-secret"
 # MongoDB
 MONGODB_PASSWORD='3-9XjJ-gUV?vp^e(WUk>LD&lAjh7yEji' # This is a randomly generated string  # pragma: allowlist secret
 MONGODB_USERNAME=root
-MONGODB_DIR=/tmp/mongodb
 MONGODB_BIND_ADDRESS=127.0.0.1
 
 APP_USE_HTTPS=false

--- a/tests/integration/compose/docker-compose-internal-auth_test.go
+++ b/tests/integration/compose/docker-compose-internal-auth_test.go
@@ -249,6 +249,7 @@ func (s *commonServicesInternalAuthDockerComposeUpTest) TestDockerComposeUp() {
 			argsUp = append(argsUp, "up", "--detach")
 			argsDown = append(argsDown, args...)
 			argsDown = append(argsDown, "down", "--remove-orphans", "--timeout", "2")
+			argsDown = append(argsDown, "--volumes")
 
 			// Config
 			docker.RunDockerCompose(

--- a/tests/integration/compose/docker-compose-legacy-auth_test.go
+++ b/tests/integration/compose/docker-compose-legacy-auth_test.go
@@ -249,6 +249,7 @@ func (s *commonServicesLegacyAuthDockerComposeUpTest) TestDockerComposeUp() {
 			argsUp = append(argsUp, "up", "--detach")
 			argsDown = append(argsDown, args...)
 			argsDown = append(argsDown, "down", "--remove-orphans", "--timeout", "2")
+			argsDown = append(argsDown, "--volumes")
 
 			// Config
 			docker.RunDockerCompose(

--- a/tests/unit/compose/docker-compose-internal-auth_test.go
+++ b/tests/unit/compose/docker-compose-internal-auth_test.go
@@ -286,7 +286,7 @@ func (s *commonServicesInternalAuthDockerComposeTest) TestServiceEnvironment() {
 				"DEBUG=cas:*,-cas:*:debug",
 				"FIFTYONE_AUTH_MODE=internal",
 				"FIFTYONE_AUTH_SECRET=test-fiftyone-auth-secret",
-				"LICENSE_KEY_FILE_PATHS=/opt/fiftyone/license",
+				"LICENSE_KEY_FILE_PATHS=/opt/fiftyone/licenses/license",
 				"NEXTAUTH_URL=https://example.fiftyone.ai/cas/api/auth",
 			},
 		},
@@ -366,7 +366,7 @@ func (s *commonServicesInternalAuthDockerComposeTest) TestServiceEnvironment() {
 				"DEBUG=cas:*,-cas:*:debug",
 				"FIFTYONE_AUTH_MODE=internal",
 				"FIFTYONE_AUTH_SECRET=test-fiftyone-auth-secret",
-				"LICENSE_KEY_FILE_PATHS=/opt/fiftyone/license",
+				"LICENSE_KEY_FILE_PATHS=/opt/fiftyone/licenses/license",
 				"NEXTAUTH_URL=https://example.fiftyone.ai/cas/api/auth",
 			},
 		},
@@ -445,7 +445,7 @@ func (s *commonServicesInternalAuthDockerComposeTest) TestServiceEnvironment() {
 				"DEBUG=cas:*,-cas:*:debug",
 				"FIFTYONE_AUTH_MODE=internal",
 				"FIFTYONE_AUTH_SECRET=test-fiftyone-auth-secret",
-				"LICENSE_KEY_FILE_PATHS=/opt/fiftyone/license",
+				"LICENSE_KEY_FILE_PATHS=/opt/fiftyone/licenses/license",
 				"NEXTAUTH_URL=https://example.fiftyone.ai/cas/api/auth",
 			},
 		},
@@ -727,8 +727,8 @@ func (s *commonServicesInternalAuthDockerComposeTest) TestServiceVolumes() {
 			[]types.ServiceVolumeConfig{
 				{
 					Type:        "bind",
-					Source:      "/opt/fiftyone/license",
-					Target:      "/opt/fiftyone/license",
+					Source:      "/some/directory/with/licenses/",
+					Target:      "/opt/fiftyone/licenses",
 					ReadOnly:    true,
 					Consistency: "",
 				},
@@ -779,8 +779,8 @@ func (s *commonServicesInternalAuthDockerComposeTest) TestServiceVolumes() {
 			[]types.ServiceVolumeConfig{
 				{
 					Type:        "bind",
-					Source:      "/opt/fiftyone/license",
-					Target:      "/opt/fiftyone/license",
+					Source:      "/some/directory/with/licenses/",
+					Target:      "/opt/fiftyone/licenses",
 					ReadOnly:    true,
 					Consistency: "",
 				},
@@ -824,8 +824,8 @@ func (s *commonServicesInternalAuthDockerComposeTest) TestServiceVolumes() {
 			[]types.ServiceVolumeConfig{
 				{
 					Type:        "bind",
-					Source:      "/opt/fiftyone/license",
-					Target:      "/opt/fiftyone/license",
+					Source:      "/some/directory/with/licenses/",
+					Target:      "/opt/fiftyone/licenses",
 					ReadOnly:    true,
 					Consistency: "",
 				},

--- a/tests/unit/compose/docker-compose-legacy-auth_test.go
+++ b/tests/unit/compose/docker-compose-legacy-auth_test.go
@@ -285,7 +285,7 @@ func (s *commonServicesLegacyAuthDockerComposeTest) TestServiceEnvironment() {
 				"CAS_URL=https://example.fiftyone.ai",
 				"DEBUG=cas:*,-cas:*:debug",
 				"FIFTYONE_AUTH_SECRET=test-fiftyone-auth-secret",
-				"LICENSE_KEY_FILE_PATHS=/opt/fiftyone/license",
+				"LICENSE_KEY_FILE_PATHS=/opt/fiftyone/licenses/license",
 				"NEXTAUTH_URL=https://example.fiftyone.ai/cas/api/auth",
 				"TEAMS_API_DATABASE_NAME=fiftyone",
 				"TEAMS_API_MONGODB_URI=mongodb://root:test-secret@mongodb.local/?authSource=admin",
@@ -362,7 +362,7 @@ func (s *commonServicesLegacyAuthDockerComposeTest) TestServiceEnvironment() {
 				"CAS_URL=https://example.fiftyone.ai",
 				"DEBUG=cas:*,-cas:*:debug",
 				"FIFTYONE_AUTH_SECRET=test-fiftyone-auth-secret",
-				"LICENSE_KEY_FILE_PATHS=/opt/fiftyone/license",
+				"LICENSE_KEY_FILE_PATHS=/opt/fiftyone/licenses/license",
 				"NEXTAUTH_URL=https://example.fiftyone.ai/cas/api/auth",
 				"TEAMS_API_DATABASE_NAME=fiftyone",
 				"TEAMS_API_MONGODB_URI=mongodb://root:test-secret@mongodb.local/?authSource=admin",
@@ -442,7 +442,7 @@ func (s *commonServicesLegacyAuthDockerComposeTest) TestServiceEnvironment() {
 				"CAS_URL=https://example.fiftyone.ai",
 				"DEBUG=cas:*,-cas:*:debug",
 				"FIFTYONE_AUTH_SECRET=test-fiftyone-auth-secret",
-				"LICENSE_KEY_FILE_PATHS=/opt/fiftyone/license",
+				"LICENSE_KEY_FILE_PATHS=/opt/fiftyone/licenses/license",
 				"NEXTAUTH_URL=https://example.fiftyone.ai/cas/api/auth",
 				"TEAMS_API_DATABASE_NAME=fiftyone",
 				"TEAMS_API_MONGODB_URI=mongodb://root:test-secret@mongodb.local/?authSource=admin",
@@ -521,7 +521,7 @@ func (s *commonServicesLegacyAuthDockerComposeTest) TestServiceEnvironment() {
 				"CAS_URL=https://example.fiftyone.ai",
 				"DEBUG=cas:*,-cas:*:debug",
 				"FIFTYONE_AUTH_SECRET=test-fiftyone-auth-secret",
-				"LICENSE_KEY_FILE_PATHS=/opt/fiftyone/license",
+				"LICENSE_KEY_FILE_PATHS=/opt/fiftyone/licenses/license",
 				"NEXTAUTH_URL=https://example.fiftyone.ai/cas/api/auth",
 				"TEAMS_API_DATABASE_NAME=fiftyone",
 				"TEAMS_API_MONGODB_URI=mongodb://root:test-secret@mongodb.local/?authSource=admin",
@@ -810,8 +810,8 @@ func (s *commonServicesLegacyAuthDockerComposeTest) TestServiceVolumes() {
 			[]types.ServiceVolumeConfig{
 				{
 					Type:        "bind",
-					Source:      "/opt/fiftyone/license",
-					Target:      "/opt/fiftyone/license",
+					Source:      "/some/directory/with/licenses/",
+					Target:      "/opt/fiftyone/licenses",
 					ReadOnly:    true,
 					Consistency: "",
 				},
@@ -862,8 +862,8 @@ func (s *commonServicesLegacyAuthDockerComposeTest) TestServiceVolumes() {
 			[]types.ServiceVolumeConfig{
 				{
 					Type:        "bind",
-					Source:      "/opt/fiftyone/license",
-					Target:      "/opt/fiftyone/license",
+					Source:      "/some/directory/with/licenses/",
+					Target:      "/opt/fiftyone/licenses",
 					ReadOnly:    true,
 					Consistency: "",
 				},
@@ -907,8 +907,8 @@ func (s *commonServicesLegacyAuthDockerComposeTest) TestServiceVolumes() {
 			[]types.ServiceVolumeConfig{
 				{
 					Type:        "bind",
-					Source:      "/opt/fiftyone/license",
-					Target:      "/opt/fiftyone/license",
+					Source:      "/some/directory/with/licenses/",
+					Target:      "/opt/fiftyone/licenses",
 					ReadOnly:    true,
 					Consistency: "",
 				},


### PR DESCRIPTION
# Rationale

For release v2.0.0 we only support a single organization, but in the future there may be multiple organizations which require multiple license files.

Rather than release one mechanism for a single license file and make everybody change over later, this PR sets us up for multiple license files in the future.

## Changes

- Refactor mongodb integration-compose tests to use a volume that is destroyed on `down`
    -   I was getting failures because `/tmp/mongodb` had corrupted database files in it
- Refactor helm chart to take a list of secret names and create a `LICENSE_KEY_FILE_PATHS` env var
- Refactor compose to mount a directory and require a `LICENSE_KEY_FILE_PATHS` env var
- Update documentation without reference to multiple license files as it's not yet supported

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

## Testing

[release cloud-build-and-deploy](https://console.cloud.google.com/cloud-build/builds/56fb48c3-e327-4897-bf35-691f41726d41?project=computer-vision-team)
<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
