### PR TITLE
chore(deps): bump actions/checkout fro 4.2.x to 4.2.2

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,7 +11,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
       - uses: actions/setup-python@v5.2.0
       - name: Temporary SQLite/LZMA - Install missing libraries
         run: sudo apt install -y libsqlite3-dev libbz2-dev

--- a/.github/workflows/pre-release-internal-env.yml
+++ b/.github/workflows/pre-release-internal-env.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.0
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
           ref: "${{ github.ref }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -19,7 +19,7 @@ jobs:
   unit-compose:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
       - uses: actions/setup-python@v5.2.0
       - name: install asdf & tools
         uses: asdf-vm/actions/install@v3.0.2
@@ -33,7 +33,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
       - uses: actions/setup-python@v5.2.0
       - name: Temporary SQLite/LZMA - Install missing libraries
         run: sudo apt install -y libsqlite3-dev libbz2-dev
@@ -72,7 +72,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
       - uses: actions/setup-python@v5.2.0
       - name: install asdf & tools
         uses: asdf-vm/actions/install@v3.0.2

--- a/.github/workflows/test-helm.yml
+++ b/.github/workflows/test-helm.yml
@@ -17,7 +17,7 @@ jobs:
   unit-helm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v4.2.2
       - uses: actions/setup-python@v5.2.0
       - name: Temporary SQLite/LZMA - Install missing libraries
         run: sudo apt install -y libsqlite3-dev libbz2-dev

--- a/.github/workflows/test-integration-helm.yml
+++ b/.github/workflows/test-integration-helm.yml
@@ -20,7 +20,7 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-      - uses: actions/checkout@v4.2.0
+      - uses: actions/checkout@v4.2.2
       - uses: actions/setup-python@v5.2.0
       - name: Temporary SQLite/LZMA - Install missing libraries
         run: sudo apt install -y libsqlite3-dev libbz2-dev


### PR DESCRIPTION
# Rationale

Supersedes [this PR](https://github.com/voxel51/fiftyone-teams-app-deploy/pull/227) and changes target to release branch.

## Changes

See [this PR](https://github.com/voxel51/fiftyone-teams-app-deploy/pull/227) for more information.

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
