### PR TITLE
chore(deps): bump actions/setup-python from 5.2.0 to 5.3.0

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
-      - uses: actions/setup-python@v5.2.0
+      - uses: actions/setup-python@v5.3.0
       - name: Temporary SQLite/LZMA - Install missing libraries
         run: sudo apt install -y libsqlite3-dev libbz2-dev
       - name: install asdf & tools

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.1
-      - uses: actions/setup-python@v5.2.0
+      - uses: actions/setup-python@v5.3.0
       - name: Temporary SQLite/LZMA - Install missing libraries
         run: sudo apt install -y libsqlite3-dev libbz2-dev
       - name: install asdf & tools

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
-      - uses: actions/setup-python@v5.2.0
+      - uses: actions/setup-python@v5.3.0
       - name: install asdf & tools
         uses: asdf-vm/actions/install@v3.0.2
       - name: Run unit tests
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
-      - uses: actions/setup-python@v5.2.0
+      - uses: actions/setup-python@v5.3.0
       - name: Temporary SQLite/LZMA - Install missing libraries
         run: sudo apt install -y libsqlite3-dev libbz2-dev
       - name: install asdf & tools
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
-      - uses: actions/setup-python@v5.2.0
+      - uses: actions/setup-python@v5.3.0
       - name: install asdf & tools
         uses: asdf-vm/actions/install@v3.0.2
       - name: Authenticate to Google Cloud

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.1
-      - uses: actions/setup-python@v5.2.0
+      - uses: actions/setup-python@v5.3.0
       - name: install asdf & tools
         uses: asdf-vm/actions/install@v3.0.2
       - name: Run unit tests
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.1
-      - uses: actions/setup-python@v5.2.0
+      - uses: actions/setup-python@v5.3.0
       - name: Temporary SQLite/LZMA - Install missing libraries
         run: sudo apt install -y libsqlite3-dev libbz2-dev
       - name: install asdf & tools
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.1
-      - uses: actions/setup-python@v5.2.0
+      - uses: actions/setup-python@v5.3.0
       - name: install asdf & tools
         uses: asdf-vm/actions/install@v3.0.2
       - name: Authenticate to Google Cloud

--- a/.github/workflows/test-helm.yml
+++ b/.github/workflows/test-helm.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.1
-      - uses: actions/setup-python@v5.2.0
+      - uses: actions/setup-python@v5.3.0
       - name: Temporary SQLite/LZMA - Install missing libraries
         run: sudo apt install -y libsqlite3-dev libbz2-dev
       - name: install asdf & tools

--- a/.github/workflows/test-helm.yml
+++ b/.github/workflows/test-helm.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
-      - uses: actions/setup-python@v5.2.0
+      - uses: actions/setup-python@v5.3.0
       - name: Temporary SQLite/LZMA - Install missing libraries
         run: sudo apt install -y libsqlite3-dev libbz2-dev
       - name: install asdf & tools

--- a/.github/workflows/test-integration-helm.yml
+++ b/.github/workflows/test-integration-helm.yml
@@ -21,7 +21,7 @@ jobs:
       id-token: 'write'
     steps:
       - uses: actions/checkout@v4.2.0
-      - uses: actions/setup-python@v5.2.0
+      - uses: actions/setup-python@v5.3.0
       - name: Temporary SQLite/LZMA - Install missing libraries
         run: sudo apt install -y libsqlite3-dev libbz2-dev
       - name: install asdf & tools

--- a/.github/workflows/test-integration-helm.yml
+++ b/.github/workflows/test-integration-helm.yml
@@ -21,7 +21,7 @@ jobs:
       id-token: 'write'
     steps:
       - uses: actions/checkout@v4.2.2
-      - uses: actions/setup-python@v5.2.0
+      - uses: actions/setup-python@v5.3.0
       - name: Temporary SQLite/LZMA - Install missing libraries
         run: sudo apt install -y libsqlite3-dev libbz2-dev
       - name: install asdf & tools


### PR DESCRIPTION
# Rationale

Supersedes [this PR](https://github.com/voxel51/fiftyone-teams-app-deploy/pull/226) and changes target to release branch.

## Changes

See [this PR](https://github.com/voxel51/fiftyone-teams-app-deploy/pull/226) for more information.

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
