### PR TITLE
AS-111 Adding Deprecation Notices

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
           - go-sum
           - makefile
   - repo: https://github.com/norwoodj/helm-docs
-    rev: v1.11.3
+    rev: v1.14.2
     hooks:
       - id: helm-docs
         args:

--- a/helm/fiftyone-teams-app/Chart.yaml
+++ b/helm/fiftyone-teams-app/Chart.yaml
@@ -7,3 +7,4 @@ type: application
 version: 2.2.0
 appVersion: "v2.2.0"
 icon: https://voxel51.com/images/logo/voxel51-logo-horz-color-600dpi.png
+kubeVersion: ">=1.18.0-0"

--- a/helm/fiftyone-teams-app/Chart.yaml
+++ b/helm/fiftyone-teams-app/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 2.2.0
 appVersion: "v2.2.0"
 icon: https://voxel51.com/images/logo/voxel51-logo-horz-color-600dpi.png
-kubeVersion: ">=1.18.0-0 || >=1.18.0"
+kubeVersion: ">=1.18-0"

--- a/helm/fiftyone-teams-app/Chart.yaml
+++ b/helm/fiftyone-teams-app/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 2.2.0
 appVersion: "v2.2.0"
 icon: https://voxel51.com/images/logo/voxel51-logo-horz-color-600dpi.png
-kubeVersion: ">=1.18.0-0"
+kubeVersion: ">=1.18.0-0 || >=1.18.0"

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -70,6 +70,7 @@ when `FIFTYONE_AUTH_MODE` is set to `internal`.
   - [Storage Credentials and `FIFTYONE_ENCRYPTION_KEY`](#storage-credentials-and-fiftyone_encryption_key)
   - [Proxies](#proxies)
   - [Text Similarity](#text-similarity)
+- [Requirements](#requirements)
 - [Values](#values)
 - [Upgrading From Previous Versions](#upgrading-from-previous-versions)
   - [From Early Adopter Versions (Versions less than 1.0)](#from-early-adopter-versions-versions-less-than-10)
@@ -403,6 +404,10 @@ appSettings:
   image:
     repository: voxel51/fiftyone-app-torch
 ```
+
+## Requirements
+
+Kubernetes: `>=1.18.0-0 || >=1.18.0`
 
 ## Values
 

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -407,7 +407,7 @@ appSettings:
 
 ## Requirements
 
-Kubernetes: `>=1.18.0-0 || >=1.18.0`
+Kubernetes: `>=1.18-0`
 
 ## Values
 

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -413,7 +413,9 @@ appSettings:
 
 {{ template "chart.sourcesSection" . }}
 
-{{ template "chart.requirementsSection" . }}
+## Requirements
+
+{{ template "chart.kubeVersionLine" . }}
 
 ## Values
 

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -72,6 +72,7 @@ when `FIFTYONE_AUTH_MODE` is set to `internal`.
   - [Storage Credentials and `FIFTYONE_ENCRYPTION_KEY`](#storage-credentials-and-fiftyone_encryption_key)
   - [Proxies](#proxies)
   - [Text Similarity](#text-similarity)
+- [Requirements](#requirements)
 - [Values](#values)
 - [Upgrading From Previous Versions](#upgrading-from-previous-versions)
   - [From Early Adopter Versions (Versions less than 1.0)](#from-early-adopter-versions-versions-less-than-10)

--- a/helm/fiftyone-teams-app/templates/NOTES.txt
+++ b/helm/fiftyone-teams-app/templates/NOTES.txt
@@ -1,2 +1,8 @@
+{{- if (semverCompare "<1.28-0" .Capabilities.KubeVersion.GitVersion) }}
+[WARN] You are running an older version of kubernetes!
+Currently supported versions of Kubernetes are described at the following link:
+
+https://kubernetes.io/releases/
+{{ end }}
 Visit the following URL to access your FiftyOne Teams application:
   http{{ if $.Values.ingress.tlsEnabled }}s{{ end }}://{{ .Values.teamsAppSettings.dnsName }}

--- a/helm/fiftyone-teams-app/templates/ingress.yaml
+++ b/helm/fiftyone-teams-app/templates/ingress.yaml
@@ -7,8 +7,6 @@
 {{- end }}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
 {{- end }}

--- a/helm/fiftyone-teams-app/templates/ingress.yaml
+++ b/helm/fiftyone-teams-app/templates/ingress.yaml
@@ -8,7 +8,7 @@
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
 {{- else -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 {{- end }}
 kind: Ingress
 metadata:


### PR DESCRIPTION
# Rationale

We should warn users who are using older kubernetes versions. For extremely old versions, like 1.18.0, we should add a hard "no install" rule by utilizing `kubeVersion`.

The soft deprecation notice will be shown when there is a version that is EOL ( older than 1.28).

## Changes

Add `kubeVersion` to `Chart.yaml`. Have to include pre-release versions for google (see [this](https://github.com/helm/helm/issues/3810))

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

`helm install --dry-run` against various versions of kube:
* [x] GKE
* [x] Minikube
* [ ] EKS?

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
