### PR TITLE
chore: Fixing google auth and logins

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.0
       - uses: actions/setup-python@v5.2.0
+      - name: Temporary SQLite/LZMA - Install missing libraries
+        run: sudo apt install -y libsqlite3-dev libbz2-dev
       - name: install asdf & tools
         uses: asdf-vm/actions/install@v3.0.2
       - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -45,6 +45,8 @@ jobs:
           service_account: 'github@computer-vision-team.iam.gserviceaccount.com'
           token_format: access_token
           workload_identity_provider: ${{ secrets.ORG_GOOGLE_WORKLOAD_IDP }}
+      - name: Set Up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
       - name: Login to GAR
         uses: docker/login-action@v3.3.0
         with:

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -80,6 +80,8 @@ jobs:
           service_account: 'github@computer-vision-team.iam.gserviceaccount.com'
           token_format: access_token
           workload_identity_provider: ${{ secrets.ORG_GOOGLE_WORKLOAD_IDP }}
+      - name: Set Up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
       - name: Login to GAR
         uses: docker/login-action@v3.3.0
         with:


### PR DESCRIPTION
# Rationale

It appears any installation of `gcloud` is missing from the docker-compose workflows. However, our makefile is requiring it.

Adding `gcloud` installation.

## Changes

Updates `test-docker.yml` to include `setup-gcloud` action.

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
