### PR TITLE
test: update helm integration test to dynamically create licensefile (retry) [AS-215]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,7 +76,7 @@ repos:
       - id: detect-secrets
         args:
           - --exclude-secrets
-          - '(password|REPLACEME|fiftyone-teams-tls-secret|3-9XjJ-gUV?vp\^e\(WUk>LD&lAjh7yEji|btv8BiFCaPIayWU3IU3a_Lm_EMIIk-t6H_yN1ORV45o=|5b32118032bfd50b64b3cc7c0e0821f4e84f63ad517a9687ac2b6ce6ab261976|aGM4\?s&t-n;\!\*U96oA#bdo,\+JU\)ac1T7|test-*|/api/proxy/fiftyone-teams|/opt/plugins|fiftyone-license|fiftyone-license|LICENSE_KEY_FILE_PATHS)'
+          - '(password|REPLACEME|fiftyone-teams-tls-secret|3-9XjJ-gUV?vp\^e\(WUk>LD&lAjh7yEji|btv8BiFCaPIayWU3IU3a_Lm_EMIIk-t6H_yN1ORV45o=|5b32118032bfd50b64b3cc7c0e0821f4e84f63ad517a9687ac2b6ce6ab261976|aGM4\?s&t-n;\!\*U96oA#bdo,\+JU\)ac1T7|test-*|/api/proxy/fiftyone-teams|/opt/plugins|fiftyone-license|LICENSE_KEY_FILE_PATHS)'
   - repo: https://github.com/dnephin/pre-commit-golang
     rev: v0.5.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,7 +76,7 @@ repos:
       - id: detect-secrets
         args:
           - --exclude-secrets
-          - '(password|REPLACEME|fiftyone-teams-tls-secret|3-9XjJ-gUV?vp\^e\(WUk>LD&lAjh7yEji|btv8BiFCaPIayWU3IU3a_Lm_EMIIk-t6H_yN1ORV45o=|5b32118032bfd50b64b3cc7c0e0821f4e84f63ad517a9687ac2b6ce6ab261976|aGM4\?s&t-n;\!\*U96oA#bdo,\+JU\)ac1T7|test-*|/api/proxy/fiftyone-teams|/opt/plugins|fiftyonelicense|fiftyone-license|LICENSE_KEY_FILE_PATHS)'
+          - '(password|REPLACEME|fiftyone-teams-tls-secret|3-9XjJ-gUV?vp\^e\(WUk>LD&lAjh7yEji|btv8BiFCaPIayWU3IU3a_Lm_EMIIk-t6H_yN1ORV45o=|5b32118032bfd50b64b3cc7c0e0821f4e84f63ad517a9687ac2b6ce6ab261976|aGM4\?s&t-n;\!\*U96oA#bdo,\+JU\)ac1T7|test-*|/api/proxy/fiftyone-teams|/opt/plugins|fiftyone-license|fiftyone-license|LICENSE_KEY_FILE_PATHS)'
   - repo: https://github.com/dnephin/pre-commit-golang
     rev: v0.5.1
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,16 @@ clean-unit-helm:  ## delete helm unit test output and reports
 	rm -rf tests/unit/helm/test_output || true
 	rm tests/unit/helm/test_output.log || true
 
+copy-license-file-docker:
+	gcloud storage cp gs://voxel51-test/licenses/299a423b/1/license.key ./docker/legacy-license.key
+	gcloud storage cp gs://voxel51-test/licenses/299a423b/1/license.key ./docker/internal-license.key
+
+copy-license-file-helm:
+	gcloud storage cp gs://voxel51-test/licenses/299a423b/1/license.key tests/fixtures/helm/internal-license.key
+
+dependencies-integration-compose:  ## create a (temporary) directory for mongodb container
+	mkdir -p /tmp/mongodb
+
 login:  ## Docker login to Google Artifact Registry (for accessing internal gcr.io container images)
 	gcloud auth print-access-token | \
 	  docker login -u oauth2accesstoken \

--- a/Makefile
+++ b/Makefile
@@ -137,15 +137,25 @@ clean-unit-helm:  ## delete helm unit test output and reports
 	rm -rf tests/unit/helm/test_output || true
 	rm tests/unit/helm/test_output.log || true
 
-copy-license-file-docker:
-	gcloud storage cp gs://voxel51-test/licenses/299a423b/1/license.key ./docker/legacy-license.key
-	gcloud storage cp gs://voxel51-test/licenses/299a423b/1/license.key ./docker/internal-license.key
+copy-license-files-docker:  ## copy local developer license files used during docker compose integration tests
+	gcloud storage cp \
+	  gs://voxel51-test/licenses/299a423b/1/license.key \
+	  ./docker/legacy-license.key \
+	  --project computer-vision-team
+	gcloud storage cp \
+	  gs://voxel51-test/licenses/299a423b/1/license.key \
+	  ./docker/internal-license.key \
+	  --project computer-vision-team
 
-copy-license-file-helm:
-	gcloud storage cp gs://voxel51-test/licenses/299a423b/1/license.key tests/fixtures/helm/internal-license.key
-
-dependencies-integration-compose:  ## create a (temporary) directory for mongodb container
-	mkdir -p /tmp/mongodb
+copy-license-files-helm:  ## copy local developer license files used during helm integration tests
+	gcloud storage cp \
+	  gs://voxel51-test/licenses/299a423b/1/license.key \
+	  tests/fixtures/helm/legacy-license.key
+	  --project computer-vision-team
+	gcloud storage cp \
+	  gs://voxel51-test/licenses/299a423b/1/license.key \
+	  tests/fixtures/helm/internal-license.key
+	  --project computer-vision-team
 
 login:  ## Docker login to Google Artifact Registry (for accessing internal gcr.io container images)
 	gcloud auth print-access-token | \
@@ -174,23 +184,23 @@ test-unit-helm-interleaved: install-terratest-log-parser  ## run go test on the 
 
 test-integration-compose: test-integration-compose-internal test-integration-compose-legacy ## run go test on the tests/integration/compose directory for both internal and legacy auth modes
 
-test-integration-compose-internal: ## run go test on the tests/integration/compose directory for internal auth mode
+test-integration-compose-internal: copy-license-files-docker ## run go test on the tests/integration/compose directory for internal auth mode
 	@cd tests/integration/compose; \
 	go test -count=1 -timeout=15m -v -tags integrationComposeInternalAuth
 
-test-integration-compose-legacy: ## run go test on the tests/integration/compose directory for legacy auth mode
+test-integration-compose-legacy: copy-license-files-docker ## run go test on the tests/integration/compose directory for legacy auth mode
 	@cd tests/integration/compose; \
 	go test -count=1 -timeout=15m -v -tags integrationComposeLegacyAuth
 
 test-integration-compose-interleaved:  test-integration-compose-interleaved-internal test-integration-compose-interleaved-legacy  ## run go test on the tests/integration/compose directory and run the terratest_log_parser for reports
 
-test-integration-compose-interleaved-internal: install-terratest-log-parser dependencies-integration-compose clean-integration-compose ## run go test on the tests/integration/compose directory for internal auth mode and run the terratest_log_parser for reports
+test-integration-compose-interleaved-internal: install-terratest-log-parser copy-license-files-docker clean-integration-compose ## run go test on the tests/integration/compose directory for internal auth mode and run the terratest_log_parser for reports
 	@cd tests/integration/compose; \
 	rm -rf test_output_internal/*; \
 	go test -count=1 -timeout=15m -v -tags integrationComposeInternalAuth | tee test_output_internal.log; \
 	${ASDF}/packages/bin/terratest_log_parser -testlog test_output_internal.log -outputdir test_output_internal
 
-test-integration-compose-interleaved-legacy: install-terratest-log-parser dependencies-integration-compose clean-integration-compose ## run go test on the tests/integration/compose directory for legacy auth mode and run the terratest_log_parser for reports
+test-integration-compose-interleaved-legacy: install-terratest-log-parser copy-license-files-docker clean-integration-compose ## run go test on the tests/integration/compose directory for legacy auth mode and run the terratest_log_parser for reports
 	@cd tests/integration/compose; \
 	rm -rf test_output_legacy/*; \
 	go test -count=1 -timeout=15m -v -tags integrationComposeLegacyAuth | tee test_output_legacy.log; \

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/voxel51/fiftyone-teams-app-deploy
 
-go 1.21.6
+go 1.22.3
 
 require (
 	github.com/compose-spec/compose-go/v2 v2.0.2

--- a/tests/integration/helm/common_test.go
+++ b/tests/integration/helm/common_test.go
@@ -19,9 +19,10 @@ import (
 )
 
 const (
-	chartPath         = "../../../helm/fiftyone-teams-app/"
-	integrationValues = "../../fixtures/helm/integration_values.yaml"
-	licenseFile       = "../../fixtures/helm/internal-license.key"
+	chartPath           = "../../../helm/fiftyone-teams-app/"
+	integrationValues   = "../../fixtures/helm/integration_values.yaml"
+	licenseFileInternal = "../../fixtures/helm/internal-license.key"
+	licenseFileLegacy   = "../../fixtures/helm/legacy-license.key"
 	// for minikube, where node count is 1, we don't need ReadWriteMany and NFS
 	persistentVolumeYaml = `---
     apiVersion: v1

--- a/tests/integration/helm/common_test.go
+++ b/tests/integration/helm/common_test.go
@@ -6,7 +6,9 @@ package integration
 import (
 	"crypto/tls"
 
+	"encoding/base64"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -19,6 +21,7 @@ import (
 const (
 	chartPath         = "../../../helm/fiftyone-teams-app/"
 	integrationValues = "../../fixtures/helm/integration_values.yaml"
+	licenseFile       = "../../fixtures/helm/internal-license.key"
 	// for minikube, where node count is 1, we don't need ReadWriteMany and NFS
 	persistentVolumeYaml = `---
     apiVersion: v1
@@ -48,6 +51,16 @@ const (
         requests:
           storage: 100Mi
 `
+
+	// License File Secret
+	licenseFileSecretTemplateYaml = `---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: fiftyonelicense
+    type: Opaque
+    data:
+      license: `
 )
 
 type serviceValidations struct {
@@ -88,4 +101,13 @@ func makeLabels(labels map[string]string) string {
 		out = append(out, fmt.Sprintf("%s=%s", key, value))
 	}
 	return strings.Join(out, ",")
+}
+
+func getBase64EncodedStringOfFile(filePath string) string {
+	b, err := os.ReadFile(filePath)
+	if err != nil {
+		fmt.Print(err)
+	}
+	sEnc := base64.StdEncoding.EncodeToString(b)
+	return sEnc
 }

--- a/tests/integration/helm/common_test.go
+++ b/tests/integration/helm/common_test.go
@@ -58,7 +58,7 @@ const (
     apiVersion: v1
     kind: Secret
     metadata:
-      name: fiftyonelicense
+      name: fiftyone-license
     type: Opaque
     data:
       license: `

--- a/tests/integration/helm/helm-internal-auth_test.go
+++ b/tests/integration/helm/helm-internal-auth_test.go
@@ -231,6 +231,11 @@ func (s *internalAuthHelmTest) TestHelmInstall() {
 				k8s.KubectlApplyFromString(subT, kubectlOptions, persistentVolumeClaimYaml)
 			}
 
+			// create licensefile secret
+			base64EncodedLicenseFile := getBase64EncodedStringOfFile(licenseFile)
+			defer k8s.KubectlDeleteFromString(subT, kubectlOptions, licenseFileSecretTemplateYaml+base64EncodedLicenseFile)
+			k8s.KubectlApplyFromString(subT, kubectlOptions, licenseFileSecretTemplateYaml+base64EncodedLicenseFile)
+
 			helmOptions := &helm.Options{
 				KubectlOptions: kubectlOptions,
 				SetValues:      testCase.values,
@@ -250,8 +255,20 @@ func (s *internalAuthHelmTest) TestHelmInstall() {
 
 				// get deployment
 				deployment := k8s.GetDeployment(subT, kubectlOptions, expected.name)
+
+				waitTime := 5 * time.Second
+				retries := 72
+
+				// `teams-api` pod does not start successfully on the first attempt.
+				// extend the timeout to allow for it to be recreated and successfully start
+				if expected.name == "teams-api" {
+					waitTime = 60 * time.Second
+					retries = 6
+				}
+
 				// when pulling images for the first time, it may take longer than 90s
-				k8s.WaitUntilDeploymentAvailable(subT, kubectlOptions, deployment.Name, 72, 5*time.Second) // 360 seconds of retries. Pods typically ready in ~51 seconds if the image is already pulled.
+				// 360 seconds of retries. Pods typically ready in ~51 seconds if the image is already pulled.
+				k8s.WaitUntilDeploymentAvailable(subT, kubectlOptions, deployment.Name, retries, waitTime)
 
 				// get deployment match labels
 				selectorLabelsPods := makeLabels(deployment.Spec.Selector.MatchLabels)

--- a/tests/integration/helm/helm-internal-auth_test.go
+++ b/tests/integration/helm/helm-internal-auth_test.go
@@ -231,8 +231,8 @@ func (s *internalAuthHelmTest) TestHelmInstall() {
 				k8s.KubectlApplyFromString(subT, kubectlOptions, persistentVolumeClaimYaml)
 			}
 
-			// create licensefile secret
-			base64EncodedLicenseFile := getBase64EncodedStringOfFile(licenseFile)
+			// create license-file secret
+			base64EncodedLicenseFile := getBase64EncodedStringOfFile(licenseFileInternal)
 			defer k8s.KubectlDeleteFromString(subT, kubectlOptions, licenseFileSecretTemplateYaml+base64EncodedLicenseFile)
 			k8s.KubectlApplyFromString(subT, kubectlOptions, licenseFileSecretTemplateYaml+base64EncodedLicenseFile)
 

--- a/tests/integration/helm/helm-legacy-auth_test.go
+++ b/tests/integration/helm/helm-legacy-auth_test.go
@@ -231,8 +231,8 @@ func (s *legacyAuthHelmTest) TestHelmInstall() {
 				k8s.KubectlApplyFromString(subT, kubectlOptions, persistentVolumeClaimYaml)
 			}
 
-			// create licensefile secret
-			base64EncodedLicenseFile := getBase64EncodedStringOfFile(licenseFile)
+			// create license-file secret
+			base64EncodedLicenseFile := getBase64EncodedStringOfFile(licenseFileLegacy)
 			defer k8s.KubectlDeleteFromString(subT, kubectlOptions, licenseFileSecretTemplateYaml+base64EncodedLicenseFile)
 			k8s.KubectlApplyFromString(subT, kubectlOptions, licenseFileSecretTemplateYaml+base64EncodedLicenseFile)
 

--- a/tests/testing.md
+++ b/tests/testing.md
@@ -121,11 +121,6 @@ See
 ### Running Docker Compose Integration Tests
 
 1. Have Docker desktop running
-1. Copy License files from Google Cloud Storage
-
-    ```shell
-    make copy-license-file-docker
-    ```
 
 1. Run tests
 
@@ -156,14 +151,6 @@ See
 
     > **NOTE**: This command will prompt for sudo permission
     > on systems where 80 and 443 are privileged ports
-
-1. Copy the 'Voxel51 GitHub Internal' license file for use by
-   integration tests that convert it to a kubernetes secret
-   in each ephemeral namespace created for each test case.
-
-   ```shell
-   make copy-license-file-helm
-   ```
 
 1. Run tests
 

--- a/tests/testing.md
+++ b/tests/testing.md
@@ -121,15 +121,12 @@ See
 ### Running Docker Compose Integration Tests
 
 1. Have Docker desktop running
-1. Copy the 'Voxel51 GitHub Legacy' license file to `docker/legacy-license.key`
-   You can retrieve this from the
-   [Voxel51 License Management](https://computer-vision-team.uc.r.appspot.com/)
-   UI
-1. Copy the 'Voxel51 GitHub Internal' license file to
-   `docker/internal-license.key`
-   You can retrieve this from the
-   [Voxel51 License Management](https://computer-vision-team.uc.r.appspot.com/)
-   UI
+1. Copy License files from Google Cloud Storage
+
+    ```shell
+    make copy-license-file-docker
+    ```
+
 1. Run tests
 
     ```shell
@@ -154,20 +151,18 @@ See
    (to expose the services within minikube outside of minikube)
 
     ```shell
-    make tunnel
+    sudo make tunnel
     ```
 
     > **NOTE**: This command will prompt for sudo permission
     > on systems where 80 and 443 are privileged ports
 
-1. Copy the 'Voxel51 GitHub Internal' license file and convert it to a
-   kubernetes secret
+1. Copy the 'Voxel51 GitHub Internal' license file for use by
+   integration tests that convert it to a kubernetes secret
+   in each ephemeral namespace created for each test case.
 
    ```shell
-   gcloud storage cp gs://voxel51-test/licenses/299a423b/1/license.key \
-     internal-license.key
-   kubectl --namespace your-namepace create secret generic fiftyonelicense \
-     --from-file=license=./internal-license.key
+   make copy-license-file-helm
    ```
 
 1. Run tests

--- a/tests/unit/helm/cas-deployment_test.go
+++ b/tests/unit/helm/cas-deployment_test.go
@@ -497,7 +497,7 @@ func (s *deploymentCasTemplateTest) TestContainerEnv() {
 		{
 			"multipleLicenses",
 			map[string]string{
-				"fiftyoneLicenseSecrets[0]": "fiftyone-license",
+				"fiftyoneLicenseSecrets[0]": "fiftyonelicense",
 				"fiftyoneLicenseSecrets[1]": "another-fiftyone-license",
 			},
 			func(envVars []corev1.EnvVar) {
@@ -526,7 +526,7 @@ func (s *deploymentCasTemplateTest) TestContainerEnv() {
           },
           {
             "name": "LICENSE_KEY_FILE_PATHS",
-            "value": "/opt/fiftyone/licenses/fiftyone-license,/opt/fiftyone/licenses/another-fiftyone-license"
+            "value": "/opt/fiftyone/licenses/fiftyonelicense,/opt/fiftyone/licenses/another-fiftyone-license"
           },
           {
             "name": "NEXTAUTH_URL",

--- a/tests/unit/helm/cas-deployment_test.go
+++ b/tests/unit/helm/cas-deployment_test.go
@@ -497,7 +497,7 @@ func (s *deploymentCasTemplateTest) TestContainerEnv() {
 		{
 			"multipleLicenses",
 			map[string]string{
-				"fiftyoneLicenseSecrets[0]": "fiftyonelicense",
+				"fiftyoneLicenseSecrets[0]": "fiftyone-license",
 				"fiftyoneLicenseSecrets[1]": "another-fiftyone-license",
 			},
 			func(envVars []corev1.EnvVar) {
@@ -526,7 +526,7 @@ func (s *deploymentCasTemplateTest) TestContainerEnv() {
           },
           {
             "name": "LICENSE_KEY_FILE_PATHS",
-            "value": "/opt/fiftyone/licenses/fiftyonelicense,/opt/fiftyone/licenses/another-fiftyone-license"
+            "value": "/opt/fiftyone/licenses/fiftyone-license,/opt/fiftyone/licenses/another-fiftyone-license"
           },
           {
             "name": "NEXTAUTH_URL",
@@ -1121,13 +1121,13 @@ func (s *deploymentCasTemplateTest) TestContainerVolumeMounts() {
 		{
 			"multipleLicenseFiles",
 			map[string]string{
-				"fiftyoneLicenseSecrets[0]": "fiftyonelicense",
+				"fiftyoneLicenseSecrets[0]": "fiftyone-license",
 				"fiftyoneLicenseSecrets[1]": "another-fiftyone-license",
 			},
 			func(volumeMounts []corev1.VolumeMount) {
 				expectedJSON := `[
           {
-            "name": "fiftyonelicense",
+            "name": "fiftyone-license",
             "mountPath": "/opt/fiftyone/licenses",
             "readOnly": true
           },


### PR DESCRIPTION
# Rationale

Like #178, but addresses all of @findtopher's PR comments.  For details, see the description of that PR.

## Changes

* In addition, finished replacement of `licencefile` to `license-file`

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

## Testing

```shell
$ make test-integration-helm
=== RUN   TestHelmInternalAuth
=== PAUSE TestHelmInternalAuth
=== CONT  TestHelmInternalAuth
=== RUN   TestHelmInternalAuth/TestHelmInstall
=== RUN   TestHelmInternalAuth/TestHelmInstall/builtinPlugins
...
--- PASS: TestHelmInternalAuth (383.09s)
    --- PASS: TestHelmInternalAuth/TestHelmInstall (383.09s)
        --- PASS: TestHelmInternalAuth/TestHelmInstall/builtinPlugins (182.95s)
        --- PASS: TestHelmInternalAuth/TestHelmInstall/sharedPlugins (105.86s)
        --- PASS: TestHelmInternalAuth/TestHelmInstall/dedicatedPlugins (94.28s)
PASS
ok  	github.com/voxel51/fiftyone-teams-app-deploy/integration/helm	383.526s
=== RUN   TestHelmLegacyAuth
=== PAUSE TestHelmLegacyAuth
=== CONT  TestHelmLegacyAuth
=== RUN   TestHelmLegacyAuth/TestHelmInstall
=== RUN   TestHelmLegacyAuth/TestHelmInstall/builtinPlugins
...
--- PASS: TestHelmLegacyAuth (275.58s)
    --- PASS: TestHelmLegacyAuth/TestHelmInstall (275.58s)
        --- PASS: TestHelmLegacyAuth/TestHelmInstall/builtinPlugins (74.89s)
        --- PASS: TestHelmLegacyAuth/TestHelmInstall/sharedPlugins (105.65s)
        --- PASS: TestHelmLegacyAuth/TestHelmInstall/dedicatedPlugins (95.04s)
PASS
ok  	github.com/voxel51/fiftyone-teams-app-deploy/integration/helm	276.060s
```

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
