### PR TITLE
AS-289 Continuous Chart Publishing

### DIFF
--- a/.github/workflows/pre-release-internal-env.yml
+++ b/.github/workflows/pre-release-internal-env.yml
@@ -1,0 +1,101 @@
+---
+name: Release Pre-release charts
+
+on:
+  push:
+    branches-ignore:
+      - main
+    paths:
+      - 'helm/**'
+      - '.github/workflows/pre-release-internal-env.yml'
+
+jobs:
+  pre-release:
+    permissions:
+      contents: write
+      id-token: write
+    env:
+      GCP_HELM_REGISTRY: helm-internal
+      GCP_LOCATION: us-central1
+      GCP_PROJECT: computer-vision-team
+      GCP_SERVICE_ACCOUNT: github@computer-vision-team.iam.gserviceaccount.com
+      HELM_CHART_NAME: fiftyone-teams-app
+    runs-on: ubuntu-latest
+
+    outputs:
+      fiftyone-teams-app-deploy-version: ${{ steps.find-versions.outputs.FIFTYONE_TEAMS_APP_DEPLOY_VERSION }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.0
+        with:
+          fetch-depth: 0
+          ref: "${{ github.ref }}"
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Set Helm Chart Version
+        id: find-versions
+        run: |
+          version=$(yq ".version" helm/fiftyone-teams-app/Chart.yaml)
+          # Don't push anything for release, just let the operator
+          # handle that by updating Chart.yaml
+          if [[ ! "${GITHUB_BRANCH}" == "release/"* ]]; then
+            version="${version}-sha-${GITHUB_SHA::7}"
+          fi
+
+          echo "FIFTYONE_TEAMS_APP_DEPLOY_VERSION=${version}" >> "${GITHUB_ENV}"
+          echo "FIFTYONE_TEAMS_APP_DEPLOY_VERSION=${version}" >> "${GITHUB_OUTPUT}"
+
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: 'latest'
+
+      - name: Set Up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ env.GCP_PROJECT }}
+          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ secrets.ORG_GOOGLE_WORKLOAD_IDP }}
+
+      - name: Helm login to Google Artifact Registry
+        run: |
+          gcloud auth print-access-token | \
+            helm registry login \
+              -u oauth2accesstoken \
+              --password-stdin \
+              "https://${GCP_LOCATION}-docker.pkg.dev"
+
+      - name: Update Charts
+        run: |
+          yq --inplace ".version = \"${{ env.FIFTYONE_TEAMS_APP_DEPLOY_VERSION }}\"" "Chart.yaml"
+        working-directory: "helm/fiftyone-teams-app"
+
+      - name: Helm publish chart to artifact registry
+        run: |
+          helm package "${{ env.HELM_CHART_NAME }}"
+          helm push "${{ env.HELM_CHART_NAME }}-${{ env.FIFTYONE_TEAMS_APP_DEPLOY_VERSION }}.tgz" oci://${{ env.GCP_LOCATION }}-docker.pkg.dev/${{ env.GCP_PROJECT }}/${{ env.GCP_HELM_REGISTRY }}/
+        working-directory: "helm"
+
+      - name: Trigger Internal Chart Build
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.CROSS_REPOSITORY_TOKEN }}
+          script: |
+            const result = await github.rest.actions.createWorkflowDispatch({
+              owner: "${{ github.repository_owner }}",
+              repo: "${{ secrets.CROSS_REPOSITORY_REPOSITORY }}",
+              workflow_id: "${{ secrets.CROSS_REPOSITORY_WORKFLOW }}",
+              ref: "main",
+              inputs: {
+                "fiftyone-teams-app-deploy-version": "${{ steps.find-versions.outputs.FIFTYONE_TEAMS_APP_DEPLOY_VERSION }}"
+              }
+            })

--- a/.github/workflows/pre-release-internal-env.yml
+++ b/.github/workflows/pre-release-internal-env.yml
@@ -41,9 +41,9 @@ jobs:
         id: find-versions
         run: |
           version=$(yq ".version" helm/fiftyone-teams-app/Chart.yaml)
-          # Don't push anything for release, just let the operator
-          # handle that by updating Chart.yaml
-          if [[ ! "${GITHUB_BRANCH}" == "release/"* ]]; then
+          if [[ "${GITHUB_BRANCH}" == "release/"* ]]; then
+            version="${version}-rc-${GITHUB_SHA::7}"
+          else
             version="${version}-sha-${GITHUB_SHA::7}"
           fi
 


### PR DESCRIPTION
# Rationale

Instead of forcing internal cloud-builds to publish charts on requests, we should just build/publish them on pushes to this repository for non-main branches. This PR builds the fiftyone teams helm chart and dependent charts in an automated fashion.

## Changes

Additional GitHub action to:

1. Update any versions
2. Package helm chart
3. Push to internal registry
4. Update dependent repositories via triggers

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

[GitHub actions](https://github.com/voxel51/helm-charts-internal/actions/runs/11439938801)

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
