### PR TITLE
feat: AS-321 Adding topology spread constraints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,7 +225,7 @@ test-integration-compose-interleaved-legacy: install-terratest-log-parser copy-l
 	go test -count=1 -timeout=15m -v -tags integrationComposeLegacyAuth | tee test_output_legacy.log; \
 	${ASDF}/packages/bin/terratest_log_parser -testlog test_output_legacy.log -outputdir test_output_legacy
 
-test-integration-helm-ci: ## set context, install mongodb, and ## run go test on the tests/integration/helm directory for both internal and legacy auth modes
+test-integration-helm-ci: ## set context, install mongodb, and run go test on the tests/integration/helm directory for both internal and legacy auth modes with topology constraints
 	@CLST=$(shell gcloud container clusters list --filter="name : voxel51-ephemeral-test-*" --format="get(name)"); \
 	INTEGRATION_TEST_KUBECONTEXT=gke_computer-vision-team_us-east4_$${CLST}; \
 	gcloud container clusters get-credentials \
@@ -237,13 +237,23 @@ test-integration-helm-ci: ## set context, install mongodb, and ## run go test on
 		--kube-context=$${INTEGRATION_TEST_KUBECONTEXT}; \
 	INTEGRATION_TEST_KUBECONTEXT=$${INTEGRATION_TEST_KUBECONTEXT} GOMAXPROCS=2 make test-integration-helm
 
-test-integration-helm: test-integration-helm-internal test-integration-helm-legacy ## run go test on the tests/integration/helm directory for both internal and legacy auth modes
+test-integration-helm: test-integration-helm-internal test-integration-helm-legacy test-integration-helm-topology ## run go test on the tests/integration/helm directory for both internal and legacy auth modes with topology constraints
 
-test-integration-helm-interleaved: test-integration-helm-interleaved-internal test-integration-helm-interleaved-legacy ## run go test on the tests/integration/helm directory for both internal and legacy auth modes
+test-integration-helm-interleaved: test-integration-helm-interleaved-internal test-integration-helm-interleaved-legacy test-integration-helm-interleaved-topology ## run go test on the tests/integration/helm directory for both internal and legacy auth modes with topology constraints
+
+test-integration-helm-topology: copy-license-files-helm  ## run go test on the tests/integration/helm directory for topology constraints
+	@cd tests/integration/helm; \
+	go test -count=1 -timeout=15m -v -tags integrationHelmTopology
 
 test-integration-helm-internal: copy-license-files-helm  ## run go test on the tests/integration/helm directory for internal auth mode
 	@cd tests/integration/helm; \
 	go test -count=1 -timeout=15m -v -tags integrationHelmInternalAuth
+
+test-integration-helm-interleaved-topology: copy-license-files-helm  ## run go test on the tests/integration/helm directory for topology constraints
+	@cd tests/integration/helm; \
+	rm -rf test_output_topology/*; \
+	go test -count=1 -timeout=15m -v -tags integrationHelmTopology | tee test_output_topology.log; \
+	${ASDF}/packages/bin/terratest_log_parser -testlog test_output_topology.log -outputdir test_output_topology
 
 test-integration-helm-legacy: copy-license-files-helm  ## run go test on the tests/integration/helm directory for legacy auth mode
 	@cd tests/integration/helm; \

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -438,6 +438,7 @@ Kubernetes: `>=1.18-0`
 | apiSettings.service.startup.periodSeconds | int | `5` | How often (in seconds) to perform the startup probe for teams-api. [Reference][probes]. |
 | apiSettings.service.type | string | `"ClusterIP"` | Service type for teams-api. [Reference][service-type]. |
 | apiSettings.tolerations | list | `[]` | Allow the k8s scheduler to schedule pods with matching taints for teams-api. [Reference][taints-and-tolerations]. |
+| apiSettings.topologySpreadConstraints | list | `[]` | Control how Pods are spread across your distributed footprint. Label selectors will be defaulted to those of the teams-api deployment. [Reference][topology-spread-constraints]. |
 | apiSettings.volumeMounts | list | `[]` | Volume mounts for teams-api. [Reference][volumes]. |
 | apiSettings.volumes | list | `[]` | Volumes for teams-api. [Reference][volumes]. |
 | appSettings.affinity | object | `{}` | Affinity and anti-affinity for fiftyone-app. [Reference][affinity]. |
@@ -471,6 +472,7 @@ Kubernetes: `>=1.18-0`
 | appSettings.service.startup.periodSeconds | int | `5` | How often (in seconds) to perform the startup probe for fiftyone-app. [Reference][probes]. |
 | appSettings.service.type | string | `"ClusterIP"` | Service type for fiftyone-app. [Reference][service-type]. |
 | appSettings.tolerations | list | `[]` | Allow the k8s scheduler to schedule fiftyone-app pods with matching taints. [Reference][taints-and-tolerations]. |
+| appSettings.topologySpreadConstraints | list | `[]` | Control how Pods are spread across your distributed footprint. Label selectors will be defaulted to those of the fiftyone-app deployment. [Reference][topology-spread-constraints]. |
 | appSettings.volumeMounts | list | `[]` | Volume mounts for fiftyone-app. [Reference][volumes]. |
 | appSettings.volumes | list | `[]` | Volumes for fiftyone-app. [Reference][volumes]. |
 | casSettings.affinity | object | `{}` | Affinity and anti-affinity for teams-cas. [Reference][affinity]. |
@@ -500,6 +502,7 @@ Kubernetes: `>=1.18-0`
 | casSettings.service.startup.periodSeconds | int | `5` | How often (in seconds) to perform the startup probe for teams-cas. [Reference][probes]. |
 | casSettings.service.type | string | `"ClusterIP"` | Service type for teams-cas. [Reference][service-type]. |
 | casSettings.tolerations | list | `[]` | Allow the k8s scheduler to schedule teams-cas pods with matching taints. [Reference][taints-and-tolerations]. |
+| casSettings.topologySpreadConstraints | list | `[]` | Control how Pods are spread across your distributed footprint. Label selectors will be defaulted to those of the teams-cas deployment. [Reference][topology-spread-constraints]. |
 | casSettings.volumeMounts | list | `[]` | Volume mounts for teams-cas. [Reference][volumes]. |
 | casSettings.volumes | list | `[]` | Volumes for teams-cas. [Reference][volumes]. |
 | fiftyoneLicenseSecrets | list | `["fiftyone-license"]` | List of secrets for FiftyOne Teams Licenses (one per org) |
@@ -552,6 +555,7 @@ Kubernetes: `>=1.18-0`
 | pluginsSettings.service.startup.periodSeconds | int | `5` | How often (in seconds) to perform the startup probe for teams-plugins. [Reference][probes]. |
 | pluginsSettings.service.type | string | `"ClusterIP"` | Service type for teams-plugins. [Reference][service-type]. |
 | pluginsSettings.tolerations | list | `[]` | Allow the k8s scheduler to schedule teams-plugins pods with matching taints. [Reference][taints-and-tolerations]. |
+| pluginsSettings.topologySpreadConstraints | list | `[]` | Control how Pods are spread across your distributed footprint. Label selectors will be defaulted to those of the teams-plugins deployment. [Reference][topology-spread-constraints]. |
 | pluginsSettings.volumeMounts | list | `[]` | Volume mounts for teams-plugins pods. [Reference][volumes]. |
 | pluginsSettings.volumes | list | `[]` | Volumes for teams-plugins. [Reference][volumes]. |
 | secret.create | bool | `true` | Controls whether to create the secret named `secret.name`. |
@@ -598,6 +602,7 @@ Kubernetes: `>=1.18-0`
 | teamsAppSettings.service.startup.periodSeconds | int | `5` | How often (in seconds) to perform the startup probe for teams-app. [Reference][probes]. |
 | teamsAppSettings.service.type | string | `"ClusterIP"` | Service type for teams-app. [Reference][service-type]. |
 | teamsAppSettings.tolerations | list | `[]` | Allow the k8s scheduler to schedule teams-app pods with matching taints. [Reference][taints-and-tolerations]. |
+| teamsAppSettings.topologySpreadConstraints | list | `[]` | Control how Pods are spread across your distributed footprint. Label selectors will be defaulted to those of the teams-app deployment. [Reference][topology-spread-constraints]. |
 | teamsAppSettings.volumeMounts | list | `[]` | Volume mounts for teams-app pods. [Reference][volumes]. |
 | teamsAppSettings.volumes | list | `[]` | Volumes for teams-app pods. [Reference][volumes]. |
 
@@ -994,6 +999,7 @@ serviceAccount:
 [service-account]: https://kubernetes.io/docs/concepts/security/service-accounts/
 [service-type]: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
 [taints-and-tolerations]: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+[topology-spread-constraints]: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
 [volumes]: https://kubernetes.io/docs/concepts/storage/volumes/
 
 [mongodb-connection-string]: https://www.mongodb.com/docs/manual/reference/connection-string/

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -814,6 +814,7 @@ serviceAccount:
 [service-account]: https://kubernetes.io/docs/concepts/security/service-accounts/
 [service-type]: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
 [taints-and-tolerations]: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+[topology-spread-constraints]: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
 [volumes]: https://kubernetes.io/docs/concepts/storage/volumes/
 
 [mongodb-connection-string]: https://www.mongodb.com/docs/manual/reference/connection-string/

--- a/helm/fiftyone-teams-app/templates/_helpers.tpl
+++ b/helm/fiftyone-teams-app/templates/_helpers.tpl
@@ -242,7 +242,7 @@ Common Topology Constraints
   {{- if $constraint.nodeTaintsPolicy }}
   nodeTaintsPolicy: {{ $constraint.nodeTaintsPolicy }}
   {{- end }}
-{{- end -}}
+{{ end }}
 {{- end }}
 
 {{/*

--- a/helm/fiftyone-teams-app/templates/_helpers.tpl
+++ b/helm/fiftyone-teams-app/templates/_helpers.tpl
@@ -214,6 +214,38 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Common Topology Constraints
+*/}}
+{{- define "fiftyone-teams-app.commonTopologySpreadConstraints" -}}
+{{- range $constraint := .constraints -}}
+- maxSkew: {{ $constraint.maxSkew }}
+  {{- if $constraint.minDomains }}
+  minDomains: {{ $constraint.minDomains }}
+  {{- end }}
+  topologyKey: {{ $constraint.topologyKey }}
+  whenUnsatisfiable: {{ $constraint.whenUnsatisfiable }}
+  {{- if $constraint.labelSelector }}
+  labelSelector:
+    {{- $constraint.labelSelector | toYaml | nindent 4 }}
+  {{- else }}
+  labelSelector:
+    matchLabels:
+      {{- include $.selectorLabels $.context | nindent 6 }}
+  {{- end }}
+  {{- if $constraint.matchLabelKeys }}
+  matchLabelKeys:
+    {{- $constraint.matchLabelKeys | nindent 4 }}
+  {{- end }}
+  {{- if $constraint.nodeAffinityPolicy }}
+  nodeAffinityPolicy: {{ $constraint.nodeAffinityPolicy }}
+  {{- end }}
+  {{- if $constraint.nodeTaintsPolicy }}
+  nodeTaintsPolicy: {{ $constraint.nodeTaintsPolicy }}
+  {{- end }}
+{{- end -}}
+{{- end }}
+
+{{/*
 Create a merged list of environment variables for fiftyone-teams-api
 */}}
 {{- define "fiftyone-teams-api.env-vars-list" -}}

--- a/helm/fiftyone-teams-app/templates/api-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/api-deployment.yaml
@@ -79,6 +79,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.apiSettings.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- include "fiftyone-teams-app.commonTopologySpreadConstraints" (dict "constraints" .Values.apiSettings.topologySpreadConstraints "selectorLabels" "fiftyone-teams-api.selectorLabels" "context" $) | nindent 8 }}
+      {{- end }}
       {{- with .Values.apiSettings.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}

--- a/helm/fiftyone-teams-app/templates/app-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/app-deployment.yaml
@@ -75,6 +75,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.appSettings.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- include "fiftyone-teams-app.commonTopologySpreadConstraints" (dict "constraints" .Values.appSettings.topologySpreadConstraints "selectorLabels" "teams-app.selectorLabels" "context" $) | nindent 8 }}
+      {{- end }}
       {{- with .Values.appSettings.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}

--- a/helm/fiftyone-teams-app/templates/cas-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/cas-deployment.yaml
@@ -81,6 +81,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.casSettings.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- include "fiftyone-teams-app.commonTopologySpreadConstraints" (dict "constraints" .Values.casSettings.topologySpreadConstraints "selectorLabels" "fiftyone-teams-cas.selectorLabels" "context" $) | nindent 8 }}
+      {{- end }}
       volumes:
         {{- range $name := .Values.fiftyoneLicenseSecrets }}
         - name: {{ print $name }}

--- a/helm/fiftyone-teams-app/templates/plugins-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/plugins-deployment.yaml
@@ -76,6 +76,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.pluginsSettings.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- include "fiftyone-teams-app.commonTopologySpreadConstraints" (dict "constraints" .Values.pluginsSettings.topologySpreadConstraints "selectorLabels" "teams-plugins.selectorLabels" "context" $) | nindent 8 }}
+      {{- end }}
       {{- with .Values.pluginsSettings.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}

--- a/helm/fiftyone-teams-app/templates/teams-app-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/teams-app-deployment.yaml
@@ -78,6 +78,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.teamsAppSettings.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- include "fiftyone-teams-app.commonTopologySpreadConstraints" (dict "constraints" .Values.teamsAppSettings.topologySpreadConstraints "selectorLabels" "teams-app.selectorLabels" "context" $) | nindent 8 }}
+      {{- end }}
       {{- with .Values.teamsAppSettings.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -82,6 +82,9 @@ apiSettings:
   securityContext: {}
   # -- Allow the k8s scheduler to schedule pods with matching taints for teams-api. [Reference][taints-and-tolerations].
   tolerations: []
+  # -- Control how Pods are spread across your distributed footprint.
+  # Label selectors will be defaulted to those of the teams-api deployment. [Reference][topology-spread-constraints].
+  topologySpreadConstraints: []
   # -- Volume mounts for teams-api. [Reference][volumes].
   volumeMounts: []
   # -- Volumes for teams-api. [Reference][volumes].
@@ -185,6 +188,9 @@ appSettings:
   securityContext: {}
   # -- Allow the k8s scheduler to schedule fiftyone-app pods with matching taints. [Reference][taints-and-tolerations].
   tolerations: []
+  # -- Control how Pods are spread across your distributed footprint.
+  # Label selectors will be defaulted to those of the fiftyone-app deployment. [Reference][topology-spread-constraints].
+  topologySpreadConstraints: []
   # -- Volume mounts for fiftyone-app. [Reference][volumes].
   volumeMounts: []
   # -- Volumes for fiftyone-app. [Reference][volumes].
@@ -277,6 +283,9 @@ casSettings:
   securityContext: {}
   # -- Allow the k8s scheduler to schedule teams-cas pods with matching taints. [Reference][taints-and-tolerations].
   tolerations: []
+  # -- Control how Pods are spread across your distributed footprint.
+  # Label selectors will be defaulted to those of the teams-cas deployment. [Reference][topology-spread-constraints].
+  topologySpreadConstraints: []
   # -- Volume mounts for teams-cas. [Reference][volumes].
   volumeMounts: []
   # -- Volumes for teams-cas. [Reference][volumes].
@@ -436,6 +445,9 @@ pluginsSettings:
   securityContext: {}
   # -- Allow the k8s scheduler to schedule teams-plugins pods with matching taints. [Reference][taints-and-tolerations].
   tolerations: []
+  # -- Control how Pods are spread across your distributed footprint.
+  # Label selectors will be defaulted to those of the teams-plugins deployment. [Reference][topology-spread-constraints].
+  topologySpreadConstraints: []
   # -- Volume mounts for teams-plugins pods. [Reference][volumes].
   volumeMounts: []
   # -- Volumes for teams-plugins. [Reference][volumes].
@@ -583,6 +595,9 @@ teamsAppSettings:
   securityContext: {}
   # -- Allow the k8s scheduler to schedule teams-app pods with matching taints. [Reference][taints-and-tolerations].
   tolerations: []
+  # -- Control how Pods are spread across your distributed footprint.
+  # Label selectors will be defaulted to those of the teams-app deployment. [Reference][topology-spread-constraints].
+  topologySpreadConstraints: []
   # -- Volume mounts for teams-app pods. [Reference][volumes].
   volumeMounts: []
   # -- Volumes for teams-app pods. [Reference][volumes].

--- a/tests/integration/helm/common_test.go
+++ b/tests/integration/helm/common_test.go
@@ -1,5 +1,5 @@
-//go:build docker || helm || integration || integrationHelmInternalAuth || integrationHelmLegacyAuth
-// +build docker helm integration integrationHelmInternalAuth integrationHelmLegacyAuth
+//go:build docker || helm || integration || integrationHelmInternalAuth || integrationHelmLegacyAuth || integrationHelmTopology
+// +build docker helm integration integrationHelmInternalAuth integrationHelmLegacyAuth integrationHelmTopology
 
 package integration
 

--- a/tests/integration/helm/helm-topology-spread-constraint_test.go
+++ b/tests/integration/helm/helm-topology-spread-constraint_test.go
@@ -1,0 +1,251 @@
+//go:build kubeall || helm || integration || integrationHelmTopology
+// +build kubeall helm integration integrationHelmTopology
+
+package integration
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+
+	"path/filepath"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/random"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type topologyAuthHelmTest struct {
+	suite.Suite
+	chartPath   string
+	namespace   string
+	context     string
+	valuesFiles []string
+}
+
+func TestHelmTopologyAuth(t *testing.T) {
+	t.Parallel()
+
+	helmChartPath, err := filepath.Abs(chartPath)
+	require.NoError(t, err)
+
+	kubeCtx := defineKubeCtx()
+	integrationValuesPath, err := filepath.Abs(integrationValues)
+
+	suite.Run(t, &topologyAuthHelmTest{
+		Suite:     suite.Suite{},
+		chartPath: helmChartPath,
+		namespace: "fiftyone-" + strings.ToLower(random.UniqueId()),
+		context:   kubeCtx,
+		valuesFiles: []string{
+			integrationValuesPath, // Copy of values from `skaffold.yaml`'s `helm.releases[0].overrides`
+		},
+	})
+}
+
+func (s *topologyAuthHelmTest) TestHelmInstall() {
+	testCases := []struct {
+		name     string
+		values   map[string]string
+		expected []serviceValidations
+	}{
+		{
+			"dedicatedPluginsTopologyConstraints", // plugins run in plugins deployment
+			map[string]string{
+				"secret.fiftyone.fiftyoneDatabaseName":                            "fiftyone-top-dp-" + suffix,
+				"apiSettings.env.FIFTYONE_PLUGINS_DIR":                            "/opt/plugins",
+				"apiSettings.topologySpreadConstraints[0].maxSkew":                "1",
+				"apiSettings.topologySpreadConstraints[0].topologyKey":            "kubernetes.io/hostname",
+				"apiSettings.topologySpreadConstraints[0].whenUnsatisfiable":      "ScheduleAnyway",
+				"apiSettings.volumes[0].name":                                     "plugins-vol",
+				"apiSettings.volumes[0].persistentVolumeClaim.claimName":          "pvc-top-dp-" + suffix,
+				"apiSettings.volumeMounts[0].name":                                "plugins-vol",
+				"apiSettings.volumeMounts[0].mountPath":                           "/opt/plugins",
+				"appSettings.topologySpreadConstraints[0].maxSkew":                "1",
+				"appSettings.topologySpreadConstraints[0].topologyKey":            "kubernetes.io/hostname",
+				"appSettings.topologySpreadConstraints[0].whenUnsatisfiable":      "ScheduleAnyway",
+				"casSettings.env.FIFTYONE_AUTH_MODE":                              "internal",
+				"casSettings.env.CAS_DATABASE_NAME":                               "cas-top-dp-" + suffix,
+				"casSettings.topologySpreadConstraints[0].maxSkew":                "1",
+				"casSettings.topologySpreadConstraints[0].topologyKey":            "kubernetes.io/hostname",
+				"casSettings.topologySpreadConstraints[0].whenUnsatisfiable":      "ScheduleAnyway",
+				"pluginsSettings.enabled":                                         "true",
+				"pluginsSettings.env.FIFTYONE_PLUGINS_DIR":                        "/opt/plugins",
+				"pluginsSettings.topologySpreadConstraints[0].maxSkew":            "1",
+				"pluginsSettings.topologySpreadConstraints[0].topologyKey":        "kubernetes.io/hostname",
+				"pluginsSettings.topologySpreadConstraints[0].whenUnsatisfiable":  "ScheduleAnyway",
+				"pluginsSettings.volumes[0].name":                                 "plugins-vol-ro",
+				"pluginsSettings.volumes[0].persistentVolumeClaim.claimName":      "pvc-top-dp-" + suffix,
+				"pluginsSettings.volumes[0].persistentVolumeClaim.readOnly":       "true",
+				"pluginsSettings.volumeMounts[0].name":                            "plugins-vol-ro",
+				"pluginsSettings.volumeMounts[0].mountPath":                       "/opt/plugins",
+				"teamsAppSettings.topologySpreadConstraints[0].maxSkew":           "1",
+				"teamsAppSettings.topologySpreadConstraints[0].topologyKey":       "kubernetes.io/hostname",
+				"teamsAppSettings.topologySpreadConstraints[0].whenUnsatisfiable": "ScheduleAnyway",
+			},
+			[]serviceValidations{
+				{
+					name:             "teams-api",
+					url:              ternary(s.context == "minikube", "https://local.fiftyone.ai/health", ""),
+					responsePayload:  `{"status":{"teams":"available"}}`,
+					httpResponseCode: 200,
+					log:              "[INFO] Starting worker",
+				},
+				{
+					name:             "teams-app",
+					url:              ternary(s.context == "minikube", "https://local.fiftyone.ai/api/hello", ""),
+					responsePayload:  `{"name":"John Doe"}`,
+					httpResponseCode: 200,
+					log:              "Listening on port 3000",
+				},
+				{
+					name:             "teams-cas",
+					url:              ternary(s.context == "minikube", "https://local.fiftyone.ai/cas/api", ""),
+					responsePayload:  `{"status":"available"}`,
+					httpResponseCode: 200,
+					log:              " ✓ Ready in",
+				},
+				// ordering this last to avoid test flakes where testing for log before the container is running
+				{
+					name:             "fiftyone-app",
+					url:              "",
+					responsePayload:  "",
+					httpResponseCode: 200,
+					log:              "[INFO] Running on http://0.0.0.0:5151",
+				},
+				{
+					name:             "teams-plugins",
+					url:              "",
+					responsePayload:  "",
+					httpResponseCode: 0,
+					log:              "[INFO] Running on http://0.0.0.0:5151", // same as fiftyone-app since plugins uses or is based on the fiftyone-app image
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		s.Run(testCase.name, func() {
+			subT := s.T()
+			subT.Parallel()
+
+			// Create namespace name for the test case
+			namespace := fmt.Sprintf(
+				"%s-%s",
+				s.namespace,
+				strings.ToLower(testCase.name),
+			)
+			//  Add namespace to helm values map
+			testCase.values["namespace.name"] = namespace
+
+			// Add namespace to kubectl options
+			kubectlOptions := k8s.NewKubectlOptions(s.context, "", namespace)
+			// Create namespace
+			defer k8s.DeleteNamespace(subT, kubectlOptions, namespace)
+			k8s.CreateNamespace(subT, kubectlOptions, namespace)
+
+			// create persistent volume, when necessary
+			needsPersistentVolume := []string{"dedicatedPluginsTopologyConstraints"}
+			if slices.Contains(needsPersistentVolume, testCase.name) {
+
+				var nfsConfig *NFSConfig
+				hostPath := "/data/pv0001/"
+
+				if s.context != "minikube" {
+					nfsConfig = &NFSConfig{
+						Server: nfsExportServer,
+						Path:   nfsExportPath,
+					}
+					hostPath = ""
+				}
+
+				pv := PersistentVolume{
+					Name:             testCase.values["apiSettings.volumes[0].persistentVolumeClaim.claimName"],
+					AccessModes:      []string{"ReadWriteOnce", "ReadOnlyMany"},
+					Capacity:         pvCapacity,
+					StorageClassName: pvStorageClassName,
+					HostPath:         hostPath,
+					NFS:              nfsConfig,
+				}
+
+				pvc := PersistentVolumeClaim{
+					Name:             testCase.values["apiSettings.volumes[0].persistentVolumeClaim.claimName"],
+					AccessModes:      []string{"ReadWriteOnce", "ReadOnlyMany"},
+					Capacity:         pv.Capacity,
+					VolumeName:       pv.Name,
+					StorageClassName: pv.StorageClassName,
+				}
+
+				persistentVolumeYaml, err := pvToYaml(pv)
+
+				if err != nil {
+					panic(err)
+				}
+				persistentVolumeClaimYaml, err := pvcToYaml(pvc)
+
+				if err != nil {
+					panic(err)
+				}
+
+				defer k8s.KubectlDeleteFromString(subT, kubectlOptions, persistentVolumeYaml)
+				k8s.KubectlApplyFromString(subT, kubectlOptions, persistentVolumeYaml)
+				defer k8s.KubectlDeleteFromString(subT, kubectlOptions, persistentVolumeClaimYaml)
+				k8s.KubectlApplyFromString(subT, kubectlOptions, persistentVolumeClaimYaml)
+			}
+
+			// create license-file secret
+			base64EncodedLicenseFile := getBase64EncodedStringOfFile(licenseFileInternal)
+			defer k8s.KubectlDeleteFromString(subT, kubectlOptions, licenseFileSecretTemplateYaml+base64EncodedLicenseFile)
+			k8s.KubectlApplyFromString(subT, kubectlOptions, licenseFileSecretTemplateYaml+base64EncodedLicenseFile)
+
+			helmOptions := &helm.Options{
+				KubectlOptions: kubectlOptions,
+				SetValues:      testCase.values,
+				ValuesFiles:    s.valuesFiles,
+			}
+			releaseName := fmt.Sprintf(
+				"%s-topology-%s",
+				strings.ToLower(testCase.name),
+				strings.ToLower(random.UniqueId()),
+			)
+			defer helm.Delete(subT, helmOptions, releaseName, true)
+			helm.Install(subT, helmOptions, s.chartPath, releaseName)
+
+			enforceReady(subT, kubectlOptions, testCase.expected)
+
+			// Validate system health
+			for _, expected := range testCase.expected {
+				logger.Log(subT, fmt.Sprintf("Validating service %s...", expected.name))
+
+				// get deployment
+				deployment := k8s.GetDeployment(subT, kubectlOptions, expected.name)
+
+				// get deployment match labels
+				selectorLabelsPods := makeLabels(deployment.Spec.Selector.MatchLabels)
+
+				// use deployment match labels to get the associated pods
+				listOptions := metav1.ListOptions{LabelSelector: selectorLabelsPods}
+				pods := k8s.ListPods(subT, kubectlOptions, listOptions)
+
+				// Validate log output is expected
+				checkPodLogsWithRetries(subT, kubectlOptions, pods, testCase.name, expected.name, expected.log)
+
+				// Validate endpoint response
+				// Skip fiftyone-app and teams-plugins because they do not have callable endpoints that return a response payload.
+				if expected.url != "" {
+					// Validate url endpoint response is expected
+					validate_endpoint(subT, expected.url, expected.responsePayload, expected.httpResponseCode)
+				}
+			}
+		})
+	}
+}

--- a/tests/unit/helm/api-deployment_test.go
+++ b/tests/unit/helm/api-deployment_test.go
@@ -240,7 +240,7 @@ func (s *deploymentApiTemplateTest) TestTopologySpreadConstraints() {
 			},
 			func(constraint []corev1.TopologySpreadConstraint) {
 				var expectedTopologySpreadConstraint []corev1.TopologySpreadConstraint
-				eexpectedTopologySpreadConstraintJSON := `[
+				expectedTopologySpreadConstraintJSON := `[
 					{
 					  "maxSkew": 1,
 					  "topologyKey": "kubernetes.io/hostname",
@@ -253,7 +253,7 @@ func (s *deploymentApiTemplateTest) TestTopologySpreadConstraints() {
 					  }
 					}
 				  ]`
-				err := json.Unmarshal([]byte(eexpectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
+				err := json.Unmarshal([]byte(expectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
 				s.NoError(err)
 				s.Equal(expectedTopologySpreadConstraint, constraint, "Constraints should be equal")
 			},
@@ -269,52 +269,52 @@ func (s *deploymentApiTemplateTest) TestTopologySpreadConstraints() {
 				"apiSettings.topologySpreadConstraints[0].topologyKey":        "kubernetes.io/hostname",
 				"apiSettings.topologySpreadConstraints[0].whenUnsatisfiable":  "DoNotSchedule",
 				"apiSettings.topologySpreadConstraints[1].matchLabelKeys":     "[\"pod-template-hash\"]",
-				"apiSettings.topologySpreadConstraints[1].maxSkew":            "1",
-				"apiSettings.topologySpreadConstraints[1].minDomains":         "1",
-				"apiSettings.topologySpreadConstraints[1].nodeAffinityPolicy": "Honor",
-				"apiSettings.topologySpreadConstraints[1].nodeTaintsPolicy":   "Honor",
-				"apiSettings.topologySpreadConstraints[1].topologyKey":        "kubernetes.io/hostname",
-				"apiSettings.topologySpreadConstraints[1].whenUnsatisfiable":  "DoNotSchedule",
+				"apiSettings.topologySpreadConstraints[1].maxSkew":            "2",
+				"apiSettings.topologySpreadConstraints[1].minDomains":         "2",
+				"apiSettings.topologySpreadConstraints[1].nodeAffinityPolicy": "Ignore",
+				"apiSettings.topologySpreadConstraints[1].nodeTaintsPolicy":   "Ignore",
+				"apiSettings.topologySpreadConstraints[1].topologyKey":        "kubernetes.io/region",
+				"apiSettings.topologySpreadConstraints[1].whenUnsatisfiable":  "ScheduleAnyway",
 			},
 			func(constraint []corev1.TopologySpreadConstraint) {
 				var expectedTopologySpreadConstraint []corev1.TopologySpreadConstraint
-				eexpectedTopologySpreadConstraintJSON := `[
-					{
-					  "matchLabelKeys": [
-					  	"pod-template-hash"
-					  ],
-					  "maxSkew": 1,
-					  "minDomains": 1,
-					  "nodeAffinityPolicy": "Honor",
-					  "nodeTaintsPolicy": "Honor",
-					  "topologyKey": "kubernetes.io/hostname",
-					  "whenUnsatisfiable": "DoNotSchedule",
-					  "labelSelector": {
-					  	"matchLabels": {
-							"app.kubernetes.io/name": "teams-api",
-							"app.kubernetes.io/instance": "fiftyone-test"
-						}
-					  }
-					},
-					{
-					  "matchLabelKeys": [
-					  	"pod-template-hash"
-					  ],
-					  "maxSkew": 1,
-					  "minDomains": 1,
-					  "nodeAffinityPolicy": "Honor",
-					  "nodeTaintsPolicy": "Honor",
-					  "topologyKey": "kubernetes.io/hostname",
-					  "whenUnsatisfiable": "DoNotSchedule",
-					  "labelSelector": {
-					  	"matchLabels": {
-							"app.kubernetes.io/name": "teams-api",
-							"app.kubernetes.io/instance": "fiftyone-test"
-						}
-					  }
-					}
-				  ]`
-				err := json.Unmarshal([]byte(eexpectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
+				expectedTopologySpreadConstraintJSON := `[
+                    {
+                      "matchLabelKeys": [
+                          "pod-template-hash"
+                      ],
+                      "maxSkew": 1,
+                      "minDomains": 1,
+                      "nodeAffinityPolicy": "Honor",
+                      "nodeTaintsPolicy": "Honor",
+                      "topologyKey": "kubernetes.io/hostname",
+                      "whenUnsatisfiable": "DoNotSchedule",
+                      "labelSelector": {
+                          "matchLabels": {
+                            "app.kubernetes.io/name": "teams-api",
+                            "app.kubernetes.io/instance": "fiftyone-test"
+                        }
+                      }
+                    },
+                    {
+                      "matchLabelKeys": [
+                          "pod-template-hash"
+                      ],
+                      "maxSkew": 2,
+                      "minDomains": 2,
+                      "nodeAffinityPolicy": "Ignore",
+                      "nodeTaintsPolicy": "Ignore",
+                      "topologyKey": "kubernetes.io/region",
+                      "whenUnsatisfiable": "ScheduleAnyway",
+                      "labelSelector": {
+                          "matchLabels": {
+                            "app.kubernetes.io/name": "teams-api",
+                            "app.kubernetes.io/instance": "fiftyone-test"
+                        }
+                      }
+                    }
+                  ]`
+				err := json.Unmarshal([]byte(expectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
 				s.NoError(err)
 				s.Equal(expectedTopologySpreadConstraint, constraint, "Constraints should be equal")
 			},
@@ -333,25 +333,25 @@ func (s *deploymentApiTemplateTest) TestTopologySpreadConstraints() {
 			},
 			func(constraint []corev1.TopologySpreadConstraint) {
 				var expectedTopologySpreadConstraint []corev1.TopologySpreadConstraint
-				eexpectedTopologySpreadConstraintJSON := `[
-					{
-					  "matchLabelKeys": [
-					  	"pod-template-hash"
-					  ],
-					  "maxSkew": 1,
-					  "minDomains": 1,
-					  "nodeAffinityPolicy": "Honor",
-					  "nodeTaintsPolicy": "Honor",
-					  "topologyKey": "kubernetes.io/hostname",
-					  "whenUnsatisfiable": "DoNotSchedule",
-					  "labelSelector": {
-					  	"matchLabels": {
-							"app": "foo"
-						}
-					  }
-					}
-				  ]`
-				err := json.Unmarshal([]byte(eexpectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
+				expectedTopologySpreadConstraintJSON := `[
+                    {
+                      "matchLabelKeys": [
+                          "pod-template-hash"
+                      ],
+                      "maxSkew": 1,
+                      "minDomains": 1,
+                      "nodeAffinityPolicy": "Honor",
+                      "nodeTaintsPolicy": "Honor",
+                      "topologyKey": "kubernetes.io/hostname",
+                      "whenUnsatisfiable": "DoNotSchedule",
+                      "labelSelector": {
+                          "matchLabels": {
+                            "app": "foo"
+                        }
+                      }
+                    }
+                  ]`
+				err := json.Unmarshal([]byte(expectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
 				s.NoError(err)
 				s.Equal(expectedTopologySpreadConstraint, constraint, "Constraints should be equal")
 			},

--- a/tests/unit/helm/api-deployment_test.go
+++ b/tests/unit/helm/api-deployment_test.go
@@ -217,6 +217,141 @@ func (s *deploymentApiTemplateTest) TestReplicas() {
 	}
 }
 
+func (s *deploymentApiTemplateTest) TestTopologySpreadConstraints() {
+	testCases := []struct {
+		name     string
+		values   map[string]string
+		expected func(constraint []corev1.TopologySpreadConstraint)
+	}{
+		{
+			"defaultValues",
+			nil,
+			func(constraint []corev1.TopologySpreadConstraint) {
+				var expectedTopologySpreadConstraint []corev1.TopologySpreadConstraint
+				s.Equal(expectedTopologySpreadConstraint, constraint, "Constraints should be equal")
+			},
+		},
+		{
+			"overrideTopologySpreadConstraintsRequiredValues",
+			map[string]string{
+				"apiSettings.topologySpreadConstraints[0].maxSkew":           "1",
+				"apiSettings.topologySpreadConstraints[0].topologyKey":       "kubernetes.io/hostname",
+				"apiSettings.topologySpreadConstraints[0].whenUnsatisfiable": "DoNotSchedule",
+			},
+			func(constraint []corev1.TopologySpreadConstraint) {
+				var expectedTopologySpreadConstraint []corev1.TopologySpreadConstraint
+				eexpectedTopologySpreadConstraintJSON := `[
+					{
+					  "maxSkew": 1,
+					  "topologyKey": "kubernetes.io/hostname",
+					  "whenUnsatisfiable": "DoNotSchedule",
+					  "labelSelector": {
+					  	"matchLabels": {
+							"app.kubernetes.io/name": "teams-api",
+							"app.kubernetes.io/instance": "fiftyone-test"
+						}
+					  }
+					}
+				  ]`
+				err := json.Unmarshal([]byte(eexpectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
+				s.NoError(err)
+				s.Equal(expectedTopologySpreadConstraint, constraint, "Constraints should be equal")
+			},
+		},
+		{
+			"overrideTopologySpreadConstraintsOptionalValues",
+			map[string]string{
+				"apiSettings.topologySpreadConstraints[0].matchLabelKeys":     "[\"pod-template-hash\"]",
+				"apiSettings.topologySpreadConstraints[0].maxSkew":            "1",
+				"apiSettings.topologySpreadConstraints[0].minDomains":         "1",
+				"apiSettings.topologySpreadConstraints[0].nodeAffinityPolicy": "Honor",
+				"apiSettings.topologySpreadConstraints[0].nodeTaintsPolicy":   "Honor",
+				"apiSettings.topologySpreadConstraints[0].topologyKey":        "kubernetes.io/hostname",
+				"apiSettings.topologySpreadConstraints[0].whenUnsatisfiable":  "DoNotSchedule",
+			},
+			func(constraint []corev1.TopologySpreadConstraint) {
+				var expectedTopologySpreadConstraint []corev1.TopologySpreadConstraint
+				eexpectedTopologySpreadConstraintJSON := `[
+					{
+					  "matchLabelKeys": [
+					  	"pod-template-hash"
+					  ],
+					  "maxSkew": 1,
+					  "minDomains": 1,
+					  "nodeAffinityPolicy": "Honor",
+					  "nodeTaintsPolicy": "Honor",
+					  "topologyKey": "kubernetes.io/hostname",
+					  "whenUnsatisfiable": "DoNotSchedule",
+					  "labelSelector": {
+					  	"matchLabels": {
+							"app.kubernetes.io/name": "teams-api",
+							"app.kubernetes.io/instance": "fiftyone-test"
+						}
+					  }
+					}
+				  ]`
+				err := json.Unmarshal([]byte(eexpectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
+				s.NoError(err)
+				s.Equal(expectedTopologySpreadConstraint, constraint, "Constraints should be equal")
+			},
+		},
+		{
+			"overrideTopologySpreadConstraintsSelectorLabels",
+			map[string]string{
+				"apiSettings.topologySpreadConstraints[0].matchLabelKeys":                "[\"pod-template-hash\"]",
+				"apiSettings.topologySpreadConstraints[0].maxSkew":                       "1",
+				"apiSettings.topologySpreadConstraints[0].minDomains":                    "1",
+				"apiSettings.topologySpreadConstraints[0].nodeAffinityPolicy":            "Honor",
+				"apiSettings.topologySpreadConstraints[0].nodeTaintsPolicy":              "Honor",
+				"apiSettings.topologySpreadConstraints[0].labelSelector.matchLabels.app": "foo",
+				"apiSettings.topologySpreadConstraints[0].topologyKey":                   "kubernetes.io/hostname",
+				"apiSettings.topologySpreadConstraints[0].whenUnsatisfiable":             "DoNotSchedule",
+			},
+			func(constraint []corev1.TopologySpreadConstraint) {
+				var expectedTopologySpreadConstraint []corev1.TopologySpreadConstraint
+				eexpectedTopologySpreadConstraintJSON := `[
+					{
+					  "matchLabelKeys": [
+					  	"pod-template-hash"
+					  ],
+					  "maxSkew": 1,
+					  "minDomains": 1,
+					  "nodeAffinityPolicy": "Honor",
+					  "nodeTaintsPolicy": "Honor",
+					  "topologyKey": "kubernetes.io/hostname",
+					  "whenUnsatisfiable": "DoNotSchedule",
+					  "labelSelector": {
+					  	"matchLabels": {
+							"app": "foo"
+						}
+					  }
+					}
+				  ]`
+				err := json.Unmarshal([]byte(eexpectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
+				s.NoError(err)
+				s.Equal(expectedTopologySpreadConstraint, constraint, "Constraints should be equal")
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		s.Run(testCase.name, func() {
+			subT := s.T()
+			subT.Parallel()
+
+			options := &helm.Options{SetValues: testCase.values}
+			output := helm.RenderTemplate(subT, options, s.chartPath, s.releaseName, s.templates)
+
+			var deployment appsv1.Deployment
+			helm.UnmarshalK8SYaml(subT, output, &deployment)
+
+			testCase.expected(deployment.Spec.Template.Spec.TopologySpreadConstraints)
+		})
+	}
+}
+
 func (s *deploymentApiTemplateTest) TestContainerCount() {
 	testCases := []struct {
 		name     string

--- a/tests/unit/helm/api-deployment_test.go
+++ b/tests/unit/helm/api-deployment_test.go
@@ -268,10 +268,34 @@ func (s *deploymentApiTemplateTest) TestTopologySpreadConstraints() {
 				"apiSettings.topologySpreadConstraints[0].nodeTaintsPolicy":   "Honor",
 				"apiSettings.topologySpreadConstraints[0].topologyKey":        "kubernetes.io/hostname",
 				"apiSettings.topologySpreadConstraints[0].whenUnsatisfiable":  "DoNotSchedule",
+				"apiSettings.topologySpreadConstraints[1].matchLabelKeys":     "[\"pod-template-hash\"]",
+				"apiSettings.topologySpreadConstraints[1].maxSkew":            "1",
+				"apiSettings.topologySpreadConstraints[1].minDomains":         "1",
+				"apiSettings.topologySpreadConstraints[1].nodeAffinityPolicy": "Honor",
+				"apiSettings.topologySpreadConstraints[1].nodeTaintsPolicy":   "Honor",
+				"apiSettings.topologySpreadConstraints[1].topologyKey":        "kubernetes.io/hostname",
+				"apiSettings.topologySpreadConstraints[1].whenUnsatisfiable":  "DoNotSchedule",
 			},
 			func(constraint []corev1.TopologySpreadConstraint) {
 				var expectedTopologySpreadConstraint []corev1.TopologySpreadConstraint
 				eexpectedTopologySpreadConstraintJSON := `[
+					{
+					  "matchLabelKeys": [
+					  	"pod-template-hash"
+					  ],
+					  "maxSkew": 1,
+					  "minDomains": 1,
+					  "nodeAffinityPolicy": "Honor",
+					  "nodeTaintsPolicy": "Honor",
+					  "topologyKey": "kubernetes.io/hostname",
+					  "whenUnsatisfiable": "DoNotSchedule",
+					  "labelSelector": {
+					  	"matchLabels": {
+							"app.kubernetes.io/name": "teams-api",
+							"app.kubernetes.io/instance": "fiftyone-test"
+						}
+					  }
+					},
 					{
 					  "matchLabelKeys": [
 					  	"pod-template-hash"

--- a/tests/unit/helm/app-deployment_test.go
+++ b/tests/unit/helm/app-deployment_test.go
@@ -273,10 +273,34 @@ func (s *deploymentAppTemplateTest) TestTopologySpreadConstraints() {
 				"appSettings.topologySpreadConstraints[0].nodeTaintsPolicy":   "Honor",
 				"appSettings.topologySpreadConstraints[0].topologyKey":        "kubernetes.io/hostname",
 				"appSettings.topologySpreadConstraints[0].whenUnsatisfiable":  "DoNotSchedule",
+				"appSettings.topologySpreadConstraints[1].matchLabelKeys":     "[\"pod-template-hash\"]",
+				"appSettings.topologySpreadConstraints[1].maxSkew":            "1",
+				"appSettings.topologySpreadConstraints[1].minDomains":         "1",
+				"appSettings.topologySpreadConstraints[1].nodeAffinityPolicy": "Honor",
+				"appSettings.topologySpreadConstraints[1].nodeTaintsPolicy":   "Honor",
+				"appSettings.topologySpreadConstraints[1].topologyKey":        "kubernetes.io/hostname",
+				"appSettings.topologySpreadConstraints[1].whenUnsatisfiable":  "DoNotSchedule",
 			},
 			func(constraint []corev1.TopologySpreadConstraint) {
 				var expectedTopologySpreadConstraint []corev1.TopologySpreadConstraint
 				eexpectedTopologySpreadConstraintJSON := `[
+					{
+					  "matchLabelKeys": [
+					  	"pod-template-hash"
+					  ],
+					  "maxSkew": 1,
+					  "minDomains": 1,
+					  "nodeAffinityPolicy": "Honor",
+					  "nodeTaintsPolicy": "Honor",
+					  "topologyKey": "kubernetes.io/hostname",
+					  "whenUnsatisfiable": "DoNotSchedule",
+					  "labelSelector": {
+					  	"matchLabels": {
+							"app.kubernetes.io/name": "fiftyone-teams-app",
+							"app.kubernetes.io/instance": "fiftyone-test"
+						}
+					  }
+					},
 					{
 					  "matchLabelKeys": [
 					  	"pod-template-hash"

--- a/tests/unit/helm/app-deployment_test.go
+++ b/tests/unit/helm/app-deployment_test.go
@@ -245,20 +245,20 @@ func (s *deploymentAppTemplateTest) TestTopologySpreadConstraints() {
 			},
 			func(constraint []corev1.TopologySpreadConstraint) {
 				var expectedTopologySpreadConstraint []corev1.TopologySpreadConstraint
-				eexpectedTopologySpreadConstraintJSON := `[
-					{
-					  "maxSkew": 1,
-					  "topologyKey": "kubernetes.io/hostname",
-					  "whenUnsatisfiable": "DoNotSchedule",
-					  "labelSelector": {
-					  	"matchLabels": {
-							"app.kubernetes.io/name": "fiftyone-teams-app",
-							"app.kubernetes.io/instance": "fiftyone-test"
-						}
-					  }
-					}
-				  ]`
-				err := json.Unmarshal([]byte(eexpectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
+				expectedTopologySpreadConstraintJSON := `[
+                    {
+                      "maxSkew": 1,
+                      "topologyKey": "kubernetes.io/hostname",
+                      "whenUnsatisfiable": "DoNotSchedule",
+                      "labelSelector": {
+                          "matchLabels": {
+                            "app.kubernetes.io/name": "fiftyone-teams-app",
+                            "app.kubernetes.io/instance": "fiftyone-test"
+                        }
+                      }
+                    }
+                  ]`
+				err := json.Unmarshal([]byte(expectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
 				s.NoError(err)
 				s.Equal(expectedTopologySpreadConstraint, constraint, "Constraints should be equal")
 			},
@@ -274,52 +274,52 @@ func (s *deploymentAppTemplateTest) TestTopologySpreadConstraints() {
 				"appSettings.topologySpreadConstraints[0].topologyKey":        "kubernetes.io/hostname",
 				"appSettings.topologySpreadConstraints[0].whenUnsatisfiable":  "DoNotSchedule",
 				"appSettings.topologySpreadConstraints[1].matchLabelKeys":     "[\"pod-template-hash\"]",
-				"appSettings.topologySpreadConstraints[1].maxSkew":            "1",
-				"appSettings.topologySpreadConstraints[1].minDomains":         "1",
-				"appSettings.topologySpreadConstraints[1].nodeAffinityPolicy": "Honor",
-				"appSettings.topologySpreadConstraints[1].nodeTaintsPolicy":   "Honor",
-				"appSettings.topologySpreadConstraints[1].topologyKey":        "kubernetes.io/hostname",
-				"appSettings.topologySpreadConstraints[1].whenUnsatisfiable":  "DoNotSchedule",
+				"appSettings.topologySpreadConstraints[1].maxSkew":            "2",
+				"appSettings.topologySpreadConstraints[1].minDomains":         "2",
+				"appSettings.topologySpreadConstraints[1].nodeAffinityPolicy": "Ignore",
+				"appSettings.topologySpreadConstraints[1].nodeTaintsPolicy":   "Ignore",
+				"appSettings.topologySpreadConstraints[1].topologyKey":        "kubernetes.io/region",
+				"appSettings.topologySpreadConstraints[1].whenUnsatisfiable":  "ScheduleAnyway",
 			},
 			func(constraint []corev1.TopologySpreadConstraint) {
 				var expectedTopologySpreadConstraint []corev1.TopologySpreadConstraint
-				eexpectedTopologySpreadConstraintJSON := `[
-					{
-					  "matchLabelKeys": [
-					  	"pod-template-hash"
-					  ],
-					  "maxSkew": 1,
-					  "minDomains": 1,
-					  "nodeAffinityPolicy": "Honor",
-					  "nodeTaintsPolicy": "Honor",
-					  "topologyKey": "kubernetes.io/hostname",
-					  "whenUnsatisfiable": "DoNotSchedule",
-					  "labelSelector": {
-					  	"matchLabels": {
-							"app.kubernetes.io/name": "fiftyone-teams-app",
-							"app.kubernetes.io/instance": "fiftyone-test"
-						}
-					  }
-					},
-					{
-					  "matchLabelKeys": [
-					  	"pod-template-hash"
-					  ],
-					  "maxSkew": 1,
-					  "minDomains": 1,
-					  "nodeAffinityPolicy": "Honor",
-					  "nodeTaintsPolicy": "Honor",
-					  "topologyKey": "kubernetes.io/hostname",
-					  "whenUnsatisfiable": "DoNotSchedule",
-					  "labelSelector": {
-					  	"matchLabels": {
-							"app.kubernetes.io/name": "fiftyone-teams-app",
-							"app.kubernetes.io/instance": "fiftyone-test"
-						}
-					  }
-					}
-				  ]`
-				err := json.Unmarshal([]byte(eexpectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
+				expectedTopologySpreadConstraintJSON := `[
+                    {
+                      "matchLabelKeys": [
+                          "pod-template-hash"
+                      ],
+                      "maxSkew": 1,
+                      "minDomains": 1,
+                      "nodeAffinityPolicy": "Honor",
+                      "nodeTaintsPolicy": "Honor",
+                      "topologyKey": "kubernetes.io/hostname",
+                      "whenUnsatisfiable": "DoNotSchedule",
+                      "labelSelector": {
+                          "matchLabels": {
+                            "app.kubernetes.io/name": "fiftyone-teams-app",
+                            "app.kubernetes.io/instance": "fiftyone-test"
+                        }
+                      }
+                    },
+                    {
+                      "matchLabelKeys": [
+                          "pod-template-hash"
+                      ],
+                      "maxSkew": 2,
+                      "minDomains": 2,
+                      "nodeAffinityPolicy": "Ignore",
+                      "nodeTaintsPolicy": "Ignore",
+                      "topologyKey": "kubernetes.io/region",
+                      "whenUnsatisfiable": "ScheduleAnyway",
+                      "labelSelector": {
+                          "matchLabels": {
+                            "app.kubernetes.io/name": "fiftyone-teams-app",
+                            "app.kubernetes.io/instance": "fiftyone-test"
+                        }
+                      }
+                    }
+                  ]`
+				err := json.Unmarshal([]byte(expectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
 				s.NoError(err)
 				s.Equal(expectedTopologySpreadConstraint, constraint, "Constraints should be equal")
 			},
@@ -338,25 +338,25 @@ func (s *deploymentAppTemplateTest) TestTopologySpreadConstraints() {
 			},
 			func(constraint []corev1.TopologySpreadConstraint) {
 				var expectedTopologySpreadConstraint []corev1.TopologySpreadConstraint
-				eexpectedTopologySpreadConstraintJSON := `[
-					{
-					  "matchLabelKeys": [
-					  	"pod-template-hash"
-					  ],
-					  "maxSkew": 1,
-					  "minDomains": 1,
-					  "nodeAffinityPolicy": "Honor",
-					  "nodeTaintsPolicy": "Honor",
-					  "topologyKey": "kubernetes.io/hostname",
-					  "whenUnsatisfiable": "DoNotSchedule",
-					  "labelSelector": {
-					  	"matchLabels": {
-							"app": "foo"
-						}
-					  }
-					}
-				  ]`
-				err := json.Unmarshal([]byte(eexpectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
+				expectedTopologySpreadConstraintJSON := `[
+                    {
+                      "matchLabelKeys": [
+                          "pod-template-hash"
+                      ],
+                      "maxSkew": 1,
+                      "minDomains": 1,
+                      "nodeAffinityPolicy": "Honor",
+                      "nodeTaintsPolicy": "Honor",
+                      "topologyKey": "kubernetes.io/hostname",
+                      "whenUnsatisfiable": "DoNotSchedule",
+                      "labelSelector": {
+                          "matchLabels": {
+                            "app": "foo"
+                        }
+                      }
+                    }
+                  ]`
+				err := json.Unmarshal([]byte(expectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
 				s.NoError(err)
 				s.Equal(expectedTopologySpreadConstraint, constraint, "Constraints should be equal")
 			},

--- a/tests/unit/helm/app-deployment_test.go
+++ b/tests/unit/helm/app-deployment_test.go
@@ -222,6 +222,141 @@ func (s *deploymentAppTemplateTest) TestReplicas() {
 	}
 }
 
+func (s *deploymentAppTemplateTest) TestTopologySpreadConstraints() {
+	testCases := []struct {
+		name     string
+		values   map[string]string
+		expected func(constraint []corev1.TopologySpreadConstraint)
+	}{
+		{
+			"defaultValues",
+			nil,
+			func(constraint []corev1.TopologySpreadConstraint) {
+				var expectedTopologySpreadConstraint []corev1.TopologySpreadConstraint
+				s.Equal(expectedTopologySpreadConstraint, constraint, "Constraints should be equal")
+			},
+		},
+		{
+			"overrideTopologySpreadConstraintsRequiredValues",
+			map[string]string{
+				"appSettings.topologySpreadConstraints[0].maxSkew":           "1",
+				"appSettings.topologySpreadConstraints[0].topologyKey":       "kubernetes.io/hostname",
+				"appSettings.topologySpreadConstraints[0].whenUnsatisfiable": "DoNotSchedule",
+			},
+			func(constraint []corev1.TopologySpreadConstraint) {
+				var expectedTopologySpreadConstraint []corev1.TopologySpreadConstraint
+				eexpectedTopologySpreadConstraintJSON := `[
+					{
+					  "maxSkew": 1,
+					  "topologyKey": "kubernetes.io/hostname",
+					  "whenUnsatisfiable": "DoNotSchedule",
+					  "labelSelector": {
+					  	"matchLabels": {
+							"app.kubernetes.io/name": "fiftyone-teams-app",
+							"app.kubernetes.io/instance": "fiftyone-test"
+						}
+					  }
+					}
+				  ]`
+				err := json.Unmarshal([]byte(eexpectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
+				s.NoError(err)
+				s.Equal(expectedTopologySpreadConstraint, constraint, "Constraints should be equal")
+			},
+		},
+		{
+			"overrideTopologySpreadConstraintsOptionalValues",
+			map[string]string{
+				"appSettings.topologySpreadConstraints[0].matchLabelKeys":     "[\"pod-template-hash\"]",
+				"appSettings.topologySpreadConstraints[0].maxSkew":            "1",
+				"appSettings.topologySpreadConstraints[0].minDomains":         "1",
+				"appSettings.topologySpreadConstraints[0].nodeAffinityPolicy": "Honor",
+				"appSettings.topologySpreadConstraints[0].nodeTaintsPolicy":   "Honor",
+				"appSettings.topologySpreadConstraints[0].topologyKey":        "kubernetes.io/hostname",
+				"appSettings.topologySpreadConstraints[0].whenUnsatisfiable":  "DoNotSchedule",
+			},
+			func(constraint []corev1.TopologySpreadConstraint) {
+				var expectedTopologySpreadConstraint []corev1.TopologySpreadConstraint
+				eexpectedTopologySpreadConstraintJSON := `[
+					{
+					  "matchLabelKeys": [
+					  	"pod-template-hash"
+					  ],
+					  "maxSkew": 1,
+					  "minDomains": 1,
+					  "nodeAffinityPolicy": "Honor",
+					  "nodeTaintsPolicy": "Honor",
+					  "topologyKey": "kubernetes.io/hostname",
+					  "whenUnsatisfiable": "DoNotSchedule",
+					  "labelSelector": {
+					  	"matchLabels": {
+							"app.kubernetes.io/name": "fiftyone-teams-app",
+							"app.kubernetes.io/instance": "fiftyone-test"
+						}
+					  }
+					}
+				  ]`
+				err := json.Unmarshal([]byte(eexpectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
+				s.NoError(err)
+				s.Equal(expectedTopologySpreadConstraint, constraint, "Constraints should be equal")
+			},
+		},
+		{
+			"overrideTopologySpreadConstraintsSelectorLabels",
+			map[string]string{
+				"appSettings.topologySpreadConstraints[0].matchLabelKeys":                "[\"pod-template-hash\"]",
+				"appSettings.topologySpreadConstraints[0].maxSkew":                       "1",
+				"appSettings.topologySpreadConstraints[0].minDomains":                    "1",
+				"appSettings.topologySpreadConstraints[0].nodeAffinityPolicy":            "Honor",
+				"appSettings.topologySpreadConstraints[0].nodeTaintsPolicy":              "Honor",
+				"appSettings.topologySpreadConstraints[0].labelSelector.matchLabels.app": "foo",
+				"appSettings.topologySpreadConstraints[0].topologyKey":                   "kubernetes.io/hostname",
+				"appSettings.topologySpreadConstraints[0].whenUnsatisfiable":             "DoNotSchedule",
+			},
+			func(constraint []corev1.TopologySpreadConstraint) {
+				var expectedTopologySpreadConstraint []corev1.TopologySpreadConstraint
+				eexpectedTopologySpreadConstraintJSON := `[
+					{
+					  "matchLabelKeys": [
+					  	"pod-template-hash"
+					  ],
+					  "maxSkew": 1,
+					  "minDomains": 1,
+					  "nodeAffinityPolicy": "Honor",
+					  "nodeTaintsPolicy": "Honor",
+					  "topologyKey": "kubernetes.io/hostname",
+					  "whenUnsatisfiable": "DoNotSchedule",
+					  "labelSelector": {
+					  	"matchLabels": {
+							"app": "foo"
+						}
+					  }
+					}
+				  ]`
+				err := json.Unmarshal([]byte(eexpectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
+				s.NoError(err)
+				s.Equal(expectedTopologySpreadConstraint, constraint, "Constraints should be equal")
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		s.Run(testCase.name, func() {
+			subT := s.T()
+			subT.Parallel()
+
+			options := &helm.Options{SetValues: testCase.values}
+			output := helm.RenderTemplate(subT, options, s.chartPath, s.releaseName, s.templates)
+
+			var deployment appsv1.Deployment
+			helm.UnmarshalK8SYaml(subT, output, &deployment)
+
+			testCase.expected(deployment.Spec.Template.Spec.TopologySpreadConstraints)
+		})
+	}
+}
+
 func (s *deploymentAppTemplateTest) TestContainerCount() {
 	testCases := []struct {
 		name     string

--- a/tests/unit/helm/cas-deployment_test.go
+++ b/tests/unit/helm/cas-deployment_test.go
@@ -273,10 +273,34 @@ func (s *deploymentCasTemplateTest) TestTopologySpreadConstraints() {
 				"casSettings.topologySpreadConstraints[0].nodeTaintsPolicy":   "Honor",
 				"casSettings.topologySpreadConstraints[0].topologyKey":        "kubernetes.io/hostname",
 				"casSettings.topologySpreadConstraints[0].whenUnsatisfiable":  "DoNotSchedule",
+				"casSettings.topologySpreadConstraints[1].matchLabelKeys":     "[\"pod-template-hash\"]",
+				"casSettings.topologySpreadConstraints[1].maxSkew":            "1",
+				"casSettings.topologySpreadConstraints[1].minDomains":         "1",
+				"casSettings.topologySpreadConstraints[1].nodeAffinityPolicy": "Honor",
+				"casSettings.topologySpreadConstraints[1].nodeTaintsPolicy":   "Honor",
+				"casSettings.topologySpreadConstraints[1].topologyKey":        "kubernetes.io/hostname",
+				"casSettings.topologySpreadConstraints[1].whenUnsatisfiable":  "DoNotSchedule",
 			},
 			func(constraint []corev1.TopologySpreadConstraint) {
 				var expectedTopologySpreadConstraint []corev1.TopologySpreadConstraint
 				eexpectedTopologySpreadConstraintJSON := `[
+					{
+					  "matchLabelKeys": [
+					  	"pod-template-hash"
+					  ],
+					  "maxSkew": 1,
+					  "minDomains": 1,
+					  "nodeAffinityPolicy": "Honor",
+					  "nodeTaintsPolicy": "Honor",
+					  "topologyKey": "kubernetes.io/hostname",
+					  "whenUnsatisfiable": "DoNotSchedule",
+					  "labelSelector": {
+					  	"matchLabels": {
+							"app.kubernetes.io/name": "teams-cas",
+							"app.kubernetes.io/instance": "fiftyone-test"
+						}
+					  }
+					},
 					{
 					  "matchLabelKeys": [
 					  	"pod-template-hash"

--- a/tests/unit/helm/cas-deployment_test.go
+++ b/tests/unit/helm/cas-deployment_test.go
@@ -245,20 +245,20 @@ func (s *deploymentCasTemplateTest) TestTopologySpreadConstraints() {
 			},
 			func(constraint []corev1.TopologySpreadConstraint) {
 				var expectedTopologySpreadConstraint []corev1.TopologySpreadConstraint
-				eexpectedTopologySpreadConstraintJSON := `[
-					{
-					  "maxSkew": 1,
-					  "topologyKey": "kubernetes.io/hostname",
-					  "whenUnsatisfiable": "DoNotSchedule",
-					  "labelSelector": {
-					  	"matchLabels": {
-							"app.kubernetes.io/name": "teams-cas",
-							"app.kubernetes.io/instance": "fiftyone-test"
-						}
-					  }
-					}
-				  ]`
-				err := json.Unmarshal([]byte(eexpectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
+				expectedTopologySpreadConstraintJSON := `[
+                    {
+                      "maxSkew": 1,
+                      "topologyKey": "kubernetes.io/hostname",
+                      "whenUnsatisfiable": "DoNotSchedule",
+                      "labelSelector": {
+                          "matchLabels": {
+                            "app.kubernetes.io/name": "teams-cas",
+                            "app.kubernetes.io/instance": "fiftyone-test"
+                        }
+                      }
+                    }
+                  ]`
+				err := json.Unmarshal([]byte(expectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
 				s.NoError(err)
 				s.Equal(expectedTopologySpreadConstraint, constraint, "Constraints should be equal")
 			},
@@ -274,52 +274,52 @@ func (s *deploymentCasTemplateTest) TestTopologySpreadConstraints() {
 				"casSettings.topologySpreadConstraints[0].topologyKey":        "kubernetes.io/hostname",
 				"casSettings.topologySpreadConstraints[0].whenUnsatisfiable":  "DoNotSchedule",
 				"casSettings.topologySpreadConstraints[1].matchLabelKeys":     "[\"pod-template-hash\"]",
-				"casSettings.topologySpreadConstraints[1].maxSkew":            "1",
-				"casSettings.topologySpreadConstraints[1].minDomains":         "1",
-				"casSettings.topologySpreadConstraints[1].nodeAffinityPolicy": "Honor",
-				"casSettings.topologySpreadConstraints[1].nodeTaintsPolicy":   "Honor",
-				"casSettings.topologySpreadConstraints[1].topologyKey":        "kubernetes.io/hostname",
-				"casSettings.topologySpreadConstraints[1].whenUnsatisfiable":  "DoNotSchedule",
+				"casSettings.topologySpreadConstraints[1].maxSkew":            "2",
+				"casSettings.topologySpreadConstraints[1].minDomains":         "2",
+				"casSettings.topologySpreadConstraints[1].nodeAffinityPolicy": "Ignore",
+				"casSettings.topologySpreadConstraints[1].nodeTaintsPolicy":   "Ignore",
+				"casSettings.topologySpreadConstraints[1].topologyKey":        "kubernetes.io/region",
+				"casSettings.topologySpreadConstraints[1].whenUnsatisfiable":  "ScheduleAnyway",
 			},
 			func(constraint []corev1.TopologySpreadConstraint) {
 				var expectedTopologySpreadConstraint []corev1.TopologySpreadConstraint
-				eexpectedTopologySpreadConstraintJSON := `[
-					{
-					  "matchLabelKeys": [
-					  	"pod-template-hash"
-					  ],
-					  "maxSkew": 1,
-					  "minDomains": 1,
-					  "nodeAffinityPolicy": "Honor",
-					  "nodeTaintsPolicy": "Honor",
-					  "topologyKey": "kubernetes.io/hostname",
-					  "whenUnsatisfiable": "DoNotSchedule",
-					  "labelSelector": {
-					  	"matchLabels": {
-							"app.kubernetes.io/name": "teams-cas",
-							"app.kubernetes.io/instance": "fiftyone-test"
-						}
-					  }
-					},
-					{
-					  "matchLabelKeys": [
-					  	"pod-template-hash"
-					  ],
-					  "maxSkew": 1,
-					  "minDomains": 1,
-					  "nodeAffinityPolicy": "Honor",
-					  "nodeTaintsPolicy": "Honor",
-					  "topologyKey": "kubernetes.io/hostname",
-					  "whenUnsatisfiable": "DoNotSchedule",
-					  "labelSelector": {
-					  	"matchLabels": {
-							"app.kubernetes.io/name": "teams-cas",
-							"app.kubernetes.io/instance": "fiftyone-test"
-						}
-					  }
-					}
-				  ]`
-				err := json.Unmarshal([]byte(eexpectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
+				expectedTopologySpreadConstraintJSON := `[
+                    {
+                      "matchLabelKeys": [
+                          "pod-template-hash"
+                      ],
+                      "maxSkew": 1,
+                      "minDomains": 1,
+                      "nodeAffinityPolicy": "Honor",
+                      "nodeTaintsPolicy": "Honor",
+                      "topologyKey": "kubernetes.io/hostname",
+                      "whenUnsatisfiable": "DoNotSchedule",
+                      "labelSelector": {
+                          "matchLabels": {
+                            "app.kubernetes.io/name": "teams-cas",
+                            "app.kubernetes.io/instance": "fiftyone-test"
+                        }
+                      }
+                    },
+                    {
+                      "matchLabelKeys": [
+                          "pod-template-hash"
+                      ],
+                      "maxSkew": 2,
+                      "minDomains": 2,
+                      "nodeAffinityPolicy": "Ignore",
+                      "nodeTaintsPolicy": "Ignore",
+                      "topologyKey": "kubernetes.io/region",
+                      "whenUnsatisfiable": "ScheduleAnyway",
+                      "labelSelector": {
+                          "matchLabels": {
+                            "app.kubernetes.io/name": "teams-cas",
+                            "app.kubernetes.io/instance": "fiftyone-test"
+                        }
+                      }
+                    }
+                  ]`
+				err := json.Unmarshal([]byte(expectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
 				s.NoError(err)
 				s.Equal(expectedTopologySpreadConstraint, constraint, "Constraints should be equal")
 			},
@@ -338,25 +338,25 @@ func (s *deploymentCasTemplateTest) TestTopologySpreadConstraints() {
 			},
 			func(constraint []corev1.TopologySpreadConstraint) {
 				var expectedTopologySpreadConstraint []corev1.TopologySpreadConstraint
-				eexpectedTopologySpreadConstraintJSON := `[
-					{
-					  "matchLabelKeys": [
-					  	"pod-template-hash"
-					  ],
-					  "maxSkew": 1,
-					  "minDomains": 1,
-					  "nodeAffinityPolicy": "Honor",
-					  "nodeTaintsPolicy": "Honor",
-					  "topologyKey": "kubernetes.io/hostname",
-					  "whenUnsatisfiable": "DoNotSchedule",
-					  "labelSelector": {
-					  	"matchLabels": {
-							"app": "foo"
-						}
-					  }
-					}
-				  ]`
-				err := json.Unmarshal([]byte(eexpectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
+				expectedTopologySpreadConstraintJSON := `[
+                    {
+                      "matchLabelKeys": [
+                          "pod-template-hash"
+                      ],
+                      "maxSkew": 1,
+                      "minDomains": 1,
+                      "nodeAffinityPolicy": "Honor",
+                      "nodeTaintsPolicy": "Honor",
+                      "topologyKey": "kubernetes.io/hostname",
+                      "whenUnsatisfiable": "DoNotSchedule",
+                      "labelSelector": {
+                          "matchLabels": {
+                            "app": "foo"
+                        }
+                      }
+                    }
+                  ]`
+				err := json.Unmarshal([]byte(expectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
 				s.NoError(err)
 				s.Equal(expectedTopologySpreadConstraint, constraint, "Constraints should be equal")
 			},

--- a/tests/unit/helm/plugins-deployment_test.go
+++ b/tests/unit/helm/plugins-deployment_test.go
@@ -354,10 +354,34 @@ func (s *deploymentPluginsTemplateTest) TestTopologySpreadConstraints() {
 				"pluginsSettings.topologySpreadConstraints[0].nodeTaintsPolicy":   "Honor",
 				"pluginsSettings.topologySpreadConstraints[0].topologyKey":        "kubernetes.io/hostname",
 				"pluginsSettings.topologySpreadConstraints[0].whenUnsatisfiable":  "DoNotSchedule",
+				"pluginsSettings.topologySpreadConstraints[1].matchLabelKeys":     "[\"pod-template-hash\"]",
+				"pluginsSettings.topologySpreadConstraints[1].maxSkew":            "1",
+				"pluginsSettings.topologySpreadConstraints[1].minDomains":         "1",
+				"pluginsSettings.topologySpreadConstraints[1].nodeAffinityPolicy": "Honor",
+				"pluginsSettings.topologySpreadConstraints[1].nodeTaintsPolicy":   "Honor",
+				"pluginsSettings.topologySpreadConstraints[1].topologyKey":        "kubernetes.io/hostname",
+				"pluginsSettings.topologySpreadConstraints[1].whenUnsatisfiable":  "DoNotSchedule",
 			},
 			func(constraint []corev1.TopologySpreadConstraint) {
 				var expectedTopologySpreadConstraint []corev1.TopologySpreadConstraint
 				eexpectedTopologySpreadConstraintJSON := `[
+					{
+					  "matchLabelKeys": [
+					  	"pod-template-hash"
+					  ],
+					  "maxSkew": 1,
+					  "minDomains": 1,
+					  "nodeAffinityPolicy": "Honor",
+					  "nodeTaintsPolicy": "Honor",
+					  "topologyKey": "kubernetes.io/hostname",
+					  "whenUnsatisfiable": "DoNotSchedule",
+					  "labelSelector": {
+					  	"matchLabels": {
+							"app.kubernetes.io/name": "teams-plugins",
+							"app.kubernetes.io/instance": "fiftyone-test"
+						}
+					  }
+					},
 					{
 					  "matchLabelKeys": [
 					  	"pod-template-hash"

--- a/tests/unit/helm/plugins-deployment_test.go
+++ b/tests/unit/helm/plugins-deployment_test.go
@@ -299,6 +299,146 @@ func (s *deploymentPluginsTemplateTest) TestReplicas() {
 	}
 }
 
+func (s *deploymentPluginsTemplateTest) TestTopologySpreadConstraints() {
+	testCases := []struct {
+		name     string
+		values   map[string]string
+		expected func(constraint []corev1.TopologySpreadConstraint)
+	}{
+		{
+			"defaultValues",
+			map[string]string{
+				"pluginsSettings.enabled": "true",
+			},
+			func(constraint []corev1.TopologySpreadConstraint) {
+				var expectedTopologySpreadConstraint []corev1.TopologySpreadConstraint
+				s.Equal(expectedTopologySpreadConstraint, constraint, "Constraints should be equal")
+			},
+		},
+		{
+			"overrideTopologySpreadConstraintsRequiredValues",
+			map[string]string{
+				"pluginsSettings.enabled":                                        "true",
+				"pluginsSettings.topologySpreadConstraints[0].maxSkew":           "1",
+				"pluginsSettings.topologySpreadConstraints[0].topologyKey":       "kubernetes.io/hostname",
+				"pluginsSettings.topologySpreadConstraints[0].whenUnsatisfiable": "DoNotSchedule",
+			},
+			func(constraint []corev1.TopologySpreadConstraint) {
+				var expectedTopologySpreadConstraint []corev1.TopologySpreadConstraint
+				eexpectedTopologySpreadConstraintJSON := `[
+					{
+					  "maxSkew": 1,
+					  "topologyKey": "kubernetes.io/hostname",
+					  "whenUnsatisfiable": "DoNotSchedule",
+					  "labelSelector": {
+					  	"matchLabels": {
+							"app.kubernetes.io/name": "teams-plugins",
+							"app.kubernetes.io/instance": "fiftyone-test"
+						}
+					  }
+					}
+				  ]`
+				err := json.Unmarshal([]byte(eexpectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
+				s.NoError(err)
+				s.Equal(expectedTopologySpreadConstraint, constraint, "Constraints should be equal")
+			},
+		},
+		{
+			"overrideTopologySpreadConstraintsOptionalValues",
+			map[string]string{
+				"pluginsSettings.enabled":                                         "true",
+				"pluginsSettings.topologySpreadConstraints[0].matchLabelKeys":     "[\"pod-template-hash\"]",
+				"pluginsSettings.topologySpreadConstraints[0].maxSkew":            "1",
+				"pluginsSettings.topologySpreadConstraints[0].minDomains":         "1",
+				"pluginsSettings.topologySpreadConstraints[0].nodeAffinityPolicy": "Honor",
+				"pluginsSettings.topologySpreadConstraints[0].nodeTaintsPolicy":   "Honor",
+				"pluginsSettings.topologySpreadConstraints[0].topologyKey":        "kubernetes.io/hostname",
+				"pluginsSettings.topologySpreadConstraints[0].whenUnsatisfiable":  "DoNotSchedule",
+			},
+			func(constraint []corev1.TopologySpreadConstraint) {
+				var expectedTopologySpreadConstraint []corev1.TopologySpreadConstraint
+				eexpectedTopologySpreadConstraintJSON := `[
+					{
+					  "matchLabelKeys": [
+					  	"pod-template-hash"
+					  ],
+					  "maxSkew": 1,
+					  "minDomains": 1,
+					  "nodeAffinityPolicy": "Honor",
+					  "nodeTaintsPolicy": "Honor",
+					  "topologyKey": "kubernetes.io/hostname",
+					  "whenUnsatisfiable": "DoNotSchedule",
+					  "labelSelector": {
+					  	"matchLabels": {
+							"app.kubernetes.io/name": "teams-plugins",
+							"app.kubernetes.io/instance": "fiftyone-test"
+						}
+					  }
+					}
+				  ]`
+				err := json.Unmarshal([]byte(eexpectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
+				s.NoError(err)
+				s.Equal(expectedTopologySpreadConstraint, constraint, "Constraints should be equal")
+			},
+		},
+		{
+			"overrideTopologySpreadConstraintsSelectorLabels",
+			map[string]string{
+				"pluginsSettings.enabled":                                                    "true",
+				"pluginsSettings.topologySpreadConstraints[0].matchLabelKeys":                "[\"pod-template-hash\"]",
+				"pluginsSettings.topologySpreadConstraints[0].maxSkew":                       "1",
+				"pluginsSettings.topologySpreadConstraints[0].minDomains":                    "1",
+				"pluginsSettings.topologySpreadConstraints[0].nodeAffinityPolicy":            "Honor",
+				"pluginsSettings.topologySpreadConstraints[0].nodeTaintsPolicy":              "Honor",
+				"pluginsSettings.topologySpreadConstraints[0].labelSelector.matchLabels.app": "foo",
+				"pluginsSettings.topologySpreadConstraints[0].topologyKey":                   "kubernetes.io/hostname",
+				"pluginsSettings.topologySpreadConstraints[0].whenUnsatisfiable":             "DoNotSchedule",
+			},
+			func(constraint []corev1.TopologySpreadConstraint) {
+				var expectedTopologySpreadConstraint []corev1.TopologySpreadConstraint
+				eexpectedTopologySpreadConstraintJSON := `[
+					{
+					  "matchLabelKeys": [
+					  	"pod-template-hash"
+					  ],
+					  "maxSkew": 1,
+					  "minDomains": 1,
+					  "nodeAffinityPolicy": "Honor",
+					  "nodeTaintsPolicy": "Honor",
+					  "topologyKey": "kubernetes.io/hostname",
+					  "whenUnsatisfiable": "DoNotSchedule",
+					  "labelSelector": {
+					  	"matchLabels": {
+							"app": "foo"
+						}
+					  }
+					}
+				  ]`
+				err := json.Unmarshal([]byte(eexpectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
+				s.NoError(err)
+				s.Equal(expectedTopologySpreadConstraint, constraint, "Constraints should be equal")
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		s.Run(testCase.name, func() {
+			subT := s.T()
+			subT.Parallel()
+
+			options := &helm.Options{SetValues: testCase.values}
+			output := helm.RenderTemplate(subT, options, s.chartPath, s.releaseName, s.templates)
+
+			var deployment appsv1.Deployment
+			helm.UnmarshalK8SYaml(subT, output, &deployment)
+
+			testCase.expected(deployment.Spec.Template.Spec.TopologySpreadConstraints)
+		})
+	}
+}
+
 func (s *deploymentPluginsTemplateTest) TestContainerCount() {
 	testCases := []struct {
 		name     string

--- a/tests/unit/helm/plugins-deployment_test.go
+++ b/tests/unit/helm/plugins-deployment_test.go
@@ -325,20 +325,20 @@ func (s *deploymentPluginsTemplateTest) TestTopologySpreadConstraints() {
 			},
 			func(constraint []corev1.TopologySpreadConstraint) {
 				var expectedTopologySpreadConstraint []corev1.TopologySpreadConstraint
-				eexpectedTopologySpreadConstraintJSON := `[
-					{
-					  "maxSkew": 1,
-					  "topologyKey": "kubernetes.io/hostname",
-					  "whenUnsatisfiable": "DoNotSchedule",
-					  "labelSelector": {
-					  	"matchLabels": {
-							"app.kubernetes.io/name": "teams-plugins",
-							"app.kubernetes.io/instance": "fiftyone-test"
-						}
-					  }
-					}
-				  ]`
-				err := json.Unmarshal([]byte(eexpectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
+				expectedTopologySpreadConstraintJSON := `[
+                    {
+                      "maxSkew": 1,
+                      "topologyKey": "kubernetes.io/hostname",
+                      "whenUnsatisfiable": "DoNotSchedule",
+                      "labelSelector": {
+                          "matchLabels": {
+                            "app.kubernetes.io/name": "teams-plugins",
+                            "app.kubernetes.io/instance": "fiftyone-test"
+                        }
+                      }
+                    }
+                  ]`
+				err := json.Unmarshal([]byte(expectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
 				s.NoError(err)
 				s.Equal(expectedTopologySpreadConstraint, constraint, "Constraints should be equal")
 			},
@@ -355,52 +355,52 @@ func (s *deploymentPluginsTemplateTest) TestTopologySpreadConstraints() {
 				"pluginsSettings.topologySpreadConstraints[0].topologyKey":        "kubernetes.io/hostname",
 				"pluginsSettings.topologySpreadConstraints[0].whenUnsatisfiable":  "DoNotSchedule",
 				"pluginsSettings.topologySpreadConstraints[1].matchLabelKeys":     "[\"pod-template-hash\"]",
-				"pluginsSettings.topologySpreadConstraints[1].maxSkew":            "1",
-				"pluginsSettings.topologySpreadConstraints[1].minDomains":         "1",
-				"pluginsSettings.topologySpreadConstraints[1].nodeAffinityPolicy": "Honor",
-				"pluginsSettings.topologySpreadConstraints[1].nodeTaintsPolicy":   "Honor",
-				"pluginsSettings.topologySpreadConstraints[1].topologyKey":        "kubernetes.io/hostname",
-				"pluginsSettings.topologySpreadConstraints[1].whenUnsatisfiable":  "DoNotSchedule",
+				"pluginsSettings.topologySpreadConstraints[1].maxSkew":            "2",
+				"pluginsSettings.topologySpreadConstraints[1].minDomains":         "2",
+				"pluginsSettings.topologySpreadConstraints[1].nodeAffinityPolicy": "Ignore",
+				"pluginsSettings.topologySpreadConstraints[1].nodeTaintsPolicy":   "Ignore",
+				"pluginsSettings.topologySpreadConstraints[1].topologyKey":        "kubernetes.io/region",
+				"pluginsSettings.topologySpreadConstraints[1].whenUnsatisfiable":  "ScheduleAnyway",
 			},
 			func(constraint []corev1.TopologySpreadConstraint) {
 				var expectedTopologySpreadConstraint []corev1.TopologySpreadConstraint
-				eexpectedTopologySpreadConstraintJSON := `[
-					{
-					  "matchLabelKeys": [
-					  	"pod-template-hash"
-					  ],
-					  "maxSkew": 1,
-					  "minDomains": 1,
-					  "nodeAffinityPolicy": "Honor",
-					  "nodeTaintsPolicy": "Honor",
-					  "topologyKey": "kubernetes.io/hostname",
-					  "whenUnsatisfiable": "DoNotSchedule",
-					  "labelSelector": {
-					  	"matchLabels": {
-							"app.kubernetes.io/name": "teams-plugins",
-							"app.kubernetes.io/instance": "fiftyone-test"
-						}
-					  }
-					},
-					{
-					  "matchLabelKeys": [
-					  	"pod-template-hash"
-					  ],
-					  "maxSkew": 1,
-					  "minDomains": 1,
-					  "nodeAffinityPolicy": "Honor",
-					  "nodeTaintsPolicy": "Honor",
-					  "topologyKey": "kubernetes.io/hostname",
-					  "whenUnsatisfiable": "DoNotSchedule",
-					  "labelSelector": {
-					  	"matchLabels": {
-							"app.kubernetes.io/name": "teams-plugins",
-							"app.kubernetes.io/instance": "fiftyone-test"
-						}
-					  }
-					}
-				  ]`
-				err := json.Unmarshal([]byte(eexpectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
+				expectedTopologySpreadConstraintJSON := `[
+                    {
+                      "matchLabelKeys": [
+                          "pod-template-hash"
+                      ],
+                      "maxSkew": 1,
+                      "minDomains": 1,
+                      "nodeAffinityPolicy": "Honor",
+                      "nodeTaintsPolicy": "Honor",
+                      "topologyKey": "kubernetes.io/hostname",
+                      "whenUnsatisfiable": "DoNotSchedule",
+                      "labelSelector": {
+                          "matchLabels": {
+                            "app.kubernetes.io/name": "teams-plugins",
+                            "app.kubernetes.io/instance": "fiftyone-test"
+                        }
+                      }
+                    },
+                    {
+                      "matchLabelKeys": [
+                          "pod-template-hash"
+                      ],
+                      "maxSkew": 2,
+                      "minDomains": 2,
+                      "nodeAffinityPolicy": "Ignore",
+                      "nodeTaintsPolicy": "Ignore",
+                      "topologyKey": "kubernetes.io/region",
+                      "whenUnsatisfiable": "ScheduleAnyway",
+                      "labelSelector": {
+                          "matchLabels": {
+                            "app.kubernetes.io/name": "teams-plugins",
+                            "app.kubernetes.io/instance": "fiftyone-test"
+                        }
+                      }
+                    }
+                  ]`
+				err := json.Unmarshal([]byte(expectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
 				s.NoError(err)
 				s.Equal(expectedTopologySpreadConstraint, constraint, "Constraints should be equal")
 			},
@@ -420,7 +420,7 @@ func (s *deploymentPluginsTemplateTest) TestTopologySpreadConstraints() {
 			},
 			func(constraint []corev1.TopologySpreadConstraint) {
 				var expectedTopologySpreadConstraint []corev1.TopologySpreadConstraint
-				eexpectedTopologySpreadConstraintJSON := `[
+				expectedTopologySpreadConstraintJSON := `[
 					{
 					  "matchLabelKeys": [
 					  	"pod-template-hash"
@@ -438,7 +438,7 @@ func (s *deploymentPluginsTemplateTest) TestTopologySpreadConstraints() {
 					  }
 					}
 				  ]`
-				err := json.Unmarshal([]byte(eexpectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
+				err := json.Unmarshal([]byte(expectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
 				s.NoError(err)
 				s.Equal(expectedTopologySpreadConstraint, constraint, "Constraints should be equal")
 			},

--- a/tests/unit/helm/teams-app-deployment_test.go
+++ b/tests/unit/helm/teams-app-deployment_test.go
@@ -276,10 +276,34 @@ func (s *deploymentTeamsAppTemplateTest) TestTopologySpreadConstraints() {
 				"teamsAppSettings.topologySpreadConstraints[0].nodeTaintsPolicy":   "Honor",
 				"teamsAppSettings.topologySpreadConstraints[0].topologyKey":        "kubernetes.io/hostname",
 				"teamsAppSettings.topologySpreadConstraints[0].whenUnsatisfiable":  "DoNotSchedule",
+				"teamsAppSettings.topologySpreadConstraints[1].matchLabelKeys":     "[\"pod-template-hash\"]",
+				"teamsAppSettings.topologySpreadConstraints[1].maxSkew":            "1",
+				"teamsAppSettings.topologySpreadConstraints[1].minDomains":         "1",
+				"teamsAppSettings.topologySpreadConstraints[1].nodeAffinityPolicy": "Honor",
+				"teamsAppSettings.topologySpreadConstraints[1].nodeTaintsPolicy":   "Honor",
+				"teamsAppSettings.topologySpreadConstraints[1].topologyKey":        "kubernetes.io/hostname",
+				"teamsAppSettings.topologySpreadConstraints[1].whenUnsatisfiable":  "DoNotSchedule",
 			},
 			func(constraint []corev1.TopologySpreadConstraint) {
 				var expectedTopologySpreadConstraint []corev1.TopologySpreadConstraint
 				eexpectedTopologySpreadConstraintJSON := `[
+					{
+					  "matchLabelKeys": [
+					  	"pod-template-hash"
+					  ],
+					  "maxSkew": 1,
+					  "minDomains": 1,
+					  "nodeAffinityPolicy": "Honor",
+					  "nodeTaintsPolicy": "Honor",
+					  "topologyKey": "kubernetes.io/hostname",
+					  "whenUnsatisfiable": "DoNotSchedule",
+					  "labelSelector": {
+					  	"matchLabels": {
+							"app.kubernetes.io/name": "fiftyone-teams-app",
+							"app.kubernetes.io/instance": "fiftyone-test"
+						}
+					  }
+					},
 					{
 					  "matchLabelKeys": [
 					  	"pod-template-hash"

--- a/tests/unit/helm/teams-app-deployment_test.go
+++ b/tests/unit/helm/teams-app-deployment_test.go
@@ -248,7 +248,7 @@ func (s *deploymentTeamsAppTemplateTest) TestTopologySpreadConstraints() {
 			},
 			func(constraint []corev1.TopologySpreadConstraint) {
 				var expectedTopologySpreadConstraint []corev1.TopologySpreadConstraint
-				eexpectedTopologySpreadConstraintJSON := `[
+				expectedTopologySpreadConstraintJSON := `[
 					{
 					  "maxSkew": 1,
 					  "topologyKey": "kubernetes.io/hostname",
@@ -261,7 +261,7 @@ func (s *deploymentTeamsAppTemplateTest) TestTopologySpreadConstraints() {
 					  }
 					}
 				  ]`
-				err := json.Unmarshal([]byte(eexpectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
+				err := json.Unmarshal([]byte(expectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
 				s.NoError(err)
 				s.Equal(expectedTopologySpreadConstraint, constraint, "Constraints should be equal")
 			},
@@ -277,16 +277,16 @@ func (s *deploymentTeamsAppTemplateTest) TestTopologySpreadConstraints() {
 				"teamsAppSettings.topologySpreadConstraints[0].topologyKey":        "kubernetes.io/hostname",
 				"teamsAppSettings.topologySpreadConstraints[0].whenUnsatisfiable":  "DoNotSchedule",
 				"teamsAppSettings.topologySpreadConstraints[1].matchLabelKeys":     "[\"pod-template-hash\"]",
-				"teamsAppSettings.topologySpreadConstraints[1].maxSkew":            "1",
-				"teamsAppSettings.topologySpreadConstraints[1].minDomains":         "1",
-				"teamsAppSettings.topologySpreadConstraints[1].nodeAffinityPolicy": "Honor",
-				"teamsAppSettings.topologySpreadConstraints[1].nodeTaintsPolicy":   "Honor",
-				"teamsAppSettings.topologySpreadConstraints[1].topologyKey":        "kubernetes.io/hostname",
-				"teamsAppSettings.topologySpreadConstraints[1].whenUnsatisfiable":  "DoNotSchedule",
+				"teamsAppSettings.topologySpreadConstraints[1].maxSkew":            "2",
+				"teamsAppSettings.topologySpreadConstraints[1].minDomains":         "2",
+				"teamsAppSettings.topologySpreadConstraints[1].nodeAffinityPolicy": "Ignore",
+				"teamsAppSettings.topologySpreadConstraints[1].nodeTaintsPolicy":   "Ignore",
+				"teamsAppSettings.topologySpreadConstraints[1].topologyKey":        "kubernetes.io/region",
+				"teamsAppSettings.topologySpreadConstraints[1].whenUnsatisfiable":  "ScheduleAnyway",
 			},
 			func(constraint []corev1.TopologySpreadConstraint) {
 				var expectedTopologySpreadConstraint []corev1.TopologySpreadConstraint
-				eexpectedTopologySpreadConstraintJSON := `[
+				expectedTopologySpreadConstraintJSON := `[
 					{
 					  "matchLabelKeys": [
 					  	"pod-template-hash"
@@ -308,12 +308,12 @@ func (s *deploymentTeamsAppTemplateTest) TestTopologySpreadConstraints() {
 					  "matchLabelKeys": [
 					  	"pod-template-hash"
 					  ],
-					  "maxSkew": 1,
-					  "minDomains": 1,
-					  "nodeAffinityPolicy": "Honor",
-					  "nodeTaintsPolicy": "Honor",
-					  "topologyKey": "kubernetes.io/hostname",
-					  "whenUnsatisfiable": "DoNotSchedule",
+					  "maxSkew": 2,
+					  "minDomains": 2,
+					  "nodeAffinityPolicy": "Ignore",
+					  "nodeTaintsPolicy": "Ignore",
+					  "topologyKey": "kubernetes.io/region",
+					  "whenUnsatisfiable": "ScheduleAnyway",
 					  "labelSelector": {
 					  	"matchLabels": {
 							"app.kubernetes.io/name": "fiftyone-teams-app",
@@ -322,7 +322,7 @@ func (s *deploymentTeamsAppTemplateTest) TestTopologySpreadConstraints() {
 					  }
 					}
 				  ]`
-				err := json.Unmarshal([]byte(eexpectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
+				err := json.Unmarshal([]byte(expectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
 				s.NoError(err)
 				s.Equal(expectedTopologySpreadConstraint, constraint, "Constraints should be equal")
 			},
@@ -341,7 +341,7 @@ func (s *deploymentTeamsAppTemplateTest) TestTopologySpreadConstraints() {
 			},
 			func(constraint []corev1.TopologySpreadConstraint) {
 				var expectedTopologySpreadConstraint []corev1.TopologySpreadConstraint
-				eexpectedTopologySpreadConstraintJSON := `[
+				expectedTopologySpreadConstraintJSON := `[
 					{
 					  "matchLabelKeys": [
 					  	"pod-template-hash"
@@ -359,7 +359,7 @@ func (s *deploymentTeamsAppTemplateTest) TestTopologySpreadConstraints() {
 					  }
 					}
 				  ]`
-				err := json.Unmarshal([]byte(eexpectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
+				err := json.Unmarshal([]byte(expectedTopologySpreadConstraintJSON), &expectedTopologySpreadConstraint)
 				s.NoError(err)
 				s.Equal(expectedTopologySpreadConstraint, constraint, "Constraints should be equal")
 			},


### PR DESCRIPTION
# Rationale

Adding topology spread constraints to the helm chart in order to support customers who may want to utilize it. This includes a flexible way to define the topology constraint including:

* optional label selectors
* optional min domains
* optional node affinity policy / taints

This PR also includes all of the test code, including both unit and integration. 

## Changes

* A new set of unit tests to test:
  * default topology constraints (nil)
  * topology constraints with required values set
  * topology constraints with overrides set
* A new set of integration test to test basic topology functionality and that helm installs work
* Shareable `_helpers.tpl` for topology constraints to keep things DRY
* Makefile and `values.yml` changes to facilitate the new values and test suite

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

```shell
helm template ./
make test-integration-helm-ci
make test-unit-helm-interleaved
```

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
