### PR TITLE
fix(skaffold): set tag versions to latest release

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -41,7 +41,7 @@ deploy:
     releases:
       - name: fiftyone-teams
         chartPath: helm/fiftyone-teams-app
-        version: 2.1.0
+        version: 2.1.1
         createNamespace: true
         namespace: fiftyone-teams
         overrides:
@@ -54,7 +54,7 @@ deploy:
               # See https://console.cloud.google.com/artifacts/docker/computer-vision-team/us-central1/dev-docker?project=computer-vision-team
               repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-teams-api
               pullPolicy: IfNotPresent
-              tag: v2.1.0rc15
+              tag: v2.1.1
 
           # FiftyOne App (fiftyone-app) configurations
           appSettings:
@@ -71,7 +71,7 @@ deploy:
               # See https://console.cloud.google.com/artifacts/docker/computer-vision-team/us-central1/dev-docker?project=computer-vision-team
               repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-app
               pullPolicy: IfNotPresent
-              tag: v2.1.0rc15
+              tag: v2.1.1
 
           # Central Authentication Service (teams-cas) configurations
           casSettings:
@@ -81,7 +81,7 @@ deploy:
               # See https://console.cloud.google.com/artifacts/docker/computer-vision-team/us-central1/dev-docker?project=computer-vision-team
               repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-teams-cas
               pullPolicy: IfNotPresent
-              tag: v2.1.0rc15
+              tag: v2.1.1
 
           # TODO: Test `minikube addons configure registry-creds` or
           # When using minikube's addon registry-creds, we may also need to create the k8s secret `regcred`
@@ -147,7 +147,7 @@ deploy:
               # See https://console.cloud.google.com/artifacts/docker/computer-vision-team/us-central1/dev-docker?project=computer-vision-team
               repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-app
               pullPolicy: IfNotPresent
-              tag: v2.1.0rc15
+              tag: v2.1.1
 
           # FiftyOne Teams App (teams-app) configurations
           teamsAppSettings:
@@ -166,6 +166,6 @@ deploy:
               # The others are `vW.X.Y.devZ` (note `.devZ` vs `-dev.Z`).
               # This is a byproduct of `npm` versioning versus Python PEP 440.
               pullPolicy: IfNotPresent
-              tag: v2.1.0rc15
+              tag: v2.1.1
 
   kubeContext: minikube


### PR DESCRIPTION
# Rationale

We recently changed how we build our release container images.  Previuosly, these would not run on arm64.  After the change, they do.  Let's rev the versions in the release/v2.2.0 in preparation for our replacement commands so they get release with the `v2.2.0` tags.

## Changes

* skaffold
  * set tag versions to latest release

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

No ^ This only affects the skaffold (Helm).

## Testing

With these settings, was able to run the app locally without the containers erroring.

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
