### PR TITLE
docs: license file for testing and make helpers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,11 +52,17 @@
     make start
     ```
 
-1. Download dev license file
+1. Download dev license file (legacy or internal)
 
-   ```shell
-   make license-secret-legacy
-   ```
+    ```shell
+    make license-secret-legacy
+    ```
+
+    or
+
+    ```shell
+    make license-secret-internal
+    ```
 
 1. Run skaffold
 
@@ -64,11 +70,33 @@
     make dev-keep
     ```
 
+    Cancelling this process will destroy the cert-manager and mongodb deployments.
+    Alternatively, they can be started with
+
+    ```shell
+    make run-cert-manager run-mongodb
+    ```
+
+    and then run this to manage the fiftyone-teams deployment resources
+
+    ```shell
+    skaffold dev \
+      --profile only-fiftyone \
+      --keep-running-on-failure \
+      --kube-context minikube
+    ```
+
+    Cancelling this process will destroy only the fiftyone-teams deployment
+    resources (leaving the cert-manager and mongodb resources).
+
 1. In another terminal, run minikube tunnel (and provide your password when prompted)
 
     ```shell
-    minikube tunnel
+    sudo minikube tunnel
     ```
+
+    > **NOTE**: This command will prompt for sudo permission
+    > on systems where 80 and 443 are privileged ports
 
 1. Navigate to
    [https://local.fiftyone.ai](https://local.fiftyone.ai)

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ run-mongodb: helm-repos  ## run skaffold run
 	  --kube-context minikube
 
 run-profile-only-fiftyone: helm-repos  ## run skaffold run -p only-fiftyone
-	skaffold run -p only-fiftyone \
+	skaffold run --profile only-fiftyone \
 	  --kube-context minikube
 
 license-secret-internal: copy-license-files-skaffold
@@ -228,21 +228,21 @@ test-integration-compose-interleaved-legacy: install-terratest-log-parser copy-l
 
 test-integration-helm: test-integration-helm-internal test-integration-helm-legacy ## run go test on the tests/integration/helm directory for both internal and legacy auth modes
 
-test-integration-helm-internal:  ## run go test on the tests/integration/helm directory for internal auth mode
+test-integration-helm-internal: copy-license-files-helm  ## run go test on the tests/integration/helm directory for internal auth mode
 	@cd tests/integration/helm; \
 	go test -count=1 -timeout=15m -v -tags integrationHelmInternalAuth
 
-test-integration-helm-legacy:  ## run go test on the tests/integration/helm directory for legacy auth mode
+test-integration-helm-legacy: copy-license-files-helm  ## run go test on the tests/integration/helm directory for legacy auth mode
 	@cd tests/integration/helm; \
 	go test -count=1 -timeout=15m -v -tags integrationHelmLegacyAuth
 
-test-integration-helm-interleaved-internal:  ## run go test on the tests/integration/helm directory for internal auth mode
+test-integration-helm-interleaved-internal: copy-license-files-helm  ## run go test on the tests/integration/helm directory for internal auth mode
 	@cd tests/integration/helm; \
 	rm -rf test_output_internal/*; \
 	go test -count=1 -timeout=15m -v -tags integrationHelmInternalAuth | tee test_output_internal.log; \
 	${ASDF}/packages/bin/terratest_log_parser -testlog test_output_internal.log -outputdir test_output_internal
 
-test-integration-helm-interleaved-legacy:  ## run go test on the tests/integration/helm directory for legacy auth mode
+test-integration-helm-interleaved-legacy: copy-license-files-helm  ## run go test on the tests/integration/helm directory for legacy auth mode
 	@cd tests/integration/helm; \
 	rm -rf test_output_legacy/*; \
 	go test -count=1 -timeout=15m -v -tags integrationHelmLegacyAuth | tee test_output_legacy.log; \

--- a/tests/testing.md
+++ b/tests/testing.md
@@ -136,6 +136,18 @@ See
     make auth start
     ```
 
+1. Download dev license file (legacy or internal)
+
+    ```shell
+    make license-secret-legacy
+    ```
+
+    or
+
+    ```shell
+    make license-secret-internal
+    ```
+
 1. Install cert-manager and mongodb into minikube
 
     ```shell
@@ -146,7 +158,7 @@ See
    (to expose the services within minikube outside of minikube)
 
     ```shell
-    sudo make tunnel
+    sudo minikube tunnel
     ```
 
     > **NOTE**: This command will prompt for sudo permission
@@ -157,6 +169,9 @@ See
     ```shell
     make test-integration-helm
     ```
+
+The helm integration tests may be run multiple times by invoking the previous step.
+It will re-use the cert-manager and mongodb deployed.
 
 ## Additional Links
 


### PR DESCRIPTION
# Rationale

While working with a colleague today, I noticed that when we refactored the tests for license file, we didn't update the tests/testing.md to include the license file steps.

While here, added some extra notes for speeding up the runs by preloading cert-manager and MongoDB.

And added make dependencies for helm integration tests to download the license secrets (so there be less commands for us to manually run). (these dependencies already existed for Docker).

If we don't want to include this in the 2.1.1 release, we can target for the next release.

## Changes

* docs
  * testing.md
  * contributing.md
* Makefile 

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
