### PR TITLE
Fixing GITHUB_REF_NAME environment variable

### DIFF
--- a/.github/workflows/pre-release-internal-env.yml
+++ b/.github/workflows/pre-release-internal-env.yml
@@ -41,7 +41,7 @@ jobs:
         id: find-versions
         run: |
           version=$(yq ".version" helm/fiftyone-teams-app/Chart.yaml)
-          if [[ "${GITHUB_BRANCH}" == "release/"* ]]; then
+          if [[ "${GITHUB_REF_NAME}" == "release/"* ]]; then
             version="${version}-rc-${GITHUB_SHA::7}"
           else
             version="${version}-sha-${GITHUB_SHA::7}"


### PR DESCRIPTION
# Rationale

In a previous PR, we enabled continuous publishing of helm charts based on branches. The `GITHUB_BRANCH` environment variable is deprecated, switching to `GITHUB_REF_NAME` per [the docs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables)

## Changes

Update conditional in GH actions.

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
