### PR TITLE
chore(workflows): on chart release, trigger action in cross repository to build and publish [AS-281]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,11 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+
       - name: Get Chart Version
         id: get-version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   release:
+    outputs:
+      changed_charts: ${{ steps.chart_releaser.outputs.changed_charts }}
     permissions:
       contents: write
     runs-on: ubuntu-latest
@@ -27,13 +29,43 @@ jobs:
         uses: azure/setup-helm@v4
         with:
           version: 'latest'
-          token: "${{ secrets.CR_TOKEN }}"
-
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.6.0
-        with:
-          charts_dir: helm
+        id: chart_releaser
         env:
           CR_TOKEN: "${{ secrets.CR_TOKEN }}"
           CR_SKIP_EXISTING: true
+        uses: helm/chart-releaser-action@v1.6.0
+        with:
+          charts_dir: helm
+
+
+  update-chart-version:
+    if: ${{ needs.release.outputs.changed_charts != '' }}
+    needs: release
+    permissions:
+      contents: write
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get Chart Version
+        id: get-version
+        run: |
+          version=$(yq ".version" helm/fiftyone-teams-app/Chart.yaml)
+          echo "FIFTYONE_TEAMS_APP_DEPLOY_VERSION=${version}" >> "${GITHUB_ENV}"
+          echo "FIFTYONE_TEAMS_APP_DEPLOY_VERSION=${version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Trigger Internal Chart Build by Release
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.CROSS_REPOSITORY_TOKEN }}
+          script: |
+            const result = await github.rest.actions.createWorkflowDispatch({
+              owner: "${{ github.repository_owner }}",
+              repo: "${{ secrets.CROSS_REPOSITORY_REPOSITORY }}",
+              workflow_id: "${{ secrets.CROSS_REPOSITORY_WORKFLOW_2 }}",
+              ref: "main",
+              inputs: {
+                "fiftyone-teams-app-deploy-version": "${{ steps.get-version.outputs.FIFTYONE_TEAMS_APP_DEPLOY_VERSION }}"
+              }
+            })


### PR DESCRIPTION
# Rationale

We use the fiftyone-teams-app chart as a subchart for our internal environments.  When we release a new version of fiftyone-teams-app, let's trigger the build of the internal environment chart.

I also created a new repo secret `CROSS_REPOSITORY_WORKFLOW_2`.

## Changes

* wokflows
  * release
    * `azure/setup-helm@v4` no longer needs a token
    * `Run chart-releaser`
      * alpha sort 
      * set id to be used in later job
    * Add job `update-chart-version` that only runs when chart release publishes to trigger remote workflow in private repo

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

No. This is a helm only change.

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
