### PR TITLE
use the github link for plugins-storage

### DIFF
--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -174,7 +174,7 @@ Supported locations are network mounted filesystems and cloud storage folders.
   - Mount a Persistent Volume Claim with `ReadWrite` permissions to
     the `teams-api` deployment at the `FIFTYONE_SNAPSHOTS_ARCHIVE_PATH` path.
     For an example, see
-    [Plugins Storage](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/plugins-storage.md).
+    [Plugins Storage][plugins-storage].
 - Cloud storage folder
   - In `values.yaml`, set the cloud storage path (for example
     `gs://my-voxel51-bucket/dev-deployment-snapshot-archives/`)
@@ -251,7 +251,7 @@ To enable this mode
   - `appSettings.env.FIFTYONE_PLUGINS_DIR`
   - `apiSettings.env.FIFTYONE_PLUGINS_DIR`
 - See
-  [Adding Shared Storage for FiftyOne Teams Plugins](../docs/plugins-storage.md)
+  [Adding Shared Storage for FiftyOne Teams Plugins][plugins-storage]
   - Mount a PVC that provides
     - `ReadWrite` permissions to the `teams-api` deployment
       at the `FIFTYONE_PLUGINS_DIR` path
@@ -269,7 +269,7 @@ To enable this mode
     - `pluginsSettings.env.FIFTYONE_PLUGINS_DIR`
     - `apiSettings.env.FIFTYONE_PLUGINS_DIR`
 - See
-  [Adding Shared Storage for FiftyOne Teams Plugins](../docs/plugins-storage.md)
+  [Adding Shared Storage for FiftyOne Teams Plugins][plugins-storage]
   - Mount a Persistent Volume Claim (PVC) that provides
     - `ReadWrite` permissions to the `teams-api` deployment
       at the `FIFTYONE_PLUGINS_DIR` path
@@ -946,6 +946,8 @@ A minimal example `values.yaml` may be found
 [autoscaling]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
 [container-security-context]: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 [deployment]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
+[fiftyone-config]: https://docs.voxel51.com/user_guide/config.html
+[fiftyone-encryption-key]: https://github.com/voxel51/fiftyone-teams-app-deploy/tree/main/helm/fiftyone-teams-app#storage-credentials-and-fiftyone_encryption_key
 [image-pull-policy]: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
 [image-pull-secrets]: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
 [ingress-default-ingress-class]: https://kubernetes.io/docs/concepts/services-networking/ingress/#default-ingress-class
@@ -954,19 +956,15 @@ A minimal example `values.yaml` may be found
 [internal-auth-mode]: https://docs.voxel51.com/teams/pluggable_auth.html#internal-mode
 [labels-and-selectors]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 [legacy-auth-mode]: https://docs.voxel51.com/teams/pluggable_auth.html#legacy-mode
+[mongodb-connection-string]: https://www.mongodb.com/docs/manual/reference/connection-string/
 [node-selector]: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+[plugins-storage]: https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/plugins-storage.md
 [ports]: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
 [probes]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+[recoil-env]: https://recoiljs.org/docs/api-reference/core/RecoilEnv/
 [resources]: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 [security-context]: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 [service-account]: https://kubernetes.io/docs/concepts/security/service-accounts/
 [service-type]: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
 [taints-and-tolerations]: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
 [volumes]: https://kubernetes.io/docs/concepts/storage/volumes/
-
-[mongodb-connection-string]: https://www.mongodb.com/docs/manual/reference/connection-string/
-
-[recoil-env]: https://recoiljs.org/docs/api-reference/core/RecoilEnv/
-
-[fiftyone-encryption-key]: https://github.com/voxel51/fiftyone-teams-app-deploy/tree/main/helm/fiftyone-teams-app#storage-credentials-and-fiftyone_encryption_key
-[fiftyone-config]: https://docs.voxel51.com/user_guide/config.html

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -176,7 +176,7 @@ Supported locations are network mounted filesystems and cloud storage folders.
   - Mount a Persistent Volume Claim with `ReadWrite` permissions to
     the `teams-api` deployment at the `FIFTYONE_SNAPSHOTS_ARCHIVE_PATH` path.
     For an example, see
-    [Plugins Storage](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/plugins-storage.md).
+    [Plugins Storage][plugins-storage].
 - Cloud storage folder
   - In `values.yaml`, set the cloud storage path (for example
     `gs://my-voxel51-bucket/dev-deployment-snapshot-archives/`)
@@ -253,7 +253,7 @@ To enable this mode
   - `appSettings.env.FIFTYONE_PLUGINS_DIR`
   - `apiSettings.env.FIFTYONE_PLUGINS_DIR`
 - See
-  [Adding Shared Storage for FiftyOne Teams Plugins](../docs/plugins-storage.md)
+  [Adding Shared Storage for FiftyOne Teams Plugins][plugins-storage]
   - Mount a PVC that provides
     - `ReadWrite` permissions to the `teams-api` deployment
       at the `FIFTYONE_PLUGINS_DIR` path
@@ -271,7 +271,7 @@ To enable this mode
     - `pluginsSettings.env.FIFTYONE_PLUGINS_DIR`
     - `apiSettings.env.FIFTYONE_PLUGINS_DIR`
 - See
-  [Adding Shared Storage for FiftyOne Teams Plugins](../docs/plugins-storage.md)
+  [Adding Shared Storage for FiftyOne Teams Plugins][plugins-storage]
   - Mount a Persistent Volume Claim (PVC) that provides
     - `ReadWrite` permissions to the `teams-api` deployment
       at the `FIFTYONE_PLUGINS_DIR` path
@@ -768,6 +768,8 @@ A minimal example `values.yaml` may be found
 [autoscaling]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
 [container-security-context]: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 [deployment]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
+[fiftyone-config]: https://docs.voxel51.com/user_guide/config.html
+[fiftyone-encryption-key]: https://github.com/voxel51/fiftyone-teams-app-deploy/tree/main/helm/fiftyone-teams-app#storage-credentials-and-fiftyone_encryption_key
 [image-pull-policy]: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
 [image-pull-secrets]: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
 [ingress-default-ingress-class]: https://kubernetes.io/docs/concepts/services-networking/ingress/#default-ingress-class
@@ -776,19 +778,15 @@ A minimal example `values.yaml` may be found
 [internal-auth-mode]: https://docs.voxel51.com/teams/pluggable_auth.html#internal-mode
 [labels-and-selectors]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 [legacy-auth-mode]: https://docs.voxel51.com/teams/pluggable_auth.html#legacy-mode
+[mongodb-connection-string]: https://www.mongodb.com/docs/manual/reference/connection-string/
 [node-selector]: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+[plugins-storage]: https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/plugins-storage.md
 [ports]: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
 [probes]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+[recoil-env]: https://recoiljs.org/docs/api-reference/core/RecoilEnv/
 [resources]: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 [security-context]: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 [service-account]: https://kubernetes.io/docs/concepts/security/service-accounts/
 [service-type]: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
 [taints-and-tolerations]: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
 [volumes]: https://kubernetes.io/docs/concepts/storage/volumes/
-
-[mongodb-connection-string]: https://www.mongodb.com/docs/manual/reference/connection-string/
-
-[recoil-env]: https://recoiljs.org/docs/api-reference/core/RecoilEnv/
-
-[fiftyone-encryption-key]: https://github.com/voxel51/fiftyone-teams-app-deploy/tree/main/helm/fiftyone-teams-app#storage-credentials-and-fiftyone_encryption_key
-[fiftyone-config]: https://docs.voxel51.com/user_guide/config.html


### PR DESCRIPTION
# Rationale

helm.fiftyone.ai links don't seem to render markdown for local files - use the github links instead

## Changes

replace the link with the github link

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

## Testing

not a really good way to test this, but the existing github link seems to work fine

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
