### PR TITLE
fix: AS-276 Adding Startup Probes

### DIFF
--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -430,12 +430,12 @@ Kubernetes: `>=1.18-0`
 | apiSettings.securityContext | object | `{}` | Container security configuration for teams-api. [Reference][container-security-context]. |
 | apiSettings.service.annotations | object | `{}` | Service annotations for teams-api. [Reference][annotations]. |
 | apiSettings.service.containerPort | int | `8000` | Service container port for teams-api. |
-| apiSettings.service.liveness.initialDelaySeconds | int | `15` | Number of seconds to wait before performing the liveness probe for teams-api. [Reference][probes]. |
 | apiSettings.service.name | string | `"teams-api"` | Service name. |
 | apiSettings.service.nodePort | int | `nil` | Service nodePort set only when `apiSettings.service.type: NodePort` for teams-api. |
 | apiSettings.service.port | int | `80` | Service port for teams-api. |
-| apiSettings.service.readiness.initialDelaySeconds | int | `15` | Number of seconds to wait before performing the readiness probe for teams-api. [Reference][probes]. |
 | apiSettings.service.shortname | string | `"teams-api"` | Port name (maximum length is 15 characters) for teams-api. [Reference][ports]. |
+| apiSettings.service.startup.failureThreshold | int | `5` | Number of times to retry the startup probe for the teams-api. [Reference][probes]. |
+| apiSettings.service.startup.periodSeconds | int | `5` | How often (in seconds) to perform the startup probe for teams-api. [Reference][probes]. |
 | apiSettings.service.type | string | `"ClusterIP"` | Service type for teams-api. [Reference][service-type]. |
 | apiSettings.tolerations | list | `[]` | Allow the k8s scheduler to schedule pods with matching taints for teams-api. [Reference][taints-and-tolerations]. |
 | apiSettings.volumeMounts | list | `[]` | Volume mounts for teams-api. [Reference][volumes]. |
@@ -463,12 +463,12 @@ Kubernetes: `>=1.18-0`
 | appSettings.securityContext | object | `{}` | Container security configuration for fiftyone-app. [Reference][container-security-context]. |
 | appSettings.service.annotations | object | `{}` | Service annotations for fiftyone-app. [Reference][annotations]. |
 | appSettings.service.containerPort | int | `5151` | Service container port for fiftyone-app. |
-| appSettings.service.liveness.initialDelaySeconds | int | `15` | Number of seconds to wait before performing the liveness probe for fiftyone-app. [Reference][probes]. |
 | appSettings.service.name | string | `"fiftyone-app"` | Service name. |
 | appSettings.service.nodePort | int | `nil` | Service nodePort set only when `appSettings.service.type: NodePort` for fiftyone-app. |
 | appSettings.service.port | int | `80` | Service port. |
-| appSettings.service.readiness.initialDelaySeconds | int | `15` | Number of seconds to wait before performing the readiness probe for fiftyone-app. [Reference][probes]. |
 | appSettings.service.shortname | string | `"fiftyone-app"` | Port name (maximum length is 15 characters) for fiftyone-app. [Reference][ports]. |
+| appSettings.service.startup.failureThreshold | int | `5` | Number of times to retry the startup probe for the fiftyone-app. [Reference][probes]. |
+| appSettings.service.startup.periodSeconds | int | `5` | How often (in seconds) to perform the startup probe for fiftyone-app. [Reference][probes]. |
 | appSettings.service.type | string | `"ClusterIP"` | Service type for fiftyone-app. [Reference][service-type]. |
 | appSettings.tolerations | list | `[]` | Allow the k8s scheduler to schedule fiftyone-app pods with matching taints. [Reference][taints-and-tolerations]. |
 | appSettings.volumeMounts | list | `[]` | Volume mounts for fiftyone-app. [Reference][volumes]. |
@@ -492,12 +492,12 @@ Kubernetes: `>=1.18-0`
 | casSettings.securityContext | object | `{}` | Container security configuration for teams-cas. [Reference][container-security-context]. |
 | casSettings.service.annotations | object | `{}` | Service annotations for teams-cas. [Reference][annotations]. |
 | casSettings.service.containerPort | int | `3000` | Service container port for teams-cas. |
-| casSettings.service.liveness.initialDelaySeconds | int | `15` | Number of seconds to wait before performing the liveness probe for fiftyone-app. [Reference][probes]. |
 | casSettings.service.name | string | `"teams-cas"` | Service name. |
 | casSettings.service.nodePort | int | `nil` | Service nodePort set only when `casSettings.service.type: NodePort` for teams-cas. |
 | casSettings.service.port | int | `80` | Service port. |
-| casSettings.service.readiness.initialDelaySeconds | int | `15` | Number of seconds to wait before performing the readiness probe for fiftyone-app. [Reference][probes]. |
 | casSettings.service.shortname | string | `"teams-cas"` | Port name (maximum length is 15 characters) for teams-cas. [Reference][ports]. |
+| casSettings.service.startup.failureThreshold | int | `5` | Number of times to retry the startup probe for the teams-cas. [Reference][probes]. |
+| casSettings.service.startup.periodSeconds | int | `5` | How often (in seconds) to perform the startup probe for teams-cas. [Reference][probes]. |
 | casSettings.service.type | string | `"ClusterIP"` | Service type for teams-cas. [Reference][service-type]. |
 | casSettings.tolerations | list | `[]` | Allow the k8s scheduler to schedule teams-cas pods with matching taints. [Reference][taints-and-tolerations]. |
 | casSettings.volumeMounts | list | `[]` | Volume mounts for teams-cas. [Reference][volumes]. |
@@ -544,12 +544,12 @@ Kubernetes: `>=1.18-0`
 | pluginsSettings.securityContext | object | `{}` | Container security configuration for teams-plugins. [Reference][container-security-context]. |
 | pluginsSettings.service.annotations | object | `{}` | Service annotations for teams-plugins. [Reference][annotations]. |
 | pluginsSettings.service.containerPort | int | `5151` | Service container port for teams-plugins. |
-| pluginsSettings.service.liveness.initialDelaySeconds | int | `15` | Number of seconds to wait before performing the liveness probe teams-plugins. [Reference][probes]. |
 | pluginsSettings.service.name | string | `"teams-plugins"` | Service name. |
 | pluginsSettings.service.nodePort | int | `nil` | Service nodePort set only when `pluginsSettings.service.type: NodePort` for teams-plugins. |
 | pluginsSettings.service.port | int | `80` | Service port. |
-| pluginsSettings.service.readiness.initialDelaySeconds | int | `15` | Number of seconds to wait before performing the readiness probe for teams-plugins. [Reference][probes]. |
 | pluginsSettings.service.shortname | string | `"teams-plugins"` | Port name (maximum length is 15 characters) for teams-plugins. [Reference][ports]. |
+| pluginsSettings.service.startup.failureThreshold | int | `5` | Number of times to retry the startup probe for the teams-plugins. [Reference][probes]. |
+| pluginsSettings.service.startup.periodSeconds | int | `5` | How often (in seconds) to perform the startup probe for teams-plugins. [Reference][probes]. |
 | pluginsSettings.service.type | string | `"ClusterIP"` | Service type for teams-plugins. [Reference][service-type]. |
 | pluginsSettings.tolerations | list | `[]` | Allow the k8s scheduler to schedule teams-plugins pods with matching taints. [Reference][taints-and-tolerations]. |
 | pluginsSettings.volumeMounts | list | `[]` | Volume mounts for teams-plugins pods. [Reference][volumes]. |
@@ -590,12 +590,12 @@ Kubernetes: `>=1.18-0`
 | teamsAppSettings.securityContext | object | `{}` | Container security configuration for teams-app. [Reference][container-security-context]. |
 | teamsAppSettings.service.annotations | object | `{}` | Service annotations for teams-app. [Reference][annotations]. |
 | teamsAppSettings.service.containerPort | int | `3000` | Service container port for teams-app. |
-| teamsAppSettings.service.liveness.initialDelaySeconds | int | `15` | Number of seconds to wait before performing the liveness probe for teams-app. [Reference][probes]. |
 | teamsAppSettings.service.name | string | `"teams-app"` | Service name. |
 | teamsAppSettings.service.nodePort | int | `nil` | Service nodePort set only when `teamsAppSettings.service.type: NodePort` for teams-app. |
 | teamsAppSettings.service.port | int | `80` | Service port. |
-| teamsAppSettings.service.readiness.initialDelaySeconds | int | `15` | Number of seconds to wait before performing the readiness probe for teams-app. [Reference][probes]. |
 | teamsAppSettings.service.shortname | string | `"teams-app"` | Port name (maximum length is 15 characters) for teams-app. [Reference][ports]. |
+| teamsAppSettings.service.startup.failureThreshold | int | `5` | Number of times to retry the startup probe for the teams-app. [Reference][probes]. |
+| teamsAppSettings.service.startup.periodSeconds | int | `5` | How often (in seconds) to perform the startup probe for teams-app. [Reference][probes]. |
 | teamsAppSettings.service.type | string | `"ClusterIP"` | Service type for teams-app. [Reference][service-type]. |
 | teamsAppSettings.tolerations | list | `[]` | Allow the k8s scheduler to schedule teams-app pods with matching taints. [Reference][taints-and-tolerations]. |
 | teamsAppSettings.volumeMounts | list | `[]` | Volume mounts for teams-app pods. [Reference][volumes]. |

--- a/helm/fiftyone-teams-app/templates/api-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/api-deployment.yaml
@@ -58,9 +58,9 @@ spec:
             httpGet:
               path: /health/
               port: {{ .Values.apiSettings.service.shortname }}
-            timeoutSeconds: 5
             failureThreshold: {{ .Values.apiSettings.service.startup.failureThreshold }}
             periodSeconds: {{ .Values.apiSettings.service.startup.periodSeconds }}
+            timeoutSeconds: 5
           resources:
             {{- toYaml .Values.apiSettings.resources | nindent 12 }}
           {{- with .Values.apiSettings.volumeMounts }}

--- a/helm/fiftyone-teams-app/templates/api-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/api-deployment.yaml
@@ -48,14 +48,19 @@ spec:
             httpGet:
               path: /health/
               port: {{ .Values.apiSettings.service.shortname }}
-            initialDelaySeconds: {{ .Values.apiSettings.service.liveness.initialDelaySeconds }}
             timeoutSeconds: 5
           readinessProbe:
             httpGet:
               path: /health/
               port: {{ .Values.apiSettings.service.shortname }}
-            initialDelaySeconds: {{ .Values.apiSettings.service.readiness.initialDelaySeconds }}
             timeoutSeconds: 5
+          startupProbe:
+            httpGet:
+              path: /health/
+              port: {{ .Values.apiSettings.service.shortname }}
+            timeoutSeconds: 5
+            failureThreshold: {{ .Values.apiSettings.service.startup.failureThreshold }}
+            periodSeconds: {{ .Values.apiSettings.service.startup.periodSeconds }}
           resources:
             {{- toYaml .Values.apiSettings.resources | nindent 12 }}
           {{- with .Values.apiSettings.volumeMounts }}

--- a/helm/fiftyone-teams-app/templates/app-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/app-deployment.yaml
@@ -54,9 +54,9 @@ spec:
           startupProbe:
             tcpSocket:
               port: {{ .Values.appSettings.service.shortname }}
-            timeoutSeconds: 5
             failureThreshold: {{ .Values.appSettings.service.startup.failureThreshold }}
             periodSeconds: {{ .Values.appSettings.service.startup.periodSeconds }}
+            timeoutSeconds: 5
           resources:
             {{- toYaml .Values.appSettings.resources | nindent 12 }}
           {{- with .Values.appSettings.volumeMounts }}

--- a/helm/fiftyone-teams-app/templates/app-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/app-deployment.yaml
@@ -46,13 +46,17 @@ spec:
           livenessProbe:
             tcpSocket:
               port: {{ .Values.appSettings.service.shortname }}
-            initialDelaySeconds: {{ .Values.appSettings.service.liveness.initialDelaySeconds }}
             timeoutSeconds: 5
           readinessProbe:
             tcpSocket:
               port: {{ .Values.appSettings.service.shortname }}
-            initialDelaySeconds: {{ .Values.appSettings.service.readiness.initialDelaySeconds }}
             timeoutSeconds: 5
+          startupProbe:
+            tcpSocket:
+              port: {{ .Values.appSettings.service.shortname }}
+            timeoutSeconds: 5
+            failureThreshold: {{ .Values.appSettings.service.startup.failureThreshold }}
+            periodSeconds: {{ .Values.appSettings.service.startup.periodSeconds }}
           resources:
             {{- toYaml .Values.appSettings.resources | nindent 12 }}
           {{- with .Values.appSettings.volumeMounts }}

--- a/helm/fiftyone-teams-app/templates/cas-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/cas-deployment.yaml
@@ -45,14 +45,19 @@ spec:
             httpGet:
               path: /cas/api
               port: {{ .Values.casSettings.service.shortname }}
-            initialDelaySeconds: {{ .Values.casSettings.service.liveness.initialDelaySeconds }}
             timeoutSeconds: 5
           readinessProbe:
             httpGet:
               path: /cas/api
               port: {{ .Values.casSettings.service.shortname }}
-            initialDelaySeconds: {{ .Values.casSettings.service.readiness.initialDelaySeconds }}
             timeoutSeconds: 5
+          startupProbe:
+            httpGet:
+              path: /cas/api
+              port: {{ .Values.casSettings.service.shortname }}
+            timeoutSeconds: 5
+            failureThreshold: {{ .Values.casSettings.service.startup.failureThreshold }}
+            periodSeconds: {{ .Values.casSettings.service.startup.periodSeconds }}
           resources:
             {{- toYaml .Values.casSettings.resources | nindent 12 }}
           volumeMounts:

--- a/helm/fiftyone-teams-app/templates/cas-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/cas-deployment.yaml
@@ -55,9 +55,9 @@ spec:
             httpGet:
               path: /cas/api
               port: {{ .Values.casSettings.service.shortname }}
-            timeoutSeconds: 5
             failureThreshold: {{ .Values.casSettings.service.startup.failureThreshold }}
             periodSeconds: {{ .Values.casSettings.service.startup.periodSeconds }}
+            timeoutSeconds: 5
           resources:
             {{- toYaml .Values.casSettings.resources | nindent 12 }}
           volumeMounts:

--- a/helm/fiftyone-teams-app/templates/plugins-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/plugins-deployment.yaml
@@ -47,13 +47,17 @@ spec:
           livenessProbe:
             tcpSocket:
               port: {{ .Values.pluginsSettings.service.shortname }}
-            initialDelaySeconds: {{ .Values.pluginsSettings.service.liveness.initialDelaySeconds }}
             timeoutSeconds: 5
           readinessProbe:
             tcpSocket:
               port: {{ .Values.pluginsSettings.service.shortname }}
-            initialDelaySeconds: {{ .Values.pluginsSettings.service.readiness.initialDelaySeconds }}
             timeoutSeconds: 5
+          startupProbe:
+            tcpSocket:
+              port: {{ .Values.pluginsSettings.service.shortname }}
+            timeoutSeconds: 5
+            failureThreshold: {{ .Values.pluginsSettings.service.startup.failureThreshold }}
+            periodSeconds: {{ .Values.pluginsSettings.service.startup.periodSeconds }}
           resources:
             {{- toYaml .Values.pluginsSettings.resources | nindent 12 }}
           {{- with .Values.pluginsSettings.volumeMounts }}

--- a/helm/fiftyone-teams-app/templates/plugins-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/plugins-deployment.yaml
@@ -55,9 +55,9 @@ spec:
           startupProbe:
             tcpSocket:
               port: {{ .Values.pluginsSettings.service.shortname }}
-            timeoutSeconds: 5
             failureThreshold: {{ .Values.pluginsSettings.service.startup.failureThreshold }}
             periodSeconds: {{ .Values.pluginsSettings.service.startup.periodSeconds }}
+            timeoutSeconds: 5
           resources:
             {{- toYaml .Values.pluginsSettings.resources | nindent 12 }}
           {{- with .Values.pluginsSettings.volumeMounts }}

--- a/helm/fiftyone-teams-app/templates/teams-app-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/teams-app-deployment.yaml
@@ -57,9 +57,9 @@ spec:
             httpGet:
               path: /api/hello
               port: {{ .Values.teamsAppSettings.service.shortname }}
-            timeoutSeconds: 5
             failureThreshold: {{ .Values.teamsAppSettings.service.startup.failureThreshold }}
             periodSeconds: {{ .Values.teamsAppSettings.service.startup.periodSeconds }}
+            timeoutSeconds: 5
           resources:
             {{- toYaml .Values.teamsAppSettings.resources | nindent 12 }}
           {{- with .Values.teamsAppSettings.volumeMounts }}

--- a/helm/fiftyone-teams-app/templates/teams-app-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/teams-app-deployment.yaml
@@ -47,14 +47,19 @@ spec:
             httpGet:
               path: /api/hello
               port: {{ .Values.teamsAppSettings.service.shortname }}
-            initialDelaySeconds: {{ .Values.teamsAppSettings.service.liveness.initialDelaySeconds }}
             timeoutSeconds: 5
           readinessProbe:
             httpGet:
               path: /api/hello
               port: {{ .Values.teamsAppSettings.service.shortname }}
-            initialDelaySeconds: {{ .Values.teamsAppSettings.service.readiness.initialDelaySeconds }}
             timeoutSeconds: 5
+          startupProbe:
+            httpGet:
+              path: /api/hello
+              port: {{ .Values.teamsAppSettings.service.shortname }}
+            timeoutSeconds: 5
+            failureThreshold: {{ .Values.teamsAppSettings.service.startup.failureThreshold }}
+            periodSeconds: {{ .Values.teamsAppSettings.service.startup.periodSeconds }}
           resources:
             {{- toYaml .Values.teamsAppSettings.resources | nindent 12 }}
           {{- with .Values.teamsAppSettings.volumeMounts }}

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -51,21 +51,21 @@ apiSettings:
     annotations: {}
     # -- Service container port for teams-api.
     containerPort: 8000
-    liveness:
-      # -- Number of seconds to wait before performing the liveness probe for teams-api. [Reference][probes].
-      initialDelaySeconds: 15
     # -- Service name.
     name: teams-api
     # -- (int) Service nodePort set only when `apiSettings.service.type: NodePort` for teams-api.
     nodePort:
     # -- Service port for teams-api.
     port: 80
-    readiness:
-      # -- Number of seconds to wait before performing the readiness probe for teams-api. [Reference][probes].
-      initialDelaySeconds: 15
     # TODO: Kevin/topher - Consider changing name from `shortname` to `portName`.
+    # TODO: Alex - Default should include protocol in the name per kubernetes standards.
     # -- Port name (maximum length is 15 characters) for teams-api. [Reference][ports].
     shortname: teams-api
+    startup:
+      # -- Number of times to retry the startup probe for the teams-api. [Reference][probes].
+      failureThreshold: 5
+      # -- How often (in seconds) to perform the startup probe for teams-api. [Reference][probes].
+      periodSeconds: 5
     # -- Service type for teams-api. [Reference][service-type].
     type: ClusterIP
 
@@ -154,21 +154,21 @@ appSettings:
     annotations: {}
     # -- Service container port for fiftyone-app.
     containerPort: 5151
-    liveness:
-      # -- Number of seconds to wait before performing the liveness probe for fiftyone-app. [Reference][probes].
-      initialDelaySeconds: 15
     # -- Service name.
     name: fiftyone-app
     # -- (int) Service nodePort set only when `appSettings.service.type: NodePort` for fiftyone-app.
     nodePort:
     # -- Service port.
     port: 80
-    readiness:
-      # -- Number of seconds to wait before performing the readiness probe for fiftyone-app. [Reference][probes].
-      initialDelaySeconds: 15
     # TODO: Kevin/topher - Consider changing name from `shortname` to `portName`.
+    # TODO: Alex - Default should include protocol in the name per kubernetes standards.
     # -- Port name (maximum length is 15 characters) for fiftyone-app. [Reference][ports].
     shortname: fiftyone-app
+    startup:
+      # -- Number of times to retry the startup probe for the fiftyone-app. [Reference][probes].
+      failureThreshold: 5
+      # -- How often (in seconds) to perform the startup probe for fiftyone-app. [Reference][probes].
+      periodSeconds: 5
     # -- Service type for fiftyone-app. [Reference][service-type].
     type: ClusterIP
 
@@ -246,21 +246,21 @@ casSettings:
     annotations: {}
     # -- Service container port for teams-cas.
     containerPort: 3000
-    liveness:
-      # -- Number of seconds to wait before performing the liveness probe for fiftyone-app. [Reference][probes].
-      initialDelaySeconds: 15
     # -- Service name.
     name: teams-cas
     # -- (int) Service nodePort set only when `casSettings.service.type: NodePort` for teams-cas.
     nodePort:
     # -- Service port.
     port: 80
-    readiness:
-      # -- Number of seconds to wait before performing the readiness probe for fiftyone-app. [Reference][probes].
-      initialDelaySeconds: 15
     # TODO: Kevin/topher - Consider changing name from `shortname` to `portName`.
+    # TODO: Alex - Default should include protocol in the name per kubernetes standards.
     # -- Port name (maximum length is 15 characters) for teams-cas. [Reference][ports].
     shortname: teams-cas
+    startup:
+      # -- Number of times to retry the startup probe for the teams-cas. [Reference][probes].
+      failureThreshold: 5
+      # -- How often (in seconds) to perform the startup probe for teams-cas. [Reference][probes].
+      periodSeconds: 5
     # -- Service type for teams-cas. [Reference][service-type].
     type: ClusterIP
 
@@ -405,21 +405,21 @@ pluginsSettings:
     annotations: {}
     # -- Service container port for teams-plugins.
     containerPort: 5151
-    liveness:
-      # -- Number of seconds to wait before performing the liveness probe teams-plugins. [Reference][probes].
-      initialDelaySeconds: 15
     # -- Service name.
     name: teams-plugins
     # -- (int) Service nodePort set only when `pluginsSettings.service.type: NodePort` for teams-plugins.
     nodePort:
     # -- Service port.
     port: 80
-    readiness:
-      # -- Number of seconds to wait before performing the readiness probe for teams-plugins. [Reference][probes].
-      initialDelaySeconds: 15
     # TODO: Kevin/topher - Consider changing name from `shortname` to `portName`.
+    # TODO: Alex - Default should include protocol in the name per kubernetes standards.
     # -- Port name (maximum length is 15 characters) for teams-plugins. [Reference][ports].
     shortname: teams-plugins
+    startup:
+      # -- Number of times to retry the startup probe for the teams-plugins. [Reference][probes].
+      failureThreshold: 5
+      # -- How often (in seconds) to perform the startup probe for teams-plugins. [Reference][probes].
+      periodSeconds: 5
     # -- Service type for teams-plugins. [Reference][service-type].
     type: ClusterIP
 
@@ -552,21 +552,21 @@ teamsAppSettings:
     annotations: {}
     # -- Service container port for teams-app.
     containerPort: 3000
-    liveness:
-      # -- Number of seconds to wait before performing the liveness probe for teams-app. [Reference][probes].
-      initialDelaySeconds: 15
     # -- Service name.
     name: teams-app
     # -- (int) Service nodePort set only when `teamsAppSettings.service.type: NodePort` for teams-app.
     nodePort:
     # -- Service port.
     port: 80
-    readiness:
-      # -- Number of seconds to wait before performing the readiness probe for teams-app. [Reference][probes].
-      initialDelaySeconds: 15
     # TODO: Kevin/topher - Consider changing name from `shortname` to `portName`.
+    # TODO: Alex - Default should include protocol in the name per kubernetes standards.
     # -- Port name (maximum length is 15 characters) for teams-app. [Reference][ports].
     shortname: teams-app
+    startup:
+      # -- Number of times to retry the startup probe for the teams-app. [Reference][probes].
+      failureThreshold: 5
+      # -- How often (in seconds) to perform the startup probe for teams-app. [Reference][probes].
+      periodSeconds: 5
     # -- Service type for teams-app. [Reference][service-type].
     type: ClusterIP
 

--- a/tests/unit/helm/api-deployment_test.go
+++ b/tests/unit/helm/api-deployment_test.go
@@ -859,8 +859,8 @@ func (s *deploymentApiTemplateTest) TestContainerStartupProbe() {
             "path": "/health/",
             "port": "teams-api"
           },
-		  "failureThreshold": 5,
-		  "periodSeconds": 5,
+          "failureThreshold": 5,
+          "periodSeconds": 5,
           "timeoutSeconds": 5
         }`
 				var expectedProbe *corev1.Probe
@@ -882,8 +882,8 @@ func (s *deploymentApiTemplateTest) TestContainerStartupProbe() {
             "path": "/health/",
             "port": "test-service-shortname"
           },
-		  "failureThreshold": 10,
-		  "periodSeconds": 10,
+          "failureThreshold": 10,
+          "periodSeconds": 10,
           "timeoutSeconds": 5
         }`
 				var expectedProbe *corev1.Probe

--- a/tests/unit/helm/app-deployment_test.go
+++ b/tests/unit/helm/app-deployment_test.go
@@ -844,8 +844,8 @@ func (s *deploymentAppTemplateTest) TestContainerStartupProbe() {
           "tcpSocket": {
             "port": "fiftyone-app"
           },
-		  "failureThreshold": 5,
-		  "periodSeconds": 5,
+          "failureThreshold": 5,
+          "periodSeconds": 5,
           "timeoutSeconds": 5
         }`
 				var expectedProbe *corev1.Probe
@@ -866,8 +866,8 @@ func (s *deploymentAppTemplateTest) TestContainerStartupProbe() {
           "tcpSocket": {
             "port": "test-service-shortname"
           },
-		  "failureThreshold": 10,
-		  "periodSeconds": 10,
+          "failureThreshold": 10,
+          "periodSeconds": 10,
           "timeoutSeconds": 5
         }`
 				var expectedProbe *corev1.Probe

--- a/tests/unit/helm/app-deployment_test.go
+++ b/tests/unit/helm/app-deployment_test.go
@@ -661,7 +661,6 @@ func (s *deploymentAppTemplateTest) TestContainerLivenessProbe() {
           "tcpSocket": {
             "port": "fiftyone-app"
           },
-          "initialDelaySeconds": 15,
           "timeoutSeconds": 5
         }`
 				var expectedProbe *corev1.Probe
@@ -671,17 +670,15 @@ func (s *deploymentAppTemplateTest) TestContainerLivenessProbe() {
 			},
 		},
 		{
-			"overrideServiceLivenessInitialDelaySecondsAndShortName",
+			"overrideServiceLivenessShortName",
 			map[string]string{
-				"appSettings.service.liveness.initialDelaySeconds": "30",
-				"appSettings.service.shortname":                    "test-service-shortname",
+				"appSettings.service.shortname": "test-service-shortname",
 			},
 			func(probe *corev1.Probe) {
 				expectedProbeJSON := `{
           "tcpSocket": {
             "port": "test-service-shortname"
           },
-          "initialDelaySeconds": 30,
           "timeoutSeconds": 5
         }`
 				var expectedProbe *corev1.Probe
@@ -787,7 +784,6 @@ func (s *deploymentAppTemplateTest) TestContainerReadinessProbe() {
           "tcpSocket": {
             "port": "fiftyone-app"
           },
-          "initialDelaySeconds": 15,
           "timeoutSeconds": 5
         }`
 				var expectedProbe *corev1.Probe
@@ -797,17 +793,15 @@ func (s *deploymentAppTemplateTest) TestContainerReadinessProbe() {
 			},
 		},
 		{
-			"overrideServiceReadinessInitialDelaySecondsAndShortName",
+			"overrideServiceReadinessShortName",
 			map[string]string{
-				"appSettings.service.readiness.initialDelaySeconds": "30",
-				"appSettings.service.shortname":                     "test-service-shortname",
+				"appSettings.service.shortname": "test-service-shortname",
 			},
 			func(probe *corev1.Probe) {
 				expectedProbeJSON := `{
           "tcpSocket": {
             "port": "test-service-shortname"
           },
-          "initialDelaySeconds": 30,
           "timeoutSeconds": 5
         }`
 				var expectedProbe *corev1.Probe
@@ -832,6 +826,72 @@ func (s *deploymentAppTemplateTest) TestContainerReadinessProbe() {
 			helm.UnmarshalK8SYaml(subT, output, &deployment)
 
 			testCase.expected(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe)
+		})
+	}
+}
+
+func (s *deploymentAppTemplateTest) TestContainerStartupProbe() {
+	testCases := []struct {
+		name     string
+		values   map[string]string
+		expected func(probe *corev1.Probe)
+	}{
+		{
+			"defaultValues",
+			nil,
+			func(probe *corev1.Probe) {
+				expectedProbeJSON := `{
+          "tcpSocket": {
+            "port": "fiftyone-app"
+          },
+		  "failureThreshold": 5,
+		  "periodSeconds": 5,
+          "timeoutSeconds": 5
+        }`
+				var expectedProbe *corev1.Probe
+				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
+				s.NoError(err)
+				s.Equal(expectedProbe, probe, "Startup Probes should be equal")
+			},
+		},
+		{
+			"overrideServiceStartupFailureThresholdAndPeriodSecondsAndShortName",
+			map[string]string{
+				"appSettings.service.shortname":                "test-service-shortname",
+				"appSettings.service.startup.failureThreshold": "10",
+				"appSettings.service.startup.periodSeconds":    "10",
+			},
+			func(probe *corev1.Probe) {
+				expectedProbeJSON := `{
+          "tcpSocket": {
+            "port": "test-service-shortname"
+          },
+		  "failureThreshold": 10,
+		  "periodSeconds": 10,
+          "timeoutSeconds": 5
+        }`
+				var expectedProbe *corev1.Probe
+				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
+				s.NoError(err)
+				s.Equal(expectedProbe, probe, "Startup Probes should be equal")
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		s.Run(testCase.name, func() {
+			subT := s.T()
+			subT.Parallel()
+
+			options := &helm.Options{SetValues: testCase.values}
+			output := helm.RenderTemplate(subT, options, s.chartPath, s.releaseName, s.templates)
+
+			var deployment appsv1.Deployment
+			helm.UnmarshalK8SYaml(subT, output, &deployment)
+
+			testCase.expected(deployment.Spec.Template.Spec.Containers[0].StartupProbe)
 		})
 	}
 }

--- a/tests/unit/helm/cas-deployment_test.go
+++ b/tests/unit/helm/cas-deployment_test.go
@@ -956,8 +956,8 @@ func (s *deploymentCasTemplateTest) TestContainerStartupProbe() {
             "path": "/cas/api",
             "port": "teams-cas"
           },
-		  "failureThreshold": 5,
-		  "periodSeconds": 5,
+          "failureThreshold": 5,
+          "periodSeconds": 5,
           "timeoutSeconds": 5
         }`
 				var expectedProbe *corev1.Probe
@@ -979,8 +979,8 @@ func (s *deploymentCasTemplateTest) TestContainerStartupProbe() {
             "path": "/cas/api",
             "port": "test-service-shortname"
           },
-		  "failureThreshold": 10,
-		  "periodSeconds": 10,
+          "failureThreshold": 10,
+          "periodSeconds": 10,
           "timeoutSeconds": 5
         }`
 				var expectedProbe *corev1.Probe

--- a/tests/unit/helm/plugins-deployment_test.go
+++ b/tests/unit/helm/plugins-deployment_test.go
@@ -845,7 +845,6 @@ func (s *deploymentPluginsTemplateTest) TestContainerLivenessProbe() {
           "tcpSocket": {
             "port": "teams-plugins"
           },
-          "initialDelaySeconds": 15,
           "timeoutSeconds": 5
         }`
 				var expectedProbe *corev1.Probe
@@ -855,18 +854,16 @@ func (s *deploymentPluginsTemplateTest) TestContainerLivenessProbe() {
 			},
 		},
 		{
-			"overrideServiceLivenessInitialDelaySecondsAndShortName",
+			"overrideServiceLivenessAndShortName",
 			map[string]string{
-				"pluginsSettings.enabled":                              "true",
-				"pluginsSettings.service.liveness.initialDelaySeconds": "30",
-				"pluginsSettings.service.shortname":                    "test-service-shortname",
+				"pluginsSettings.enabled":           "true",
+				"pluginsSettings.service.shortname": "test-service-shortname",
 			},
 			func(probe *corev1.Probe) {
 				expectedProbeJSON := `{
           "tcpSocket": {
             "port": "test-service-shortname"
           },
-          "initialDelaySeconds": 30,
           "timeoutSeconds": 5
         }`
 				var expectedProbe *corev1.Probe
@@ -1017,7 +1014,6 @@ func (s *deploymentPluginsTemplateTest) TestContainerReadinessProbe() {
           "tcpSocket": {
             "port": "teams-plugins"
           },
-          "initialDelaySeconds": 15,
           "timeoutSeconds": 5
         }`
 				var expectedProbe *corev1.Probe
@@ -1027,18 +1023,16 @@ func (s *deploymentPluginsTemplateTest) TestContainerReadinessProbe() {
 			},
 		},
 		{
-			"overrideServiceReadinessInitialDelaySecondsAndShortName",
+			"overrideServiceReadinessAndShortName",
 			map[string]string{
-				"pluginsSettings.enabled":                               "true",
-				"pluginsSettings.service.readiness.initialDelaySeconds": "30",
-				"pluginsSettings.service.shortname":                     "test-service-shortname",
+				"pluginsSettings.enabled":           "true",
+				"pluginsSettings.service.shortname": "test-service-shortname",
 			},
 			func(probe *corev1.Probe) {
 				expectedProbeJSON := `{
           "tcpSocket": {
             "port": "test-service-shortname"
           },
-          "initialDelaySeconds": 30,
           "timeoutSeconds": 5
         }`
 				var expectedProbe *corev1.Probe
@@ -1075,6 +1069,95 @@ func (s *deploymentPluginsTemplateTest) TestContainerReadinessProbe() {
 				helm.UnmarshalK8SYaml(subT, output, &deployment)
 
 				testCase.expected(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe)
+			}
+		})
+	}
+}
+
+func (s *deploymentPluginsTemplateTest) TestContainerStartupProbe() {
+	testCases := []struct {
+		name     string
+		values   map[string]string
+		expected func(probe *corev1.Probe)
+	}{
+		{
+			"defaultValues",
+			nil,
+			func(probe *corev1.Probe) {
+				s.Empty(probe, "Startup Probes should not be set")
+			},
+		},
+		{
+			"defaultValuesPluginsEnabled",
+			map[string]string{
+				"pluginsSettings.enabled": "true",
+			},
+			func(probe *corev1.Probe) {
+				expectedProbeJSON := `{
+          "tcpSocket": {
+            "port": "teams-plugins"
+          },
+		  "failureThreshold": 5,
+		  "periodSeconds": 5,
+          "timeoutSeconds": 5
+        }`
+				var expectedProbe *corev1.Probe
+				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
+				s.NoError(err)
+				s.Equal(expectedProbe, probe, "Startup Probes should be equal")
+			},
+		},
+		{
+			"overrideServiceStartupFailureThresholdAndPeriodSecondsAndShortName",
+			map[string]string{
+				"pluginsSettings.enabled":                          "true",
+				"pluginsSettings.service.shortname":                "test-service-shortname",
+				"pluginsSettings.service.startup.failureThreshold": "10",
+				"pluginsSettings.service.startup.periodSeconds":    "10",
+			},
+			func(probe *corev1.Probe) {
+				expectedProbeJSON := `{
+          "tcpSocket": {
+            "port": "test-service-shortname"
+          },
+		  "failureThreshold": 10,
+		  "periodSeconds": 10,
+          "timeoutSeconds": 5
+        }`
+				var expectedProbe *corev1.Probe
+				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
+				s.NoError(err)
+				s.Equal(expectedProbe, probe, "Startup Probes should be equal")
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		s.Run(testCase.name, func() {
+			subT := s.T()
+			subT.Parallel()
+
+			// when vars are set outside of the if statement, they aren't accessible from within the conditional
+			if testCase.values == nil {
+				options := &helm.Options{SetValues: testCase.values}
+				output, err := helm.RenderTemplateE(subT, options, s.chartPath, s.releaseName, s.templates)
+
+				s.ErrorContains(err, "could not find template templates/plugins-deployment.yaml in chart")
+				var deployment appsv1.Deployment
+
+				helm.UnmarshalK8SYaml(subT, output, &deployment)
+
+				s.Nil(deployment.Spec.Template.Spec.Containers)
+			} else {
+				options := &helm.Options{SetValues: testCase.values}
+				output := helm.RenderTemplate(subT, options, s.chartPath, s.releaseName, s.templates)
+
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(subT, output, &deployment)
+
+				testCase.expected(deployment.Spec.Template.Spec.Containers[0].StartupProbe)
 			}
 		})
 	}

--- a/tests/unit/helm/plugins-deployment_test.go
+++ b/tests/unit/helm/plugins-deployment_test.go
@@ -1097,8 +1097,8 @@ func (s *deploymentPluginsTemplateTest) TestContainerStartupProbe() {
           "tcpSocket": {
             "port": "teams-plugins"
           },
-		  "failureThreshold": 5,
-		  "periodSeconds": 5,
+          "failureThreshold": 5,
+          "periodSeconds": 5,
           "timeoutSeconds": 5
         }`
 				var expectedProbe *corev1.Probe
@@ -1120,8 +1120,8 @@ func (s *deploymentPluginsTemplateTest) TestContainerStartupProbe() {
           "tcpSocket": {
             "port": "test-service-shortname"
           },
-		  "failureThreshold": 10,
-		  "periodSeconds": 10,
+          "failureThreshold": 10,
+          "periodSeconds": 10,
           "timeoutSeconds": 5
         }`
 				var expectedProbe *corev1.Probe

--- a/tests/unit/helm/teams-app-deployment_test.go
+++ b/tests/unit/helm/teams-app-deployment_test.go
@@ -767,8 +767,8 @@ func (s *deploymentTeamsAppTemplateTest) TestContainerStartupProbe() {
             "path": "/api/hello",
             "port": "teams-app"
           },
-		  "failureThreshold": 5,
-		  "periodSeconds": 5,
+          "failureThreshold": 5,
+          "periodSeconds": 5,
           "timeoutSeconds": 5
         }`
 				var expectedProbe *corev1.Probe
@@ -790,8 +790,8 @@ func (s *deploymentTeamsAppTemplateTest) TestContainerStartupProbe() {
             "path": "/api/hello",
             "port": "test-service-shortname"
           },
-		  "failureThreshold": 10,
-		  "periodSeconds": 10,
+          "failureThreshold": 10,
+          "periodSeconds": 10,
           "timeoutSeconds": 5
         }`
 				var expectedProbe *corev1.Probe

--- a/tests/unit/helm/teams-app-deployment_test.go
+++ b/tests/unit/helm/teams-app-deployment_test.go
@@ -580,7 +580,6 @@ func (s *deploymentTeamsAppTemplateTest) TestContainerLivenessProbe() {
             "path": "/api/hello",
             "port": "teams-app"
           },
-          "initialDelaySeconds": 15,
           "timeoutSeconds": 5
         }`
 				var expectedProbe *corev1.Probe
@@ -590,10 +589,9 @@ func (s *deploymentTeamsAppTemplateTest) TestContainerLivenessProbe() {
 			},
 		},
 		{
-			"overrideServiceLivenessInitialDelaySecondsAndShortName",
+			"overrideServiceLivenessShortName",
 			map[string]string{
-				"teamsAppSettings.service.liveness.initialDelaySeconds": "30",
-				"teamsAppSettings.service.shortname":                    "test-service-shortname",
+				"teamsAppSettings.service.shortname": "test-service-shortname",
 			},
 			func(probe *corev1.Probe) {
 				expectedProbeJSON := `{
@@ -601,7 +599,6 @@ func (s *deploymentTeamsAppTemplateTest) TestContainerLivenessProbe() {
             "path": "/api/hello",
             "port": "test-service-shortname"
           },
-          "initialDelaySeconds": 30,
           "timeoutSeconds": 5
         }`
 				var expectedProbe *corev1.Probe
@@ -708,7 +705,6 @@ func (s *deploymentTeamsAppTemplateTest) TestContainerReadinessProbe() {
             "path": "/api/hello",
             "port": "teams-app"
           },
-          "initialDelaySeconds": 15,
           "timeoutSeconds": 5
         }`
 				var expectedProbe *corev1.Probe
@@ -718,10 +714,9 @@ func (s *deploymentTeamsAppTemplateTest) TestContainerReadinessProbe() {
 			},
 		},
 		{
-			"overrideServiceReadinessInitialDelaySecondsAndShortName",
+			"overrideServiceReadinessShortName",
 			map[string]string{
-				"teamsAppSettings.service.readiness.initialDelaySeconds": "30",
-				"teamsAppSettings.service.shortname":                     "test-service-shortname",
+				"teamsAppSettings.service.shortname": "test-service-shortname",
 			},
 			func(probe *corev1.Probe) {
 				expectedProbeJSON := `{
@@ -729,7 +724,6 @@ func (s *deploymentTeamsAppTemplateTest) TestContainerReadinessProbe() {
             "path": "/api/hello",
             "port": "test-service-shortname"
           },
-          "initialDelaySeconds": 30,
           "timeoutSeconds": 5
         }`
 				var expectedProbe *corev1.Probe
@@ -754,6 +748,74 @@ func (s *deploymentTeamsAppTemplateTest) TestContainerReadinessProbe() {
 			helm.UnmarshalK8SYaml(subT, output, &deployment)
 
 			testCase.expected(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe)
+		})
+	}
+}
+
+func (s *deploymentTeamsAppTemplateTest) TestContainerStartupProbe() {
+	testCases := []struct {
+		name     string
+		values   map[string]string
+		expected func(probe *corev1.Probe)
+	}{
+		{
+			"defaultValues",
+			nil,
+			func(probe *corev1.Probe) {
+				expectedProbeJSON := `{
+          "httpGet": {
+            "path": "/api/hello",
+            "port": "teams-app"
+          },
+		  "failureThreshold": 5,
+		  "periodSeconds": 5,
+          "timeoutSeconds": 5
+        }`
+				var expectedProbe *corev1.Probe
+				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
+				s.NoError(err)
+				s.Equal(expectedProbe, probe, "Startup Probes should be equal")
+			},
+		},
+		{
+			"overrideServiceStartupFailureThresholdAndPeriodSecondsAndShortName",
+			map[string]string{
+				"teamsAppSettings.service.shortname":                "test-service-shortname",
+				"teamsAppSettings.service.startup.failureThreshold": "10",
+				"teamsAppSettings.service.startup.periodSeconds":    "10",
+			},
+			func(probe *corev1.Probe) {
+				expectedProbeJSON := `{
+          "httpGet": {
+            "path": "/api/hello",
+            "port": "test-service-shortname"
+          },
+		  "failureThreshold": 10,
+		  "periodSeconds": 10,
+          "timeoutSeconds": 5
+        }`
+				var expectedProbe *corev1.Probe
+				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
+				s.NoError(err)
+				s.Equal(expectedProbe, probe, "Startup Probes should be equal")
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		s.Run(testCase.name, func() {
+			subT := s.T()
+			subT.Parallel()
+
+			options := &helm.Options{SetValues: testCase.values}
+			output := helm.RenderTemplate(subT, options, s.chartPath, s.releaseName, s.templates)
+
+			var deployment appsv1.Deployment
+			helm.UnmarshalK8SYaml(subT, output, &deployment)
+
+			testCase.expected(deployment.Spec.Template.Spec.Containers[0].StartupProbe)
 		})
 	}
 }


### PR DESCRIPTION
# Rationale

Kubernetes supports [startup probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes) which seems like a preferred method over `initialDelaySeconds`.

This PR aims to deprecate/remove `initialDelaySeconds` and replace it with actionable `startupProbes`. The probe definitions are the same as the `livenessProbe` and `readinessProbe` definitions, however, the shouldn't cycle pods as often.

Also adding TODO notes about port naming so that we adhere to typical Kubernetes standards (using `<protocol>-<name>` as port names).

## Changes

* Removes `initialDelaySeconds` from  `livenessProbe` and `readinessProbe` definitions. Also removes the corresponding item in the `values.yaml`.
* Adds `startupProbe` definitions to the templates. Also adds `startup` section to allow for configuration of the probe.
* Updates README
* Updates unit tests to handle changes

`initContainers` will also be tagged as `AS-276`. But the body of work won't be small, so it seems like a good idea to do 2 PRs.

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

```shell
helm template
make test-unit-helm-interleaved
make test-integration-helm-ci
```

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
