### PR TITLE
fix(charts): AS-101 Decoupling labels and metadata in charts

### DIFF
--- a/helm/fiftyone-teams-app/templates/_helpers.tpl
+++ b/helm/fiftyone-teams-app/templates/_helpers.tpl
@@ -164,17 +164,17 @@ Plugins Combined labels
 {{/*
 Teams APP Selector labels
 */}}
-{{- define "fiftyone-teams-app.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "fiftyone-teams-app.name" . }}
+{{- define "teams-app.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "teams-app.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
 Teams APP Combined labels
 */}}
-{{- define "fiftyone-teams-app.labels" -}}
+{{- define "teams-app.labels" -}}
 {{ include "fiftyone-teams-app.commonLabels" . }}
-{{ include "fiftyone-teams-app.selectorLabels" . }}
+{{ include "teams-app.selectorLabels" . }}
 {{- end }}
 
 {{/*
@@ -185,6 +185,27 @@ Create the name of the service account to use
 {{- default (include "fiftyone-teams-app.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Service Account labels
+*/}}
+{{- define "fiftyone-teams-app.serviceAccountLabels" -}}
+{{ include "fiftyone-teams-app.commonLabels" . }}
+app.kubernetes.io/name: {{ default (include "fiftyone-teams-app.fullname" .) .Values.serviceAccount.name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Ingress labels
+*/}}
+{{- define "fiftyone-teams-app.ingressLabels" -}}
+{{ include "fiftyone-teams-app.commonLabels" . }}
+app.kubernetes.io/name: {{ include "fiftyone-teams-app.fullname" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- with .Values.ingress.labels }}
+{{ toYaml . }}
 {{- end }}
 {{- end }}
 

--- a/helm/fiftyone-teams-app/templates/_helpers.tpl
+++ b/helm/fiftyone-teams-app/templates/_helpers.tpl
@@ -163,9 +163,13 @@ Plugins Combined labels
 
 {{/*
 Teams APP Selector labels
+
+NOTE: Selector labels are immutable.
+We will keep app.kubernetes.io/name
+as fiftyone-teams-app.name and not teams-app.name.
 */}}
 {{- define "teams-app.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "teams-app.name" . }}
+app.kubernetes.io/name: {{ include "fiftyone-teams-app.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 

--- a/helm/fiftyone-teams-app/templates/ingress.yaml
+++ b/helm/fiftyone-teams-app/templates/ingress.yaml
@@ -17,10 +17,7 @@ metadata:
   name: {{ $fullName }}
   namespace: {{ .Values.namespace.name }}
   labels:
-    {{- include "fiftyone-teams-app.labels" . | nindent 4 }}
-    {{- with .Values.ingress.labels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
+    {{- include "fiftyone-teams-app.ingressLabels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/helm/fiftyone-teams-app/templates/serviceaccount.yaml
+++ b/helm/fiftyone-teams-app/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "fiftyone-teams-app.serviceAccountName" . }}
   namespace: {{ .Values.namespace.name }}
   labels:
-    {{- include "fiftyone-teams-app.labels" . | nindent 4 }}
+    {{- include "fiftyone-teams-app.serviceAccountLabels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/helm/fiftyone-teams-app/templates/teams-app-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/teams-app-deployment.yaml
@@ -4,14 +4,14 @@ metadata:
   name: {{ include "teams-app.name" . }}
   namespace: {{ .Values.namespace.name }}
   labels:
-    {{- include "fiftyone-teams-app.labels" . | nindent 4 }}
+    {{- include "teams-app.labels" . | nindent 4 }}
 spec:
   {{- if not .Values.teamsAppSettings.autoscaling.enabled }}
   replicas: {{ .Values.teamsAppSettings.replicaCount | default 2 }}
   {{- end }}
   selector:
     matchLabels:
-      {{- include "fiftyone-teams-app.selectorLabels" . | nindent 6 }}
+      {{- include "teams-app.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       {{- with .Values.teamsAppSettings.podAnnotations }}
@@ -19,7 +19,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "fiftyone-teams-app.selectorLabels" . | nindent 8 }}
+        {{- include "teams-app.selectorLabels" . | nindent 8 }}
         {{- with .Values.teamsAppSettings.labels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/helm/fiftyone-teams-app/templates/teams-app-hpa.yaml
+++ b/helm/fiftyone-teams-app/templates/teams-app-hpa.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "teams-app.name" . }}
   namespace: {{ .Values.namespace.name }}
   labels:
-    {{- include "fiftyone-teams-app.labels" . | nindent 4 }}
+    {{- include "teams-app.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/helm/fiftyone-teams-app/templates/teams-app-service.yaml
+++ b/helm/fiftyone-teams-app/templates/teams-app-service.yaml
@@ -8,7 +8,7 @@ metadata:
   name: {{ include "teams-app.name" . }}
   namespace: {{ .Values.namespace.name }}
   labels:
-    {{- include "fiftyone-teams-app.labels" . | nindent 4 }}
+    {{- include "teams-app.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.teamsAppSettings.service.type }}
   ports:
@@ -20,4 +20,4 @@ spec:
       nodePort: {{ .Values.teamsAppSettings.service.nodePort }}
       {{- end }}
   selector:
-    {{- include "fiftyone-teams-app.selectorLabels" . | nindent 4 }}
+    {{- include "teams-app.selectorLabels" . | nindent 4 }}

--- a/tests/unit/helm/ingress_test.go
+++ b/tests/unit/helm/ingress_test.go
@@ -198,22 +198,7 @@ func (s *ingressTemplateTest) TestMetadataLabels() {
 				"helm.sh/chart":                fmt.Sprintf("fiftyone-teams-app-%s", chartVersion),
 				"app.kubernetes.io/version":    fmt.Sprintf("%s", chartAppVersion),
 				"app.kubernetes.io/managed-by": "Helm",
-				"app.kubernetes.io/name":       "fiftyone-teams-app",
-				"app.kubernetes.io/instance":   "fiftyone-test",
-			},
-		},
-		{
-			"overrideMetadataLabels",
-			map[string]string{
-				// Unlike teams-api, fiftyone-app, and teams-plugins, setting `teamsAppSettings.service.name`
-				// does not affect the label `app.kubernetes.io/name` for the ingress.
-				"appSettings.service.name": "test-service-name",
-			},
-			map[string]string{
-				"helm.sh/chart":                fmt.Sprintf("fiftyone-teams-app-%s", chartVersion),
-				"app.kubernetes.io/version":    fmt.Sprintf("%s", chartAppVersion),
-				"app.kubernetes.io/managed-by": "Helm",
-				"app.kubernetes.io/name":       "fiftyone-teams-app",
+				"app.kubernetes.io/name":       "fiftyone-test-fiftyone-teams-app",
 				"app.kubernetes.io/instance":   "fiftyone-test",
 			},
 		},
@@ -226,7 +211,7 @@ func (s *ingressTemplateTest) TestMetadataLabels() {
 				"helm.sh/chart":                fmt.Sprintf("fiftyone-teams-app-%s", chartVersion),
 				"app.kubernetes.io/version":    fmt.Sprintf("%s", chartAppVersion),
 				"app.kubernetes.io/managed-by": "Helm",
-				"app.kubernetes.io/name":       "fiftyone-teams-app",
+				"app.kubernetes.io/name":       "fiftyone-test-fiftyone-teams-app",
 				"app.kubernetes.io/instance":   "fiftyone-test",
 				"test-label-key":               "test-label-value",
 			},

--- a/tests/unit/helm/serviceaccount_test.go
+++ b/tests/unit/helm/serviceaccount_test.go
@@ -241,22 +241,20 @@ func (s *serviceAccountTemplateTest) TestMetadataLabels() {
 				"helm.sh/chart":                fmt.Sprintf("fiftyone-teams-app-%s", chartVersion),
 				"app.kubernetes.io/version":    fmt.Sprintf("%s", chartAppVersion),
 				"app.kubernetes.io/managed-by": "Helm",
-				"app.kubernetes.io/name":       "fiftyone-teams-app",
+				"app.kubernetes.io/name":       "fiftyone-teams",
 				"app.kubernetes.io/instance":   "fiftyone-test",
 			},
 		},
 		{
 			"overrideMetadataLabels",
 			map[string]string{
-				// Unlike teams-api, fiftyone-app, and teams-plugins, setting `teamsAppSettings.service.name`
-				// does not affect the label `app.kubernetes.io/name` for the serviceAccount.
-				"appSettings.service.name": "test-service-name",
+				"serviceAccount.name": "test-service-account-name",
 			},
 			map[string]string{
 				"helm.sh/chart":                fmt.Sprintf("fiftyone-teams-app-%s", chartVersion),
 				"app.kubernetes.io/version":    fmt.Sprintf("%s", chartAppVersion),
 				"app.kubernetes.io/managed-by": "Helm",
-				"app.kubernetes.io/name":       "fiftyone-teams-app",
+				"app.kubernetes.io/name":       "test-service-account-name",
 				"app.kubernetes.io/instance":   "fiftyone-test",
 			},
 		},

--- a/tests/unit/helm/teams-app-deployment_test.go
+++ b/tests/unit/helm/teams-app-deployment_test.go
@@ -68,20 +68,23 @@ func (s *deploymentTeamsAppTemplateTest) TestMetadataLabels() {
 				"helm.sh/chart":                fmt.Sprintf("fiftyone-teams-app-%s", chartVersion),
 				"app.kubernetes.io/version":    fmt.Sprintf("%s", chartAppVersion),
 				"app.kubernetes.io/managed-by": "Helm",
-				"app.kubernetes.io/name":       "teams-app",
+				"app.kubernetes.io/name":       "fiftyone-teams-app",
 				"app.kubernetes.io/instance":   "fiftyone-test",
 			},
 		},
 		{
 			"overrideMetadataLabels",
 			map[string]string{
+				// Unlike teams-api, fiftyone-app, and teams-plugins, setting `teamsAppSettings.service.name`
+				// does not affect the label `app.kubernetes.io/name` for teams-app.
+				// See note in _helpers.tpl.
 				"teamsAppSettings.service.name": "test-service-name",
 			},
 			map[string]string{
 				"helm.sh/chart":                fmt.Sprintf("fiftyone-teams-app-%s", chartVersion),
 				"app.kubernetes.io/version":    fmt.Sprintf("%s", chartAppVersion),
 				"app.kubernetes.io/managed-by": "Helm",
-				"app.kubernetes.io/name":       "test-service-name",
+				"app.kubernetes.io/name":       "fiftyone-teams-app",
 				"app.kubernetes.io/instance":   "fiftyone-test",
 			},
 		},
@@ -1235,14 +1238,17 @@ func (s *deploymentTeamsAppTemplateTest) TestTemplateLabels() {
 		{
 			"overrideSelectorMatchLabels",
 			map[string]string{
+				// Unlike teams-api, fiftyone-app, and teams-plugins, setting `teamsAppSettings.service.name`
+				// does not affect the label `app.kubernetes.io/name` for teams-app.
+				// See note in _helpers.tpl.
 				"teamsAppSettings.service.name": "test-service-name",
 			},
 			map[string]string{
-				"app.kubernetes.io/name":     "test-service-name",
+				"app.kubernetes.io/name":     "fiftyone-teams-app",
 				"app.kubernetes.io/instance": "fiftyone-test",
 			},
 			map[string]string{
-				"app.kubernetes.io/name":     "test-service-name",
+				"app.kubernetes.io/name":     "fiftyone-teams-app",
 				"app.kubernetes.io/instance": "fiftyone-test",
 			},
 		},

--- a/tests/unit/helm/teams-app-deployment_test.go
+++ b/tests/unit/helm/teams-app-deployment_test.go
@@ -68,22 +68,20 @@ func (s *deploymentTeamsAppTemplateTest) TestMetadataLabels() {
 				"helm.sh/chart":                fmt.Sprintf("fiftyone-teams-app-%s", chartVersion),
 				"app.kubernetes.io/version":    fmt.Sprintf("%s", chartAppVersion),
 				"app.kubernetes.io/managed-by": "Helm",
-				"app.kubernetes.io/name":       "fiftyone-teams-app",
+				"app.kubernetes.io/name":       "teams-app",
 				"app.kubernetes.io/instance":   "fiftyone-test",
 			},
 		},
 		{
 			"overrideMetadataLabels",
 			map[string]string{
-				// Unlike teams-api, fiftyone-app, and teams-plugins, setting `teamsAppSettings.service.name`
-				// does not affect the label `app.kubernetes.io/name` for teams-app.
 				"teamsAppSettings.service.name": "test-service-name",
 			},
 			map[string]string{
 				"helm.sh/chart":                fmt.Sprintf("fiftyone-teams-app-%s", chartVersion),
 				"app.kubernetes.io/version":    fmt.Sprintf("%s", chartAppVersion),
 				"app.kubernetes.io/managed-by": "Helm",
-				"app.kubernetes.io/name":       "fiftyone-teams-app",
+				"app.kubernetes.io/name":       "test-service-name",
 				"app.kubernetes.io/instance":   "fiftyone-test",
 			},
 		},
@@ -1237,16 +1235,14 @@ func (s *deploymentTeamsAppTemplateTest) TestTemplateLabels() {
 		{
 			"overrideSelectorMatchLabels",
 			map[string]string{
-				// Unlike teams-api, fiftyone-app, and teams-plugins, setting `teamsAppSettings.service.name`
-				// does not affect the label `app.kubernetes.io/name` for teams-app.
 				"teamsAppSettings.service.name": "test-service-name",
 			},
 			map[string]string{
-				"app.kubernetes.io/name":     "fiftyone-teams-app",
+				"app.kubernetes.io/name":     "test-service-name",
 				"app.kubernetes.io/instance": "fiftyone-test",
 			},
 			map[string]string{
-				"app.kubernetes.io/name":     "fiftyone-teams-app",
+				"app.kubernetes.io/name":     "test-service-name",
 				"app.kubernetes.io/instance": "fiftyone-test",
 			},
 		},

--- a/tests/unit/helm/teams-app-hpa_test.go
+++ b/tests/unit/helm/teams-app-hpa_test.go
@@ -73,7 +73,7 @@ func (s *horizontalPodAutoscalerTeamsAppTemplateTest) TestMetadataLabels() {
 				"helm.sh/chart":                fmt.Sprintf("fiftyone-teams-app-%s", chartVersion),
 				"app.kubernetes.io/version":    fmt.Sprintf("%s", chartAppVersion),
 				"app.kubernetes.io/managed-by": "Helm",
-				"app.kubernetes.io/name":       "fiftyone-teams-app",
+				"app.kubernetes.io/name":       "teams-app",
 				"app.kubernetes.io/instance":   "fiftyone-test",
 			},
 		},
@@ -81,15 +81,13 @@ func (s *horizontalPodAutoscalerTeamsAppTemplateTest) TestMetadataLabels() {
 			"overrideMetadataLabels",
 			map[string]string{
 				"teamsAppSettings.autoscaling.enabled": "true",
-				// Unlike teams-api, fiftyone-app, and teams-plugins, setting `teamsAppSettings.service.name`
-				// does not affect the label `app.kubernetes.io/name` for teams-app.
-				"teamsAppSettings.service.name": "test-service-name",
+				"teamsAppSettings.service.name":        "test-service-name",
 			},
 			map[string]string{
 				"helm.sh/chart":                fmt.Sprintf("fiftyone-teams-app-%s", chartVersion),
 				"app.kubernetes.io/version":    fmt.Sprintf("%s", chartAppVersion),
 				"app.kubernetes.io/managed-by": "Helm",
-				"app.kubernetes.io/name":       "fiftyone-teams-app",
+				"app.kubernetes.io/name":       "test-service-name",
 				"app.kubernetes.io/instance":   "fiftyone-test",
 			},
 		},

--- a/tests/unit/helm/teams-app-hpa_test.go
+++ b/tests/unit/helm/teams-app-hpa_test.go
@@ -73,7 +73,7 @@ func (s *horizontalPodAutoscalerTeamsAppTemplateTest) TestMetadataLabels() {
 				"helm.sh/chart":                fmt.Sprintf("fiftyone-teams-app-%s", chartVersion),
 				"app.kubernetes.io/version":    fmt.Sprintf("%s", chartAppVersion),
 				"app.kubernetes.io/managed-by": "Helm",
-				"app.kubernetes.io/name":       "teams-app",
+				"app.kubernetes.io/name":       "fiftyone-teams-app",
 				"app.kubernetes.io/instance":   "fiftyone-test",
 			},
 		},
@@ -81,13 +81,16 @@ func (s *horizontalPodAutoscalerTeamsAppTemplateTest) TestMetadataLabels() {
 			"overrideMetadataLabels",
 			map[string]string{
 				"teamsAppSettings.autoscaling.enabled": "true",
-				"teamsAppSettings.service.name":        "test-service-name",
+				// Unlike teams-api, fiftyone-app, and teams-plugins, setting `teamsAppSettings.service.name`
+				// does not affect the label `app.kubernetes.io/name` for teams-app.
+				// See note in _helpers.tpl.
+				"teamsAppSettings.service.name": "test-service-name",
 			},
 			map[string]string{
 				"helm.sh/chart":                fmt.Sprintf("fiftyone-teams-app-%s", chartVersion),
 				"app.kubernetes.io/version":    fmt.Sprintf("%s", chartAppVersion),
 				"app.kubernetes.io/managed-by": "Helm",
-				"app.kubernetes.io/name":       "test-service-name",
+				"app.kubernetes.io/name":       "fiftyone-teams-app",
 				"app.kubernetes.io/instance":   "fiftyone-test",
 			},
 		},

--- a/tests/unit/helm/teams-app-service_test.go
+++ b/tests/unit/helm/teams-app-service_test.go
@@ -113,20 +113,23 @@ func (s *serviceTeamsAppTemplateTest) TestMetadataLabels() {
 				"helm.sh/chart":                fmt.Sprintf("fiftyone-teams-app-%s", chartVersion),
 				"app.kubernetes.io/version":    fmt.Sprintf("%s", chartAppVersion),
 				"app.kubernetes.io/managed-by": "Helm",
-				"app.kubernetes.io/name":       "teams-app",
+				"app.kubernetes.io/name":       "fiftyone-teams-app",
 				"app.kubernetes.io/instance":   "fiftyone-test",
 			},
 		},
 		{
 			"overrideMetadataLabels",
 			map[string]string{
+				// Unlike teams-api, fiftyone-app, and teams-plugins, setting `teamsAppSettings.service.name`
+				// does not affect the label `app.kubernetes.io/name` for teams-app.
+				// See note in _helpers.tpl.
 				"teamsAppSettings.service.name": "test-service-name",
 			},
 			map[string]string{
 				"helm.sh/chart":                fmt.Sprintf("fiftyone-teams-app-%s", chartVersion),
 				"app.kubernetes.io/version":    fmt.Sprintf("%s", chartAppVersion),
 				"app.kubernetes.io/managed-by": "Helm",
-				"app.kubernetes.io/name":       "test-service-name",
+				"app.kubernetes.io/name":       "fiftyone-teams-app",
 				"app.kubernetes.io/instance":   "fiftyone-test",
 			},
 		},
@@ -384,17 +387,20 @@ func (s *serviceTeamsAppTemplateTest) TestSelectorLabels() {
 			"defaultValues",
 			nil,
 			map[string]string{
-				"app.kubernetes.io/name":     "teams-app",
+				"app.kubernetes.io/name":     "fiftyone-teams-app",
 				"app.kubernetes.io/instance": "fiftyone-test",
 			},
 		},
 		{
 			"overrideSelectorLabels",
 			map[string]string{
+				// Unlike teams-api, fiftyone-app, and teams-plugins, setting `teamsAppSettings.service.name`
+				// does not affect the label `app.kubernetes.io/name` for teams-app.
+				// See note in _helpers.tpl.
 				"teamsAppSettings.service.name": "test-service-name",
 			},
 			map[string]string{
-				"app.kubernetes.io/name":     "test-service-name",
+				"app.kubernetes.io/name":     "fiftyone-teams-app",
 				"app.kubernetes.io/instance": "fiftyone-test",
 			},
 		},

--- a/tests/unit/helm/teams-app-service_test.go
+++ b/tests/unit/helm/teams-app-service_test.go
@@ -113,22 +113,20 @@ func (s *serviceTeamsAppTemplateTest) TestMetadataLabels() {
 				"helm.sh/chart":                fmt.Sprintf("fiftyone-teams-app-%s", chartVersion),
 				"app.kubernetes.io/version":    fmt.Sprintf("%s", chartAppVersion),
 				"app.kubernetes.io/managed-by": "Helm",
-				"app.kubernetes.io/name":       "fiftyone-teams-app",
+				"app.kubernetes.io/name":       "teams-app",
 				"app.kubernetes.io/instance":   "fiftyone-test",
 			},
 		},
 		{
 			"overrideMetadataLabels",
 			map[string]string{
-				// Unlike teams-api, fiftyone-app, and teams-plugins, setting `teamsAppSettings.service.name`
-				// does not affect the label `app.kubernetes.io/name` for teams-app.
 				"teamsAppSettings.service.name": "test-service-name",
 			},
 			map[string]string{
 				"helm.sh/chart":                fmt.Sprintf("fiftyone-teams-app-%s", chartVersion),
 				"app.kubernetes.io/version":    fmt.Sprintf("%s", chartAppVersion),
 				"app.kubernetes.io/managed-by": "Helm",
-				"app.kubernetes.io/name":       "fiftyone-teams-app",
+				"app.kubernetes.io/name":       "test-service-name",
 				"app.kubernetes.io/instance":   "fiftyone-test",
 			},
 		},
@@ -386,19 +384,17 @@ func (s *serviceTeamsAppTemplateTest) TestSelectorLabels() {
 			"defaultValues",
 			nil,
 			map[string]string{
-				"app.kubernetes.io/name":     "fiftyone-teams-app",
+				"app.kubernetes.io/name":     "teams-app",
 				"app.kubernetes.io/instance": "fiftyone-test",
 			},
 		},
 		{
 			"overrideSelectorLabels",
 			map[string]string{
-				// Unlike teams-api, fiftyone-app, and teams-plugins, setting `teamsAppSettings.service.name`
-				// does not affect the label `app.kubernetes.io/name` for teams-app.
 				"teamsAppSettings.service.name": "test-service-name",
 			},
 			map[string]string{
-				"app.kubernetes.io/name":     "fiftyone-teams-app",
+				"app.kubernetes.io/name":     "test-service-name",
 				"app.kubernetes.io/instance": "fiftyone-test",
 			},
 		},


### PR DESCRIPTION
# Rationale

~~Updates to `teamsAppSettings.service.name` didn't change the metadata/selector labels in the `teams-app` service or deployment.~~ It was also confusing that changes to `teamsAppSettings.service.name` changed the metadata for the shared ingress and service account as those are not specific to the `teams-app` objects.

This PR aims to change those.

[EDIT]

Selector labels are immutable. To not break existing deployments, we will leave those and just change the `_helpers.tpl` name.

## Changes

1. Rename `"fiftyone-teams-app.selectorLabels"` to `"teams-app.selectorLabels"` in `_helpers.tpl`
2. Add specific label helpers for the service account and ingress object that are unrelated to `teams-app`
3. Updated tests to reflect the changes made

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

`helm template` for visual inspection
`make test-unit-helm-interleaved` for full unit tests
`make test-integration-helm-ci` for integration tests

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
