### PR TITLE
bumping google-github-actions from 2.1.6 to 2.1.7

### DIFF
--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -41,7 +41,7 @@ jobs:
         uses: asdf-vm/actions/install@v3.0.2
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@v2.1.6
+        uses: google-github-actions/auth@v2.1.7
         with:
           project_id: 'computer-vision-team'
           service_account: 'github@computer-vision-team.iam.gserviceaccount.com'
@@ -78,7 +78,7 @@ jobs:
         uses: asdf-vm/actions/install@v3.0.2
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@v2.1.6
+        uses: google-github-actions/auth@v2.1.7
         with:
           project_id: 'computer-vision-team'
           service_account: 'github@computer-vision-team.iam.gserviceaccount.com'


### PR DESCRIPTION
# Rationale

Bumps google-github-actions/auth from 2.1.6 to 2.1.7

Replaces [PR 234](https://github.com/voxel51/fiftyone-teams-app-deploy/pull/234)

## Changes

- bump google-github-actions/auth from 2.1.6 to 2.1.7

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

Not Applicable

## Testing

See tests below

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
