### PR TITLE
chore(deps): bump google-github-actions/auth from 2.1.3 to 2.1.5

### DIFF
--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -39,7 +39,7 @@ jobs:
         uses: asdf-vm/actions/install@v3.0.2
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@v2.1.3
+        uses: google-github-actions/auth@v2.1.5
         with:
           project_id: 'computer-vision-team'
           service_account: 'github@computer-vision-team.iam.gserviceaccount.com'
@@ -74,7 +74,7 @@ jobs:
         uses: asdf-vm/actions/install@v3.0.2
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@v2.1.3
+        uses: google-github-actions/auth@v2.1.5
         with:
           project_id: 'computer-vision-team'
           service_account: 'github@computer-vision-team.iam.gserviceaccount.com'


### PR DESCRIPTION
# Rationale

Like #183, but performed by human to trigger PR checks

## Changes

See #183 

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->

## Notes

After this PR passes checks and merges, I will close #183 