### PR TITLE
`TEAMS_API_DATABASE_NAME` is required

### DIFF
--- a/docker/common-services.yaml
+++ b/docker/common-services.yaml
@@ -99,6 +99,8 @@ services:
       DEBUG: ${CAS_DEBUG:-cas:*,-cas:*:debug}
       FIFTYONE_AUTH_SECRET: ${FIFTYONE_AUTH_SECRET}
       LICENSE_KEY_FILE_PATHS: ${LICENSE_KEY_FILE_PATHS:-/opt/fiftyone/licenses/license}
+      TEAMS_API_DATABASE_NAME: ${FIFTYONE_DATABASE_NAME}
+      TEAMS_API_MONGODB_URI: ${FIFTYONE_DATABASE_URI}
       # If you are routing through a proxy server you will want to set
       #  HTTP_PROXY_URL, HTTPS_PROXY_URL, and NO_PROXY_LIST in your .env
       #  then add the following environment variables to your

--- a/docker/legacy-auth/compose.dedicated-plugins.yaml
+++ b/docker/legacy-auth/compose.dedicated-plugins.yaml
@@ -27,8 +27,6 @@ services:
     environment:
       CAS_URL: ${AUTH0_BASE_URL}
       NEXTAUTH_URL: ${AUTH0_BASE_URL}/cas/api/auth
-      TEAMS_API_DATABASE_NAME: ${FIFTYONE_DATABASE_NAME}
-      TEAMS_API_MONGODB_URI: ${FIFTYONE_DATABASE_URI}
     extends:
       file: ../common-services.yaml
       service: teams-cas-common

--- a/docker/legacy-auth/compose.plugins.yaml
+++ b/docker/legacy-auth/compose.plugins.yaml
@@ -33,8 +33,6 @@ services:
     environment:
       CAS_URL: ${AUTH0_BASE_URL}
       NEXTAUTH_URL: ${AUTH0_BASE_URL}/cas/api/auth
-      TEAMS_API_DATABASE_NAME: ${FIFTYONE_DATABASE_NAME}
-      TEAMS_API_MONGODB_URI: ${FIFTYONE_DATABASE_URI}
 
 volumes:
   plugins-vol:

--- a/docker/legacy-auth/compose.yaml
+++ b/docker/legacy-auth/compose.yaml
@@ -21,8 +21,6 @@ services:
     environment:
       CAS_URL: ${AUTH0_BASE_URL}
       NEXTAUTH_URL: ${AUTH0_BASE_URL}/cas/api/auth
-      TEAMS_API_DATABASE_NAME: ${FIFTYONE_DATABASE_NAME}
-      TEAMS_API_MONGODB_URI: ${FIFTYONE_DATABASE_URI}
     extends:
       file: ../common-services.yaml
       service: teams-cas-common

--- a/helm/fiftyone-teams-app/templates/_helpers.tpl
+++ b/helm/fiftyone-teams-app/templates/_helpers.tpl
@@ -301,7 +301,6 @@ Create a merged list of environment variables for fiftyone-teams-cas
   value: {{ include "teams-cas.license-key-file-paths" . | quote }}
 - name: NEXTAUTH_URL
   value: {{ printf "https://%s/cas/api/auth" .Values.teamsAppSettings.dnsName | quote }}
-{{- if eq .Values.casSettings.env.FIFTYONE_AUTH_MODE "legacy" }}
 - name: TEAMS_API_DATABASE_NAME
   valueFrom:
     secretKeyRef:
@@ -312,7 +311,6 @@ Create a merged list of environment variables for fiftyone-teams-cas
     secretKeyRef:
       name: {{ $secretName }}
       key: mongodbConnectionString
-{{- end }}
 {{- range $key, $val := .Values.casSettings.env }}
 - name: {{ $key }}
   value: {{ $val | quote }}

--- a/tests/unit/compose/docker-compose-internal-auth_test.go
+++ b/tests/unit/compose/docker-compose-internal-auth_test.go
@@ -288,6 +288,8 @@ func (s *commonServicesInternalAuthDockerComposeTest) TestServiceEnvironment() {
 				"FIFTYONE_AUTH_SECRET=test-fiftyone-auth-secret",
 				"LICENSE_KEY_FILE_PATHS=/opt/fiftyone/licenses/license",
 				"NEXTAUTH_URL=https://example.fiftyone.ai/cas/api/auth",
+				"TEAMS_API_DATABASE_NAME=fiftyone",
+				"TEAMS_API_MONGODB_URI=mongodb://root:test-secret@mongodb.local/?authSource=admin",
 			},
 		},
 		{
@@ -368,6 +370,8 @@ func (s *commonServicesInternalAuthDockerComposeTest) TestServiceEnvironment() {
 				"FIFTYONE_AUTH_SECRET=test-fiftyone-auth-secret",
 				"LICENSE_KEY_FILE_PATHS=/opt/fiftyone/licenses/license",
 				"NEXTAUTH_URL=https://example.fiftyone.ai/cas/api/auth",
+				"TEAMS_API_DATABASE_NAME=fiftyone",
+				"TEAMS_API_MONGODB_URI=mongodb://root:test-secret@mongodb.local/?authSource=admin",
 			},
 		},
 		{
@@ -447,6 +451,8 @@ func (s *commonServicesInternalAuthDockerComposeTest) TestServiceEnvironment() {
 				"FIFTYONE_AUTH_SECRET=test-fiftyone-auth-secret",
 				"LICENSE_KEY_FILE_PATHS=/opt/fiftyone/licenses/license",
 				"NEXTAUTH_URL=https://example.fiftyone.ai/cas/api/auth",
+				"TEAMS_API_DATABASE_NAME=fiftyone",
+				"TEAMS_API_MONGODB_URI=mongodb://root:test-secret@mongodb.local/?authSource=admin",
 			},
 		},
 		{

--- a/tests/unit/helm/cas-deployment_test.go
+++ b/tests/unit/helm/cas-deployment_test.go
@@ -464,6 +464,24 @@ func (s *deploymentCasTemplateTest) TestContainerEnv() {
             "value": "https:///cas/api/auth"
           },
           {
+            "name": "TEAMS_API_DATABASE_NAME",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "fiftyone-teams-secrets",
+                "key": "fiftyoneDatabaseName"
+              }
+            }
+          },
+          {
+            "name": "TEAMS_API_MONGODB_URI",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "fiftyone-teams-secrets",
+                "key": "mongodbConnectionString"
+              }
+            }
+          },
+          {
             "name": "CAS_DATABASE_NAME",
             "value": "cas"
           },


### PR DESCRIPTION
# Rationale

`TEAMS_API_DATABASE_NAME` is required in `internal` mode now -  [PR 1443](https://github.com/voxel51/voxel-hub/pull/1443/files)

## Changes

remove the `if legacy` clause around the env vars

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

unit tests - compose tests

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
