### PR TITLE
feat(charts): AS-276 Init Containers

### DIFF
--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -422,7 +422,7 @@ Kubernetes: `>=1.18-0`
 | apiSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy]. |
 | apiSettings.image.repository | string | `"voxel51/fiftyone-teams-api"` | Container image for the teams-api. |
 | apiSettings.image.tag | string | `""` | Image tag for teams-api. Defaults to the chart version. |
-| apiSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for teams-app. [Reference][init-containers]. |
+| apiSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for teams-api. [Reference][init-containers]. |
 | apiSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for teams-api. [Reference][init-containers]. |
 | apiSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for teams-api. [Reference][init-containers]. |
 | apiSettings.labels | object | `{}` | Additional labels for the `teams-api` deployment. [Reference][labels-and-selectors]. |
@@ -458,7 +458,7 @@ Kubernetes: `>=1.18-0`
 | appSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy]. |
 | appSettings.image.repository | string | `"voxel51/fiftyone-app"` | Container image for fiftyone-app. |
 | appSettings.image.tag | string | `""` | Image tag for fiftyone-app. Defaults to the chart version. |
-| appSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for teams-app. [Reference][init-containers]. |
+| appSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for fiftyone-app. [Reference][init-containers]. |
 | appSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for fiftyone-app. [Reference][init-containers]. |
 | appSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for fiftyone-app. [Reference][init-containers]. |
 | appSettings.labels | object | `{}` | Additional labels for the `fiftyone-app` deployment. [Reference][labels-and-selectors]. |
@@ -491,7 +491,7 @@ Kubernetes: `>=1.18-0`
 | casSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy]. |
 | casSettings.image.repository | string | `"voxel51/fiftyone-teams-cas"` | Container image for teams-cas. |
 | casSettings.image.tag | string | `""` | Image tag for teams-cas. Defaults to the chart version. |
-| casSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for teams-app. [Reference][init-containers]. |
+| casSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for teams-cas. [Reference][init-containers]. |
 | casSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for teams-cas. [Reference][init-containers]. |
 | casSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for teams-cas. [Reference][init-containers]. |
 | casSettings.labels | object | `{}` | Additional labels for the `teams-cas` deployment. [Reference][labels-and-selectors]. |
@@ -547,7 +547,7 @@ Kubernetes: `>=1.18-0`
 | pluginsSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy]. |
 | pluginsSettings.image.repository | string | `"voxel51/fiftyone-app"` | Container image for teams-plugins. |
 | pluginsSettings.image.tag | string | `""` | Image tag for teams-plugins. Defaults to the chart version. |
-| pluginsSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for teams-app. [Reference][init-containers]. |
+| pluginsSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for teams-plugins. [Reference][init-containers]. |
 | pluginsSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for teams-plugins. [Reference][init-containers]. |
 | pluginsSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for teams-plugins. [Reference][init-containers]. |
 | pluginsSettings.labels | object | `{}` | Additional labels for the `teams-plugins` deployment. [Reference][labels-and-selectors]. |

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -422,6 +422,8 @@ Kubernetes: `>=1.18-0`
 | apiSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy]. |
 | apiSettings.image.repository | string | `"voxel51/fiftyone-teams-api"` | Container image for the teams-api. |
 | apiSettings.image.tag | string | `""` | Image tag for teams-api. Defaults to the chart version. |
+| apiSettings.initContainers.repository | string | `"docker.io/busybox"` | Init container images repositories for teams-api. [Reference][init-containers]. |
+| apiSettings.initContainers.tag | string | `"stable-glibc"` | Init container images tags for teams-api. [Reference][init-containers]. |
 | apiSettings.labels | object | `{}` | Additional labels for the `teams-api` deployment. [Reference][labels-and-selectors]. |
 | apiSettings.nodeSelector | object | `{}` | nodeSelector for teams-api. [Reference][node-selector]. |
 | apiSettings.podAnnotations | object | `{}` | Annotations for pods for teams-api. [Reference][annotations]. |
@@ -455,6 +457,8 @@ Kubernetes: `>=1.18-0`
 | appSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy]. |
 | appSettings.image.repository | string | `"voxel51/fiftyone-app"` | Container image for fiftyone-app. |
 | appSettings.image.tag | string | `""` | Image tag for fiftyone-app. Defaults to the chart version. |
+| appSettings.initContainers.repository | string | `"docker.io/busybox"` | Init container images repositories for fiftyone-app. [Reference][init-containers]. |
+| appSettings.initContainers.tag | string | `"stable-glibc"` | Init container images tags for fiftyone-app. [Reference][init-containers]. |
 | appSettings.labels | object | `{}` | Additional labels for the `fiftyone-app` deployment. [Reference][labels-and-selectors]. |
 | appSettings.nodeSelector | object | `{}` | nodeSelector for fiftyone-app. [Reference][node-selector]. |
 | appSettings.podAnnotations | object | `{}` | Annotations for pods for fiftyone-app. [Reference][annotations]. |
@@ -485,6 +489,8 @@ Kubernetes: `>=1.18-0`
 | casSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy]. |
 | casSettings.image.repository | string | `"voxel51/fiftyone-teams-cas"` | Container image for teams-cas. |
 | casSettings.image.tag | string | `""` | Image tag for teams-cas. Defaults to the chart version. |
+| casSettings.initContainers.repository | string | `"docker.io/busybox"` | Init container images repositories for teams-cas. [Reference][init-containers]. |
+| casSettings.initContainers.tag | string | `"stable-glibc"` | Init container images tags for teams-cas. [Reference][init-containers]. |
 | casSettings.labels | object | `{}` | Additional labels for the `teams-cas` deployment. [Reference][labels-and-selectors]. |
 | casSettings.nodeSelector | object | `{}` | nodeSelector for teams-cas. [Reference][node-selector]. |
 | casSettings.podAnnotations | object | `{}` | Annotations for pods for teams-cas. [Reference][annotations]. |
@@ -538,6 +544,8 @@ Kubernetes: `>=1.18-0`
 | pluginsSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy]. |
 | pluginsSettings.image.repository | string | `"voxel51/fiftyone-app"` | Container image for teams-plugins. |
 | pluginsSettings.image.tag | string | `""` | Image tag for teams-plugins. Defaults to the chart version. |
+| pluginsSettings.initContainers.repository | string | `"docker.io/busybox"` | Init container images repositories for teams-plugins. [Reference][init-containers]. |
+| pluginsSettings.initContainers.tag | string | `"stable-glibc"` | Init container images tags for teams-plugins. [Reference][init-containers]. |
 | pluginsSettings.labels | object | `{}` | Additional labels for the `teams-plugins` deployment. [Reference][labels-and-selectors]. |
 | pluginsSettings.nodeSelector | object | `{}` | nodeSelector for teams-plugins. [Reference][node-selector]. |
 | pluginsSettings.podAnnotations | object | `{}` | Annotations for teams-plugins pods. [Reference][annotations]. |
@@ -585,6 +593,8 @@ Kubernetes: `>=1.18-0`
 | teamsAppSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. Reference][image-pull-policy]. |
 | teamsAppSettings.image.repository | string | `"voxel51/fiftyone-teams-app"` | Container image for teams-app. |
 | teamsAppSettings.image.tag | string | `""` | Image tag for teams-app. Defaults to the chart version. |
+| teamsAppSettings.initContainers.repository | string | `"docker.io/busybox"` | Init container images repositories for teams-app. [Reference][init-containers]. |
+| teamsAppSettings.initContainers.tag | string | `"stable-glibc"` | Init container images tags for teams-app. [Reference][init-containers]. |
 | teamsAppSettings.labels | object | `{}` | Additional labels for the `teams-app` deployment. [Reference][labels-and-selectors]. |
 | teamsAppSettings.nodeSelector | object | `{}` | nodeSelector for teams-app. [Reference][node-selector]. |
 | teamsAppSettings.podAnnotations | object | `{}` | Annotations for teams-app pods. [Reference][annotations]. |
@@ -988,6 +998,7 @@ serviceAccount:
 [ingress-default-ingress-class]: https://kubernetes.io/docs/concepts/services-networking/ingress/#default-ingress-class
 [ingress-rules]: https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
 [ingress]: https://kubernetes.io/docs/concepts/services-networking/ingress/
+[init-containers]: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 [internal-auth-mode]: https://docs.voxel51.com/teams/pluggable_auth.html#internal-mode
 [labels-and-selectors]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 [legacy-auth-mode]: https://docs.voxel51.com/teams/pluggable_auth.html#legacy-mode

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -422,8 +422,9 @@ Kubernetes: `>=1.18-0`
 | apiSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy]. |
 | apiSettings.image.repository | string | `"voxel51/fiftyone-teams-api"` | Container image for the teams-api. |
 | apiSettings.image.tag | string | `""` | Image tag for teams-api. Defaults to the chart version. |
-| apiSettings.initContainers.repository | string | `"docker.io/busybox"` | Init container images repositories for teams-api. [Reference][init-containers]. |
-| apiSettings.initContainers.tag | string | `"stable-glibc"` | Init container images tags for teams-api. [Reference][init-containers]. |
+| apiSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for teams-app. [Reference][init-containers]. |
+| apiSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for teams-api. [Reference][init-containers]. |
+| apiSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for teams-api. [Reference][init-containers]. |
 | apiSettings.labels | object | `{}` | Additional labels for the `teams-api` deployment. [Reference][labels-and-selectors]. |
 | apiSettings.nodeSelector | object | `{}` | nodeSelector for teams-api. [Reference][node-selector]. |
 | apiSettings.podAnnotations | object | `{}` | Annotations for pods for teams-api. [Reference][annotations]. |
@@ -457,8 +458,9 @@ Kubernetes: `>=1.18-0`
 | appSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy]. |
 | appSettings.image.repository | string | `"voxel51/fiftyone-app"` | Container image for fiftyone-app. |
 | appSettings.image.tag | string | `""` | Image tag for fiftyone-app. Defaults to the chart version. |
-| appSettings.initContainers.repository | string | `"docker.io/busybox"` | Init container images repositories for fiftyone-app. [Reference][init-containers]. |
-| appSettings.initContainers.tag | string | `"stable-glibc"` | Init container images tags for fiftyone-app. [Reference][init-containers]. |
+| appSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for teams-app. [Reference][init-containers]. |
+| appSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for fiftyone-app. [Reference][init-containers]. |
+| appSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for fiftyone-app. [Reference][init-containers]. |
 | appSettings.labels | object | `{}` | Additional labels for the `fiftyone-app` deployment. [Reference][labels-and-selectors]. |
 | appSettings.nodeSelector | object | `{}` | nodeSelector for fiftyone-app. [Reference][node-selector]. |
 | appSettings.podAnnotations | object | `{}` | Annotations for pods for fiftyone-app. [Reference][annotations]. |
@@ -489,8 +491,9 @@ Kubernetes: `>=1.18-0`
 | casSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy]. |
 | casSettings.image.repository | string | `"voxel51/fiftyone-teams-cas"` | Container image for teams-cas. |
 | casSettings.image.tag | string | `""` | Image tag for teams-cas. Defaults to the chart version. |
-| casSettings.initContainers.repository | string | `"docker.io/busybox"` | Init container images repositories for teams-cas. [Reference][init-containers]. |
-| casSettings.initContainers.tag | string | `"stable-glibc"` | Init container images tags for teams-cas. [Reference][init-containers]. |
+| casSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for teams-app. [Reference][init-containers]. |
+| casSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for teams-cas. [Reference][init-containers]. |
+| casSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for teams-cas. [Reference][init-containers]. |
 | casSettings.labels | object | `{}` | Additional labels for the `teams-cas` deployment. [Reference][labels-and-selectors]. |
 | casSettings.nodeSelector | object | `{}` | nodeSelector for teams-cas. [Reference][node-selector]. |
 | casSettings.podAnnotations | object | `{}` | Annotations for pods for teams-cas. [Reference][annotations]. |
@@ -544,8 +547,9 @@ Kubernetes: `>=1.18-0`
 | pluginsSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy]. |
 | pluginsSettings.image.repository | string | `"voxel51/fiftyone-app"` | Container image for teams-plugins. |
 | pluginsSettings.image.tag | string | `""` | Image tag for teams-plugins. Defaults to the chart version. |
-| pluginsSettings.initContainers.repository | string | `"docker.io/busybox"` | Init container images repositories for teams-plugins. [Reference][init-containers]. |
-| pluginsSettings.initContainers.tag | string | `"stable-glibc"` | Init container images tags for teams-plugins. [Reference][init-containers]. |
+| pluginsSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for teams-app. [Reference][init-containers]. |
+| pluginsSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for teams-plugins. [Reference][init-containers]. |
+| pluginsSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for teams-plugins. [Reference][init-containers]. |
 | pluginsSettings.labels | object | `{}` | Additional labels for the `teams-plugins` deployment. [Reference][labels-and-selectors]. |
 | pluginsSettings.nodeSelector | object | `{}` | nodeSelector for teams-plugins. [Reference][node-selector]. |
 | pluginsSettings.podAnnotations | object | `{}` | Annotations for teams-plugins pods. [Reference][annotations]. |
@@ -593,8 +597,9 @@ Kubernetes: `>=1.18-0`
 | teamsAppSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. Reference][image-pull-policy]. |
 | teamsAppSettings.image.repository | string | `"voxel51/fiftyone-teams-app"` | Container image for teams-app. |
 | teamsAppSettings.image.tag | string | `""` | Image tag for teams-app. Defaults to the chart version. |
-| teamsAppSettings.initContainers.repository | string | `"docker.io/busybox"` | Init container images repositories for teams-app. [Reference][init-containers]. |
-| teamsAppSettings.initContainers.tag | string | `"stable-glibc"` | Init container images tags for teams-app. [Reference][init-containers]. |
+| teamsAppSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for teams-app. [Reference][init-containers]. |
+| teamsAppSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for teams-app. [Reference][init-containers]. |
+| teamsAppSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for teams-app. [Reference][init-containers]. |
 | teamsAppSettings.labels | object | `{}` | Additional labels for the `teams-app` deployment. [Reference][labels-and-selectors]. |
 | teamsAppSettings.nodeSelector | object | `{}` | nodeSelector for teams-app. [Reference][node-selector]. |
 | teamsAppSettings.podAnnotations | object | `{}` | Annotations for teams-app pods. [Reference][annotations]. |

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -803,6 +803,7 @@ serviceAccount:
 [ingress-default-ingress-class]: https://kubernetes.io/docs/concepts/services-networking/ingress/#default-ingress-class
 [ingress-rules]: https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
 [ingress]: https://kubernetes.io/docs/concepts/services-networking/ingress/
+[init-containers]: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 [internal-auth-mode]: https://docs.voxel51.com/teams/pluggable_auth.html#internal-mode
 [labels-and-selectors]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 [legacy-auth-mode]: https://docs.voxel51.com/teams/pluggable_auth.html#legacy-mode

--- a/helm/fiftyone-teams-app/templates/_helpers.tpl
+++ b/helm/fiftyone-teams-app/templates/_helpers.tpl
@@ -246,6 +246,18 @@ Common Topology Constraints
 {{- end }}
 
 {{/*
+Common Init Containers
+*/}}
+{{- define "fiftyone-teams-app.commonInitContainers" -}}
+- name: init-cas
+  image: {{ $.repository }}:{{ $.tag }}
+  command:
+    - 'sh'
+    - '-c'
+    - "until nslookup teams-cas; do echo waiting for cas; sleep 2; done"
+{{- end }}
+
+{{/*
 Create a merged list of environment variables for fiftyone-teams-api
 */}}
 {{- define "fiftyone-teams-api.env-vars-list" -}}

--- a/helm/fiftyone-teams-app/templates/_helpers.tpl
+++ b/helm/fiftyone-teams-app/templates/_helpers.tpl
@@ -254,7 +254,7 @@ Common Init Containers
   command:
     - 'sh'
     - '-c'
-    - "until nslookup {{ $.casHostname }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for cas; sleep 2; done"
+    - "until nslookup {{ $.casServiceName }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for cas; sleep 2; done"
 {{- end }}
 
 {{/*

--- a/helm/fiftyone-teams-app/templates/_helpers.tpl
+++ b/helm/fiftyone-teams-app/templates/_helpers.tpl
@@ -254,7 +254,7 @@ Common Init Containers
   command:
     - 'sh'
     - '-c'
-    - "until nslookup teams-cas; do echo waiting for cas; sleep 2; done"
+    - "until nslookup teams-cas.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for cas; sleep 2; done"
 {{- end }}
 
 {{/*

--- a/helm/fiftyone-teams-app/templates/_helpers.tpl
+++ b/helm/fiftyone-teams-app/templates/_helpers.tpl
@@ -254,7 +254,7 @@ Common Init Containers
   command:
     - 'sh'
     - '-c'
-    - "until nslookup teams-cas.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for cas; sleep 2; done"
+    - "until nslookup {{ $.casHostname }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for cas; sleep 2; done"
 {{- end }}
 
 {{/*

--- a/helm/fiftyone-teams-app/templates/api-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/api-deployment.yaml
@@ -67,6 +67,13 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+      initContainers:
+        - name: init-cas
+          image: {{ .Values.apiSettings.initContainers.repository }}:{{ .Values.apiSettings.initContainers.tag }}
+          command:
+            - 'sh'
+            - '-c'
+            - "until nslookup teams-cas.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for cas; sleep 2; done"
       {{- with .Values.apiSettings.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/fiftyone-teams-app/templates/api-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/api-deployment.yaml
@@ -67,13 +67,10 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+      {{- if .Values.apiSettings.initContainers.enabled }}
       initContainers:
-        - name: init-cas
-          image: {{ .Values.apiSettings.initContainers.repository }}:{{ .Values.apiSettings.initContainers.tag }}
-          command:
-            - 'sh'
-            - '-c'
-            - "until nslookup teams-cas.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for cas; sleep 2; done"
+        {{- include "fiftyone-teams-app.commonInitContainers" (dict "repository" .Values.apiSettings.initContainers.image.repository "tag" .Values.apiSettings.initContainers.image.tag) | nindent 8 }}
+      {{- end }}
       {{- with .Values.apiSettings.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/fiftyone-teams-app/templates/api-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/api-deployment.yaml
@@ -69,7 +69,11 @@ spec:
           {{- end }}
       {{- if .Values.apiSettings.initContainers.enabled }}
       initContainers:
-        {{- include "fiftyone-teams-app.commonInitContainers" (dict "repository" .Values.apiSettings.initContainers.image.repository "tag" .Values.apiSettings.initContainers.image.tag) | nindent 8 }}
+        {{-
+          include "fiftyone-teams-app.commonInitContainers"
+          (dict "repository" .Values.apiSettings.initContainers.image.repository "tag" .Values.apiSettings.initContainers.image.tag "casHostname" (include "teams-cas.name" .) )
+          | nindent 8
+        }}
       {{- end }}
       {{- with .Values.apiSettings.nodeSelector }}
       nodeSelector:

--- a/helm/fiftyone-teams-app/templates/api-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/api-deployment.yaml
@@ -71,7 +71,7 @@ spec:
       initContainers:
         {{-
           include "fiftyone-teams-app.commonInitContainers"
-          (dict "repository" .Values.apiSettings.initContainers.image.repository "tag" .Values.apiSettings.initContainers.image.tag "casHostname" (include "teams-cas.name" .) )
+          (dict "repository" .Values.apiSettings.initContainers.image.repository "tag" .Values.apiSettings.initContainers.image.tag "casServiceName" (include "teams-cas.name" .) )
           | nindent 8
         }}
       {{- end }}

--- a/helm/fiftyone-teams-app/templates/app-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/app-deployment.yaml
@@ -67,7 +67,7 @@ spec:
       initContainers:
         {{-
           include "fiftyone-teams-app.commonInitContainers"
-          (dict "repository" .Values.appSettings.initContainers.image.repository "tag" .Values.appSettings.initContainers.image.tag "casHostname" (include "teams-cas.name" .) )
+          (dict "repository" .Values.appSettings.initContainers.image.repository "tag" .Values.appSettings.initContainers.image.tag "casServiceName" (include "teams-cas.name" .) )
           | nindent 8
         }}
       {{- end }}

--- a/helm/fiftyone-teams-app/templates/app-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/app-deployment.yaml
@@ -63,6 +63,13 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+      initContainers:
+        - name: init-cas
+          image: {{ .Values.appSettings.initContainers.repository }}:{{ .Values.appSettings.initContainers.tag }}
+          command:
+            - 'sh'
+            - '-c'
+            - "until nslookup teams-cas.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for cas; sleep 2; done"
       {{- with .Values.appSettings.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/fiftyone-teams-app/templates/app-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/app-deployment.yaml
@@ -65,7 +65,11 @@ spec:
           {{- end }}
       {{- if .Values.appSettings.initContainers.enabled }}
       initContainers:
-        {{- include "fiftyone-teams-app.commonInitContainers" (dict "repository" .Values.appSettings.initContainers.image.repository "tag" .Values.appSettings.initContainers.image.tag) | nindent 8 }}
+        {{-
+          include "fiftyone-teams-app.commonInitContainers"
+          (dict "repository" .Values.appSettings.initContainers.image.repository "tag" .Values.appSettings.initContainers.image.tag "casHostname" (include "teams-cas.name" .) )
+          | nindent 8
+        }}
       {{- end }}
       {{- with .Values.appSettings.nodeSelector }}
       nodeSelector:

--- a/helm/fiftyone-teams-app/templates/app-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/app-deployment.yaml
@@ -63,13 +63,10 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+      {{- if .Values.appSettings.initContainers.enabled }}
       initContainers:
-        - name: init-cas
-          image: {{ .Values.appSettings.initContainers.repository }}:{{ .Values.appSettings.initContainers.tag }}
-          command:
-            - 'sh'
-            - '-c'
-            - "until nslookup teams-cas.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for cas; sleep 2; done"
+        {{- include "fiftyone-teams-app.commonInitContainers" (dict "repository" .Values.appSettings.initContainers.image.repository "tag" .Values.appSettings.initContainers.image.tag) | nindent 8 }}
+      {{- end }}
       {{- with .Values.appSettings.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/fiftyone-teams-app/templates/plugins-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/plugins-deployment.yaml
@@ -66,7 +66,11 @@ spec:
           {{- end }}
       {{- if .Values.pluginsSettings.initContainers.enabled }}
       initContainers:
-        {{- include "fiftyone-teams-app.commonInitContainers" (dict "repository" .Values.pluginsSettings.initContainers.image.repository "tag" .Values.pluginsSettings.initContainers.image.tag) | nindent 8 }}
+        {{-
+          include "fiftyone-teams-app.commonInitContainers"
+          (dict "repository" .Values.pluginsSettings.initContainers.image.repository "tag" .Values.pluginsSettings.initContainers.image.tag "casHostname" (include "teams-cas.name" .) )
+          | nindent 8
+        }}
       {{- end }}
       {{- with .Values.pluginsSettings.nodeSelector }}
       nodeSelector:

--- a/helm/fiftyone-teams-app/templates/plugins-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/plugins-deployment.yaml
@@ -64,13 +64,10 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+      {{- if .Values.pluginsSettings.initContainers.enabled }}
       initContainers:
-        - name: init-cas
-          image: {{ .Values.pluginsSettings.initContainers.repository }}:{{ .Values.pluginsSettings.initContainers.tag }}
-          command:
-            - 'sh'
-            - '-c'
-            - "until nslookup teams-cas.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for cas; sleep 2; done"
+        {{- include "fiftyone-teams-app.commonInitContainers" (dict "repository" .Values.pluginsSettings.initContainers.image.repository "tag" .Values.pluginsSettings.initContainers.image.tag) | nindent 8 }}
+      {{- end }}
       {{- with .Values.pluginsSettings.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/fiftyone-teams-app/templates/plugins-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/plugins-deployment.yaml
@@ -64,6 +64,13 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+      initContainers:
+        - name: init-cas
+          image: {{ .Values.pluginsSettings.initContainers.repository }}:{{ .Values.pluginsSettings.initContainers.tag }}
+          command:
+            - 'sh'
+            - '-c'
+            - "until nslookup teams-cas.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for cas; sleep 2; done"
       {{- with .Values.pluginsSettings.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/fiftyone-teams-app/templates/plugins-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/plugins-deployment.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
         {{-
           include "fiftyone-teams-app.commonInitContainers"
-          (dict "repository" .Values.pluginsSettings.initContainers.image.repository "tag" .Values.pluginsSettings.initContainers.image.tag "casHostname" (include "teams-cas.name" .) )
+          (dict "repository" .Values.pluginsSettings.initContainers.image.repository "tag" .Values.pluginsSettings.initContainers.image.tag "casServiceName" (include "teams-cas.name" .) )
           | nindent 8
         }}
       {{- end }}

--- a/helm/fiftyone-teams-app/templates/teams-app-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/teams-app-deployment.yaml
@@ -70,7 +70,7 @@ spec:
       initContainers:
         {{-
           include "fiftyone-teams-app.commonInitContainers"
-          (dict "repository" .Values.teamsAppSettings.initContainers.image.repository "tag" .Values.teamsAppSettings.initContainers.image.tag "casHostname" (include "teams-cas.name" .) )
+          (dict "repository" .Values.teamsAppSettings.initContainers.image.repository "tag" .Values.teamsAppSettings.initContainers.image.tag "casServiceName" (include "teams-cas.name" .) )
           | nindent 8
         }}
       {{- end }}

--- a/helm/fiftyone-teams-app/templates/teams-app-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/teams-app-deployment.yaml
@@ -66,13 +66,10 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+      {{- if .Values.teamsAppSettings.initContainers.enabled }}
       initContainers:
-        - name: init-cas
-          image: {{ .Values.teamsAppSettings.initContainers.repository }}:{{ .Values.teamsAppSettings.initContainers.tag }}
-          command:
-            - 'sh'
-            - '-c'
-            - "until nslookup teams-cas.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for cas; sleep 2; done"
+        {{- include "fiftyone-teams-app.commonInitContainers" (dict "repository" .Values.teamsAppSettings.initContainers.image.repository "tag" .Values.teamsAppSettings.initContainers.image.tag) | nindent 8 }}
+      {{- end }}
       {{- with .Values.teamsAppSettings.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/fiftyone-teams-app/templates/teams-app-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/teams-app-deployment.yaml
@@ -68,7 +68,11 @@ spec:
           {{- end }}
       {{- if .Values.teamsAppSettings.initContainers.enabled }}
       initContainers:
-        {{- include "fiftyone-teams-app.commonInitContainers" (dict "repository" .Values.teamsAppSettings.initContainers.image.repository "tag" .Values.teamsAppSettings.initContainers.image.tag) | nindent 8 }}
+        {{-
+          include "fiftyone-teams-app.commonInitContainers"
+          (dict "repository" .Values.teamsAppSettings.initContainers.image.repository "tag" .Values.teamsAppSettings.initContainers.image.tag "casHostname" (include "teams-cas.name" .) )
+          | nindent 8
+        }}
       {{- end }}
       {{- with .Values.teamsAppSettings.nodeSelector }}
       nodeSelector:

--- a/helm/fiftyone-teams-app/templates/teams-app-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/teams-app-deployment.yaml
@@ -66,6 +66,13 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+      initContainers:
+        - name: init-cas
+          image: {{ .Values.teamsAppSettings.initContainers.repository }}:{{ .Values.teamsAppSettings.initContainers.tag }}
+          command:
+            - 'sh'
+            - '-c'
+            - "until nslookup teams-cas.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for cas; sleep 2; done"
       {{- with .Values.teamsAppSettings.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -71,6 +71,11 @@ apiSettings:
 
   # -- Affinity and anti-affinity for teams-api. [Reference][affinity].
   affinity: {}
+  initContainers:
+    # -- Init container images repositories for teams-api. [Reference][init-containers].
+    repository: docker.io/busybox
+    # -- Init container images tags for teams-api. [Reference][init-containers].
+    tag: stable-glibc
   # -- nodeSelector for teams-api. [Reference][node-selector].
   nodeSelector: {}
   # -- Annotations for pods for teams-api. [Reference][annotations].
@@ -177,6 +182,11 @@ appSettings:
 
   # -- Affinity and anti-affinity for fiftyone-app. [Reference][affinity].
   affinity: {}
+  initContainers:
+    # -- Init container images repositories for fiftyone-app. [Reference][init-containers].
+    repository: docker.io/busybox
+    # -- Init container images tags for fiftyone-app. [Reference][init-containers].
+    tag: stable-glibc
   # -- nodeSelector for fiftyone-app. [Reference][node-selector].
   nodeSelector: {}
   # -- Annotations for pods for fiftyone-app. [Reference][annotations].
@@ -272,6 +282,11 @@ casSettings:
 
   # -- Affinity and anti-affinity for teams-cas. [Reference][affinity].
   affinity: {}
+  initContainers:
+    # -- Init container images repositories for teams-cas. [Reference][init-containers].
+    repository: docker.io/busybox
+    # -- Init container images tags for teams-cas. [Reference][init-containers].
+    tag: stable-glibc
   # -- nodeSelector for teams-cas. [Reference][node-selector].
   nodeSelector: {}
   # -- Annotations for pods for teams-cas. [Reference][annotations].
@@ -434,6 +449,11 @@ pluginsSettings:
 
   # -- Affinity and anti-affinity for teams-plugins. [Reference][affinity].
   affinity: {}
+  initContainers:
+    # -- Init container images repositories for teams-plugins. [Reference][init-containers].
+    repository: docker.io/busybox
+    # -- Init container images tags for teams-plugins. [Reference][init-containers].
+    tag: stable-glibc
   # -- nodeSelector for teams-plugins. [Reference][node-selector].
   nodeSelector: {}
   # -- Annotations for teams-plugins pods. [Reference][annotations].
@@ -584,6 +604,11 @@ teamsAppSettings:
 
   # -- Affinity and anti-affinity for teams-app. [Reference][affinity].
   affinity: {}
+  initContainers:
+    # -- Init container images repositories for teams-app. [Reference][init-containers].
+    repository: docker.io/busybox
+    # -- Init container images tags for teams-app. [Reference][init-containers].
+    tag: stable-glibc
   # -- nodeSelector for teams-app. [Reference][node-selector].
   nodeSelector: {}
   # -- Annotations for teams-app pods. [Reference][annotations].

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -72,7 +72,7 @@ apiSettings:
   # -- Affinity and anti-affinity for teams-api. [Reference][affinity].
   affinity: {}
   initContainers:
-    # -- Whether to enable init containers for teams-app. [Reference][init-containers].
+    # -- Whether to enable init containers for teams-api. [Reference][init-containers].
     enabled: true
     image:
       # -- Init container images repositories for teams-api. [Reference][init-containers].
@@ -186,7 +186,7 @@ appSettings:
   # -- Affinity and anti-affinity for fiftyone-app. [Reference][affinity].
   affinity: {}
   initContainers:
-    # -- Whether to enable init containers for teams-app. [Reference][init-containers].
+    # -- Whether to enable init containers for fiftyone-app. [Reference][init-containers].
     enabled: true
     image:
       # -- Init container images repositories for fiftyone-app. [Reference][init-containers].
@@ -289,7 +289,7 @@ casSettings:
   # -- Affinity and anti-affinity for teams-cas. [Reference][affinity].
   affinity: {}
   initContainers:
-    # -- Whether to enable init containers for teams-app. [Reference][init-containers].
+    # -- Whether to enable init containers for teams-cas. [Reference][init-containers].
     enabled: true
     image:
       # -- Init container images repositories for teams-cas. [Reference][init-containers].
@@ -459,7 +459,7 @@ pluginsSettings:
   # -- Affinity and anti-affinity for teams-plugins. [Reference][affinity].
   affinity: {}
   initContainers:
-    # -- Whether to enable init containers for teams-app. [Reference][init-containers].
+    # -- Whether to enable init containers for teams-plugins. [Reference][init-containers].
     enabled: true
     image:
       # -- Init container images repositories for teams-plugins. [Reference][init-containers].

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -72,10 +72,13 @@ apiSettings:
   # -- Affinity and anti-affinity for teams-api. [Reference][affinity].
   affinity: {}
   initContainers:
-    # -- Init container images repositories for teams-api. [Reference][init-containers].
-    repository: docker.io/busybox
-    # -- Init container images tags for teams-api. [Reference][init-containers].
-    tag: stable-glibc
+    # -- Whether to enable init containers for teams-app. [Reference][init-containers].
+    enabled: true
+    image:
+      # -- Init container images repositories for teams-api. [Reference][init-containers].
+      repository: docker.io/busybox
+      # -- Init container images tags for teams-api. [Reference][init-containers].
+      tag: stable-glibc
   # -- nodeSelector for teams-api. [Reference][node-selector].
   nodeSelector: {}
   # -- Annotations for pods for teams-api. [Reference][annotations].
@@ -183,10 +186,13 @@ appSettings:
   # -- Affinity and anti-affinity for fiftyone-app. [Reference][affinity].
   affinity: {}
   initContainers:
-    # -- Init container images repositories for fiftyone-app. [Reference][init-containers].
-    repository: docker.io/busybox
-    # -- Init container images tags for fiftyone-app. [Reference][init-containers].
-    tag: stable-glibc
+    # -- Whether to enable init containers for teams-app. [Reference][init-containers].
+    enabled: true
+    image:
+      # -- Init container images repositories for fiftyone-app. [Reference][init-containers].
+      repository: docker.io/busybox
+      # -- Init container images tags for fiftyone-app. [Reference][init-containers].
+      tag: stable-glibc
   # -- nodeSelector for fiftyone-app. [Reference][node-selector].
   nodeSelector: {}
   # -- Annotations for pods for fiftyone-app. [Reference][annotations].
@@ -283,10 +289,13 @@ casSettings:
   # -- Affinity and anti-affinity for teams-cas. [Reference][affinity].
   affinity: {}
   initContainers:
-    # -- Init container images repositories for teams-cas. [Reference][init-containers].
-    repository: docker.io/busybox
-    # -- Init container images tags for teams-cas. [Reference][init-containers].
-    tag: stable-glibc
+    # -- Whether to enable init containers for teams-app. [Reference][init-containers].
+    enabled: true
+    image:
+      # -- Init container images repositories for teams-cas. [Reference][init-containers].
+      repository: docker.io/busybox
+      # -- Init container images tags for teams-cas. [Reference][init-containers].
+      tag: stable-glibc
   # -- nodeSelector for teams-cas. [Reference][node-selector].
   nodeSelector: {}
   # -- Annotations for pods for teams-cas. [Reference][annotations].
@@ -450,10 +459,13 @@ pluginsSettings:
   # -- Affinity and anti-affinity for teams-plugins. [Reference][affinity].
   affinity: {}
   initContainers:
-    # -- Init container images repositories for teams-plugins. [Reference][init-containers].
-    repository: docker.io/busybox
-    # -- Init container images tags for teams-plugins. [Reference][init-containers].
-    tag: stable-glibc
+    # -- Whether to enable init containers for teams-app. [Reference][init-containers].
+    enabled: true
+    image:
+      # -- Init container images repositories for teams-plugins. [Reference][init-containers].
+      repository: docker.io/busybox
+      # -- Init container images tags for teams-plugins. [Reference][init-containers].
+      tag: stable-glibc
   # -- nodeSelector for teams-plugins. [Reference][node-selector].
   nodeSelector: {}
   # -- Annotations for teams-plugins pods. [Reference][annotations].
@@ -605,10 +617,13 @@ teamsAppSettings:
   # -- Affinity and anti-affinity for teams-app. [Reference][affinity].
   affinity: {}
   initContainers:
-    # -- Init container images repositories for teams-app. [Reference][init-containers].
-    repository: docker.io/busybox
-    # -- Init container images tags for teams-app. [Reference][init-containers].
-    tag: stable-glibc
+    # -- Whether to enable init containers for teams-app. [Reference][init-containers].
+    enabled: true
+    image:
+      # -- Init container images repositories for teams-app. [Reference][init-containers].
+      repository: docker.io/busybox
+      # -- Init container images tags for teams-app. [Reference][init-containers].
+      tag: stable-glibc
   # -- nodeSelector for teams-app. [Reference][node-selector].
   nodeSelector: {}
   # -- Annotations for teams-app pods. [Reference][annotations].

--- a/tests/unit/helm/api-deployment_test.go
+++ b/tests/unit/helm/api-deployment_test.go
@@ -1350,7 +1350,7 @@ func (s *deploymentApiTemplateTest) TestInitContainerCommand() {
 				expectedCmd := []string{
 					"sh",
 					"-c",
-					"until nslookup teams-cas; do echo waiting for cas; sleep 2; done",
+					"until nslookup teams-cas.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for cas; sleep 2; done",
 				}
 				s.Equal(expectedCmd, cmd, "InitContainer commands should be equal")
 			},

--- a/tests/unit/helm/api-deployment_test.go
+++ b/tests/unit/helm/api-deployment_test.go
@@ -1260,6 +1260,114 @@ func (s *deploymentApiTemplateTest) TestContainerVolumeMounts() {
 	}
 }
 
+func (s *deploymentApiTemplateTest) TestInitContainerCount() {
+	testCases := []struct {
+		name     string
+		values   map[string]string
+		expected int
+	}{
+		{
+			"defaultValues",
+			nil,
+			1,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		s.Run(testCase.name, func() {
+			subT := s.T()
+			subT.Parallel()
+
+			options := &helm.Options{SetValues: testCase.values}
+			output := helm.RenderTemplate(subT, options, s.chartPath, s.releaseName, s.templates)
+
+			var deployment appsv1.Deployment
+			helm.UnmarshalK8SYaml(subT, output, &deployment)
+
+			s.Equal(testCase.expected, len(deployment.Spec.Template.Spec.InitContainers), "Init container count should be equal.")
+		})
+	}
+}
+
+func (s *deploymentApiTemplateTest) TestInitContainerImage() {
+	testCases := []struct {
+		name     string
+		values   map[string]string
+		expected string
+	}{
+		{
+			"defaultValues",
+			nil,
+			"docker.io/busybox:stable-glibc",
+		},
+		{
+			"overrideImageRepositoryAndTag",
+			map[string]string{
+				"apiSettings.initContainers.repository": "docker.io/bash",
+				"apiSettings.initContainers.tag":        "devel-alpine3.20",
+			},
+			"docker.io/bash:devel-alpine3.20",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		s.Run(testCase.name, func() {
+			subT := s.T()
+			subT.Parallel()
+
+			options := &helm.Options{SetValues: testCase.values}
+			output := helm.RenderTemplate(subT, options, s.chartPath, s.releaseName, s.templates)
+
+			var deployment appsv1.Deployment
+			helm.UnmarshalK8SYaml(subT, output, &deployment)
+
+			s.Equal(testCase.expected, deployment.Spec.Template.Spec.InitContainers[0].Image, "Image values should be equal.")
+		})
+	}
+}
+
+func (s *deploymentApiTemplateTest) TestInitContainerCommand() {
+	testCases := []struct {
+		name     string
+		values   map[string]string
+		expected func(cmd []string)
+	}{
+		{
+			"defaultValues",
+			nil,
+			func(cmd []string) {
+				expectedCmd := []string{
+					"sh",
+					"-c",
+					"until nslookup teams-cas.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for cas; sleep 2; done",
+				}
+				s.Equal(expectedCmd, cmd, "InitContainer commands should be equal")
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		s.Run(testCase.name, func() {
+			subT := s.T()
+			subT.Parallel()
+
+			options := &helm.Options{SetValues: testCase.values}
+			output := helm.RenderTemplate(subT, options, s.chartPath, s.releaseName, s.templates)
+
+			var deployment appsv1.Deployment
+			helm.UnmarshalK8SYaml(subT, output, &deployment)
+
+			testCase.expected(deployment.Spec.Template.Spec.InitContainers[0].Command)
+		})
+	}
+}
+
 func (s *deploymentApiTemplateTest) TestAffinity() {
 	testCases := []struct {
 		name     string

--- a/tests/unit/helm/api-deployment_test.go
+++ b/tests/unit/helm/api-deployment_test.go
@@ -1271,6 +1271,13 @@ func (s *deploymentApiTemplateTest) TestInitContainerCount() {
 			nil,
 			1,
 		},
+		{
+			"overrideInitContainersEnabled",
+			map[string]string{
+				"apiSettings.initContainers.enabled": "false",
+			},
+			0,
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -1305,8 +1312,8 @@ func (s *deploymentApiTemplateTest) TestInitContainerImage() {
 		{
 			"overrideImageRepositoryAndTag",
 			map[string]string{
-				"apiSettings.initContainers.repository": "docker.io/bash",
-				"apiSettings.initContainers.tag":        "devel-alpine3.20",
+				"apiSettings.initContainers.image.repository": "docker.io/bash",
+				"apiSettings.initContainers.image.tag":        "devel-alpine3.20",
 			},
 			"docker.io/bash:devel-alpine3.20",
 		},
@@ -1343,7 +1350,7 @@ func (s *deploymentApiTemplateTest) TestInitContainerCommand() {
 				expectedCmd := []string{
 					"sh",
 					"-c",
-					"until nslookup teams-cas.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for cas; sleep 2; done",
+					"until nslookup teams-cas; do echo waiting for cas; sleep 2; done",
 				}
 				s.Equal(expectedCmd, cmd, "InitContainer commands should be equal")
 			},

--- a/tests/unit/helm/api-deployment_test.go
+++ b/tests/unit/helm/api-deployment_test.go
@@ -1355,6 +1355,20 @@ func (s *deploymentApiTemplateTest) TestInitContainerCommand() {
 				s.Equal(expectedCmd, cmd, "InitContainer commands should be equal")
 			},
 		},
+		{
+			"overrideCasHostname",
+			map[string]string{
+				"casSettings.service.name": "test-service-name",
+			},
+			func(cmd []string) {
+				expectedCmd := []string{
+					"sh",
+					"-c",
+					"until nslookup test-service-name.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for cas; sleep 2; done",
+				}
+				s.Equal(expectedCmd, cmd, "InitContainer commands should be equal")
+			},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/tests/unit/helm/app-deployment_test.go
+++ b/tests/unit/helm/app-deployment_test.go
@@ -1334,7 +1334,7 @@ func (s *deploymentAppTemplateTest) TestInitContainerCommand() {
 				expectedCmd := []string{
 					"sh",
 					"-c",
-					"until nslookup teams-cas; do echo waiting for cas; sleep 2; done",
+					"until nslookup teams-cas.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for cas; sleep 2; done",
 				}
 				s.Equal(expectedCmd, cmd, "InitContainer commands should be equal")
 			},

--- a/tests/unit/helm/app-deployment_test.go
+++ b/tests/unit/helm/app-deployment_test.go
@@ -1244,6 +1244,114 @@ func (s *deploymentAppTemplateTest) TestContainerVolumeMounts() {
 	}
 }
 
+func (s *deploymentAppTemplateTest) TestInitContainerCount() {
+	testCases := []struct {
+		name     string
+		values   map[string]string
+		expected int
+	}{
+		{
+			"defaultValues",
+			nil,
+			1,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		s.Run(testCase.name, func() {
+			subT := s.T()
+			subT.Parallel()
+
+			options := &helm.Options{SetValues: testCase.values}
+			output := helm.RenderTemplate(subT, options, s.chartPath, s.releaseName, s.templates)
+
+			var deployment appsv1.Deployment
+			helm.UnmarshalK8SYaml(subT, output, &deployment)
+
+			s.Equal(testCase.expected, len(deployment.Spec.Template.Spec.InitContainers), "Init container count should be equal.")
+		})
+	}
+}
+
+func (s *deploymentAppTemplateTest) TestInitContainerImage() {
+	testCases := []struct {
+		name     string
+		values   map[string]string
+		expected string
+	}{
+		{
+			"defaultValues",
+			nil,
+			"docker.io/busybox:stable-glibc",
+		},
+		{
+			"overrideImageRepositoryAndTag",
+			map[string]string{
+				"appSettings.initContainers.repository": "docker.io/bash",
+				"appSettings.initContainers.tag":        "devel-alpine3.20",
+			},
+			"docker.io/bash:devel-alpine3.20",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		s.Run(testCase.name, func() {
+			subT := s.T()
+			subT.Parallel()
+
+			options := &helm.Options{SetValues: testCase.values}
+			output := helm.RenderTemplate(subT, options, s.chartPath, s.releaseName, s.templates)
+
+			var deployment appsv1.Deployment
+			helm.UnmarshalK8SYaml(subT, output, &deployment)
+
+			s.Equal(testCase.expected, deployment.Spec.Template.Spec.InitContainers[0].Image, "Image values should be equal.")
+		})
+	}
+}
+
+func (s *deploymentAppTemplateTest) TestInitContainerCommand() {
+	testCases := []struct {
+		name     string
+		values   map[string]string
+		expected func(cmd []string)
+	}{
+		{
+			"defaultValues",
+			nil,
+			func(cmd []string) {
+				expectedCmd := []string{
+					"sh",
+					"-c",
+					"until nslookup teams-cas.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for cas; sleep 2; done",
+				}
+				s.Equal(expectedCmd, cmd, "InitContainer commands should be equal")
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		s.Run(testCase.name, func() {
+			subT := s.T()
+			subT.Parallel()
+
+			options := &helm.Options{SetValues: testCase.values}
+			output := helm.RenderTemplate(subT, options, s.chartPath, s.releaseName, s.templates)
+
+			var deployment appsv1.Deployment
+			helm.UnmarshalK8SYaml(subT, output, &deployment)
+
+			testCase.expected(deployment.Spec.Template.Spec.InitContainers[0].Command)
+		})
+	}
+}
+
 func (s *deploymentAppTemplateTest) TestAffinity() {
 	testCases := []struct {
 		name     string

--- a/tests/unit/helm/app-deployment_test.go
+++ b/tests/unit/helm/app-deployment_test.go
@@ -1255,6 +1255,13 @@ func (s *deploymentAppTemplateTest) TestInitContainerCount() {
 			nil,
 			1,
 		},
+		{
+			"overrideInitContainersEnabled",
+			map[string]string{
+				"appSettings.initContainers.enabled": "false",
+			},
+			0,
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -1289,8 +1296,8 @@ func (s *deploymentAppTemplateTest) TestInitContainerImage() {
 		{
 			"overrideImageRepositoryAndTag",
 			map[string]string{
-				"appSettings.initContainers.repository": "docker.io/bash",
-				"appSettings.initContainers.tag":        "devel-alpine3.20",
+				"appSettings.initContainers.image.repository": "docker.io/bash",
+				"appSettings.initContainers.image.tag":        "devel-alpine3.20",
 			},
 			"docker.io/bash:devel-alpine3.20",
 		},
@@ -1327,7 +1334,7 @@ func (s *deploymentAppTemplateTest) TestInitContainerCommand() {
 				expectedCmd := []string{
 					"sh",
 					"-c",
-					"until nslookup teams-cas.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for cas; sleep 2; done",
+					"until nslookup teams-cas; do echo waiting for cas; sleep 2; done",
 				}
 				s.Equal(expectedCmd, cmd, "InitContainer commands should be equal")
 			},

--- a/tests/unit/helm/app-deployment_test.go
+++ b/tests/unit/helm/app-deployment_test.go
@@ -1339,6 +1339,20 @@ func (s *deploymentAppTemplateTest) TestInitContainerCommand() {
 				s.Equal(expectedCmd, cmd, "InitContainer commands should be equal")
 			},
 		},
+		{
+			"overrideCasHostname",
+			map[string]string{
+				"casSettings.service.name": "test-service-name",
+			},
+			func(cmd []string) {
+				expectedCmd := []string{
+					"sh",
+					"-c",
+					"until nslookup test-service-name.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for cas; sleep 2; done",
+				}
+				s.Equal(expectedCmd, cmd, "InitContainer commands should be equal")
+			},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/tests/unit/helm/plugins-deployment_test.go
+++ b/tests/unit/helm/plugins-deployment_test.go
@@ -1685,7 +1685,7 @@ func (s *deploymentPluginsTemplateTest) TestInitContainerCommand() {
 				expectedCmd := []string{
 					"sh",
 					"-c",
-					"until nslookup teams-cas; do echo waiting for cas; sleep 2; done",
+					"until nslookup teams-cas.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for cas; sleep 2; done",
 				}
 				s.Equal(expectedCmd, cmd, "InitContainer commands should be equal")
 			},

--- a/tests/unit/helm/plugins-deployment_test.go
+++ b/tests/unit/helm/plugins-deployment_test.go
@@ -1600,6 +1600,14 @@ func (s *deploymentPluginsTemplateTest) TestInitContainerCount() {
 			},
 			1,
 		},
+		{
+			"overrideInitContainersEnabled",
+			map[string]string{
+				"pluginsSettings.enabled":                "true",
+				"pluginsSettings.initContainers.enabled": "false",
+			},
+			0,
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -1636,9 +1644,9 @@ func (s *deploymentPluginsTemplateTest) TestInitContainerImage() {
 		{
 			"overrideImageRepositoryAndTag",
 			map[string]string{
-				"pluginsSettings.enabled":                   "true",
-				"pluginsSettings.initContainers.repository": "docker.io/bash",
-				"pluginsSettings.initContainers.tag":        "devel-alpine3.20",
+				"pluginsSettings.enabled":                         "true",
+				"pluginsSettings.initContainers.image.repository": "docker.io/bash",
+				"pluginsSettings.initContainers.image.tag":        "devel-alpine3.20",
 			},
 			"docker.io/bash:devel-alpine3.20",
 		},
@@ -1677,7 +1685,7 @@ func (s *deploymentPluginsTemplateTest) TestInitContainerCommand() {
 				expectedCmd := []string{
 					"sh",
 					"-c",
-					"until nslookup teams-cas.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for cas; sleep 2; done",
+					"until nslookup teams-cas; do echo waiting for cas; sleep 2; done",
 				}
 				s.Equal(expectedCmd, cmd, "InitContainer commands should be equal")
 			},

--- a/tests/unit/helm/plugins-deployment_test.go
+++ b/tests/unit/helm/plugins-deployment_test.go
@@ -1690,6 +1690,21 @@ func (s *deploymentPluginsTemplateTest) TestInitContainerCommand() {
 				s.Equal(expectedCmd, cmd, "InitContainer commands should be equal")
 			},
 		},
+		{
+			"overrideCasHostname",
+			map[string]string{
+				"casSettings.service.name": "test-service-name",
+				"pluginsSettings.enabled":  "true",
+			},
+			func(cmd []string) {
+				expectedCmd := []string{
+					"sh",
+					"-c",
+					"until nslookup test-service-name.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for cas; sleep 2; done",
+				}
+				s.Equal(expectedCmd, cmd, "InitContainer commands should be equal")
+			},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/tests/unit/helm/plugins-deployment_test.go
+++ b/tests/unit/helm/plugins-deployment_test.go
@@ -1587,6 +1587,121 @@ func (s *deploymentPluginsTemplateTest) TestContainerVolumeMounts() {
 	}
 }
 
+func (s *deploymentPluginsTemplateTest) TestInitContainerCount() {
+	testCases := []struct {
+		name     string
+		values   map[string]string
+		expected int
+	}{
+		{
+			"defaultValues",
+			map[string]string{
+				"pluginsSettings.enabled": "true",
+			},
+			1,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		s.Run(testCase.name, func() {
+			subT := s.T()
+			subT.Parallel()
+
+			options := &helm.Options{SetValues: testCase.values}
+			output := helm.RenderTemplate(subT, options, s.chartPath, s.releaseName, s.templates)
+
+			var deployment appsv1.Deployment
+			helm.UnmarshalK8SYaml(subT, output, &deployment)
+
+			s.Equal(testCase.expected, len(deployment.Spec.Template.Spec.InitContainers), "Init container count should be equal.")
+		})
+	}
+}
+
+func (s *deploymentPluginsTemplateTest) TestInitContainerImage() {
+	testCases := []struct {
+		name     string
+		values   map[string]string
+		expected string
+	}{
+		{
+			"defaultValues",
+			map[string]string{
+				"pluginsSettings.enabled": "true",
+			},
+			"docker.io/busybox:stable-glibc",
+		},
+		{
+			"overrideImageRepositoryAndTag",
+			map[string]string{
+				"pluginsSettings.enabled":                   "true",
+				"pluginsSettings.initContainers.repository": "docker.io/bash",
+				"pluginsSettings.initContainers.tag":        "devel-alpine3.20",
+			},
+			"docker.io/bash:devel-alpine3.20",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		s.Run(testCase.name, func() {
+			subT := s.T()
+			subT.Parallel()
+
+			options := &helm.Options{SetValues: testCase.values}
+			output := helm.RenderTemplate(subT, options, s.chartPath, s.releaseName, s.templates)
+
+			var deployment appsv1.Deployment
+			helm.UnmarshalK8SYaml(subT, output, &deployment)
+
+			s.Equal(testCase.expected, deployment.Spec.Template.Spec.InitContainers[0].Image, "Image values should be equal.")
+		})
+	}
+}
+
+func (s *deploymentPluginsTemplateTest) TestInitContainerCommand() {
+	testCases := []struct {
+		name     string
+		values   map[string]string
+		expected func(cmd []string)
+	}{
+		{
+			"defaultValues",
+			map[string]string{
+				"pluginsSettings.enabled": "true",
+			},
+			func(cmd []string) {
+				expectedCmd := []string{
+					"sh",
+					"-c",
+					"until nslookup teams-cas.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for cas; sleep 2; done",
+				}
+				s.Equal(expectedCmd, cmd, "InitContainer commands should be equal")
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		s.Run(testCase.name, func() {
+			subT := s.T()
+			subT.Parallel()
+
+			options := &helm.Options{SetValues: testCase.values}
+			output := helm.RenderTemplate(subT, options, s.chartPath, s.releaseName, s.templates)
+
+			var deployment appsv1.Deployment
+			helm.UnmarshalK8SYaml(subT, output, &deployment)
+
+			testCase.expected(deployment.Spec.Template.Spec.InitContainers[0].Command)
+		})
+	}
+}
+
 func (s *deploymentPluginsTemplateTest) TestAffinity() {
 	testCases := []struct {
 		name     string

--- a/tests/unit/helm/teams-app-deployment_test.go
+++ b/tests/unit/helm/teams-app-deployment_test.go
@@ -1258,7 +1258,7 @@ func (s *deploymentTeamsAppTemplateTest) TestInitContainerCommand() {
 				expectedCmd := []string{
 					"sh",
 					"-c",
-					"until nslookup teams-cas; do echo waiting for cas; sleep 2; done",
+					"until nslookup teams-cas.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for cas; sleep 2; done",
 				}
 				s.Equal(expectedCmd, cmd, "InitContainer commands should be equal")
 			},

--- a/tests/unit/helm/teams-app-deployment_test.go
+++ b/tests/unit/helm/teams-app-deployment_test.go
@@ -1263,6 +1263,20 @@ func (s *deploymentTeamsAppTemplateTest) TestInitContainerCommand() {
 				s.Equal(expectedCmd, cmd, "InitContainer commands should be equal")
 			},
 		},
+		{
+			"overrideCasHostname",
+			map[string]string{
+				"casSettings.service.name": "test-service-name",
+			},
+			func(cmd []string) {
+				expectedCmd := []string{
+					"sh",
+					"-c",
+					"until nslookup test-service-name.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for cas; sleep 2; done",
+				}
+				s.Equal(expectedCmd, cmd, "InitContainer commands should be equal")
+			},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/tests/unit/helm/teams-app-deployment_test.go
+++ b/tests/unit/helm/teams-app-deployment_test.go
@@ -1179,6 +1179,13 @@ func (s *deploymentTeamsAppTemplateTest) TestInitContainerCount() {
 			nil,
 			1,
 		},
+		{
+			"overrideInitContainersEnabled",
+			map[string]string{
+				"teamsAppSettings.initContainers.enabled": "false",
+			},
+			0,
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -1213,8 +1220,8 @@ func (s *deploymentTeamsAppTemplateTest) TestInitContainerImage() {
 		{
 			"overrideImageRepositoryAndTag",
 			map[string]string{
-				"teamsAppSettings.initContainers.repository": "docker.io/bash",
-				"teamsAppSettings.initContainers.tag":        "devel-alpine3.20",
+				"teamsAppSettings.initContainers.image.repository": "docker.io/bash",
+				"teamsAppSettings.initContainers.image.tag":        "devel-alpine3.20",
 			},
 			"docker.io/bash:devel-alpine3.20",
 		},
@@ -1251,7 +1258,7 @@ func (s *deploymentTeamsAppTemplateTest) TestInitContainerCommand() {
 				expectedCmd := []string{
 					"sh",
 					"-c",
-					"until nslookup teams-cas.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for cas; sleep 2; done",
+					"until nslookup teams-cas; do echo waiting for cas; sleep 2; done",
 				}
 				s.Equal(expectedCmd, cmd, "InitContainer commands should be equal")
 			},


### PR DESCRIPTION
# Rationale

This adds optional `initContainers` to our helm chart. After talking with a CS engineer, the main concern in enabling these is the security scanning of busybox. To aid in this the containers were made optional (disable them via `<svcname>.initContainers.enabled = false`). The image repositories and tags are also configurable. The init script uses `nslookup` to make sure cas is deployed before allowing the application to start.

*Caveat* - NSLookup just makes sure the domain is reachable. We could switch to `wget` or `curl`, the reason for `nslookup` was because it's read-only, doesn't write anything to disk, etc. However, `wget` would be easy to implement as well, but have to make sure the port number is passed through:

```
wget -qO- http://www.example.com:<some port>
```

## Changes

This adds `initContainers` to the helm deployments. The bulk of `initContainers` are shared, so a single helper was used and we will just form the context in the service and pass through to keep things DRY.

Updates unit tests as well to account for the following cases:

1. Default values - make sure an init container is deployed and configured properly
2. Override image repos/tags - make sure an init container is deployed and configured properly with updated repos/tags
3. Disable init containers - make sure disabling init containers works

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

```shell
helm template ./
make test-integration-helm-ci
make test-unit-helm-interleaved
```

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
