### PR TITLE
chore: Branching off of 2.2.0 because of conflicts

### DIFF
--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -78,6 +78,7 @@ when `FIFTYONE_AUTH_MODE` is set to `internal`.
   - [From FiftyOne Teams Versions 1.6.0 to 1.7.1](#from-fiftyone-teams-versions-160-to-171)
   - [From FiftyOne Teams Version 2.0.0](#from-fiftyone-teams-version-200)
 - [Deploying FiftyOne Teams](#deploying-fiftyone-teams)
+  - [Deploying On GKE](#deploying-on-gke)
 
 <!-- tocstop -->
 
@@ -940,12 +941,38 @@ A minimal example `values.yaml` may be found
         > helm diff -C1 upgrade fiftyone-teams-app voxel51/fiftyone-teams-app -f values.yaml
         > ```
 
+### Deploying On GKE
+
+Voxel51 FiftyOne Teams supports
+[Workload Identity Federation for GKE][about-wif]
+when installing via Helm into Google Kubernetes Engine (GKE).
+Workload Identity is achieved using service account annotations
+that can be defined in the `values.yaml` file when installing
+or upgrading the application.
+
+Please follow the steps
+[outlined by Google][howto-wif]
+to allow your cluster to utilize workload identity federation and to
+create a service account with the required IAM permissions.
+
+Once the cluster and service account are configured, you can permit your
+workloads to utilize the GCP service account via service account annotations
+defined in the `values.yaml` file:
+
+```yaml
+serviceAccount:
+  annotations:
+    iam.gke.io/gcp-service-account: <GSA_NAME>@<GSA_PROJECT>.iam.gserviceaccount.com
+```
+
 <!-- Reference Links -->
+[about-wif]: https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity
 [affinity]: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
 [annotations]: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 [autoscaling]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
 [container-security-context]: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 [deployment]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
+[howto-wif]: https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
 [image-pull-policy]: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
 [image-pull-secrets]: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
 [ingress-default-ingress-class]: https://kubernetes.io/docs/concepts/services-networking/ingress/#default-ingress-class

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -80,6 +80,7 @@ when `FIFTYONE_AUTH_MODE` is set to `internal`.
   - [From FiftyOne Teams Versions 1.6.0 to 1.7.1](#from-fiftyone-teams-versions-160-to-171)
   - [From FiftyOne Teams Version 2.0.0](#from-fiftyone-teams-version-200)
 - [Deploying FiftyOne Teams](#deploying-fiftyone-teams)
+  - [Deploying On GKE](#deploying-on-gke)
 
 <!-- tocstop -->
 
@@ -762,12 +763,38 @@ A minimal example `values.yaml` may be found
         > helm diff -C1 upgrade fiftyone-teams-app voxel51/fiftyone-teams-app -f values.yaml
         > ```
 
+### Deploying On GKE
+
+Voxel51 FiftyOne Teams supports
+[Workload Identity Federation for GKE][about-wif]
+when installing via Helm into Google Kubernetes Engine (GKE).
+Workload Identity is achieved using service account annotations
+that can be defined in the `values.yaml` file when installing
+or upgrading the application.
+
+Please follow the steps
+[outlined by Google][howto-wif]
+to allow your cluster to utilize workload identity federation and to
+create a service account with the required IAM permissions.
+
+Once the cluster and service account are configured, you can permit your
+workloads to utilize the GCP service account via service account annotations
+defined in the `values.yaml` file:
+
+```yaml
+serviceAccount:
+  annotations:
+    iam.gke.io/gcp-service-account: <GSA_NAME>@<GSA_PROJECT>.iam.gserviceaccount.com
+```
+
 <!-- Reference Links -->
+[about-wif]: https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity
 [affinity]: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
 [annotations]: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 [autoscaling]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
 [container-security-context]: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 [deployment]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
+[howto-wif]: https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
 [image-pull-policy]: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
 [image-pull-secrets]: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
 [ingress-default-ingress-class]: https://kubernetes.io/docs/concepts/services-networking/ingress/#default-ingress-class


### PR DESCRIPTION
# Rationale

We should document how [GKE Workload Identity Federation](https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity) is achieved in FiftyoneTeams. This PR aims to add a new section to the helm chart's README, adding GKE-centric deployment steps.

Closing [this PR](https://github.com/voxel51/fiftyone-teams-app-deploy/pull/214) in favor of this new one because of conflicts and unexpected diffs.

## Changes

New links, docs, and write-ups pertaining to GKE workload identity.

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
