### PR TITLE
bump startup probe timeout to 15 seconds

### DIFF
--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -465,7 +465,7 @@ Kubernetes: `>=1.18-0`
 | apiSettings.service.port | int | `80` | Service port for teams-api. |
 | apiSettings.service.shortname | string | `"teams-api"` | Port name (maximum length is 15 characters) for teams-api. [Reference][ports]. |
 | apiSettings.service.startup.failureThreshold | int | `5` | Number of times to retry the startup probe for the teams-api. [Reference][probes]. |
-| apiSettings.service.startup.periodSeconds | int | `5` | How often (in seconds) to perform the startup probe for teams-api. [Reference][probes]. |
+| apiSettings.service.startup.periodSeconds | int | `15` | How often (in seconds) to perform the startup probe for teams-api. [Reference][probes]. |
 | apiSettings.service.type | string | `"ClusterIP"` | Service type for teams-api. [Reference][service-type]. |
 | apiSettings.tolerations | list | `[]` | Allow the k8s scheduler to schedule pods with matching taints for teams-api. [Reference][taints-and-tolerations]. |
 | apiSettings.topologySpreadConstraints | list | `[]` | Control how Pods are spread across your distributed footprint. Label selectors will be defaulted to those of the teams-api deployment. [Reference][topology-spread-constraints]. |
@@ -502,7 +502,7 @@ Kubernetes: `>=1.18-0`
 | appSettings.service.port | int | `80` | Service port. |
 | appSettings.service.shortname | string | `"fiftyone-app"` | Port name (maximum length is 15 characters) for fiftyone-app. [Reference][ports]. |
 | appSettings.service.startup.failureThreshold | int | `5` | Number of times to retry the startup probe for the fiftyone-app. [Reference][probes]. |
-| appSettings.service.startup.periodSeconds | int | `5` | How often (in seconds) to perform the startup probe for fiftyone-app. [Reference][probes]. |
+| appSettings.service.startup.periodSeconds | int | `15` | How often (in seconds) to perform the startup probe for fiftyone-app. [Reference][probes]. |
 | appSettings.service.type | string | `"ClusterIP"` | Service type for fiftyone-app. [Reference][service-type]. |
 | appSettings.tolerations | list | `[]` | Allow the k8s scheduler to schedule fiftyone-app pods with matching taints. [Reference][taints-and-tolerations]. |
 | appSettings.topologySpreadConstraints | list | `[]` | Control how Pods are spread across your distributed footprint. Label selectors will be defaulted to those of the fiftyone-app deployment. [Reference][topology-spread-constraints]. |
@@ -535,7 +535,7 @@ Kubernetes: `>=1.18-0`
 | casSettings.service.port | int | `80` | Service port. |
 | casSettings.service.shortname | string | `"teams-cas"` | Port name (maximum length is 15 characters) for teams-cas. [Reference][ports]. |
 | casSettings.service.startup.failureThreshold | int | `5` | Number of times to retry the startup probe for the teams-cas. [Reference][probes]. |
-| casSettings.service.startup.periodSeconds | int | `5` | How often (in seconds) to perform the startup probe for teams-cas. [Reference][probes]. |
+| casSettings.service.startup.periodSeconds | int | `15` | How often (in seconds) to perform the startup probe for teams-cas. [Reference][probes]. |
 | casSettings.service.type | string | `"ClusterIP"` | Service type for teams-cas. [Reference][service-type]. |
 | casSettings.tolerations | list | `[]` | Allow the k8s scheduler to schedule teams-cas pods with matching taints. [Reference][taints-and-tolerations]. |
 | casSettings.topologySpreadConstraints | list | `[]` | Control how Pods are spread across your distributed footprint. Label selectors will be defaulted to those of the teams-cas deployment. [Reference][topology-spread-constraints]. |
@@ -609,7 +609,7 @@ Kubernetes: `>=1.18-0`
 | pluginsSettings.service.port | int | `80` | Service port. |
 | pluginsSettings.service.shortname | string | `"teams-plugins"` | Port name (maximum length is 15 characters) for teams-plugins. [Reference][ports]. |
 | pluginsSettings.service.startup.failureThreshold | int | `5` | Number of times to retry the startup probe for the teams-plugins. [Reference][probes]. |
-| pluginsSettings.service.startup.periodSeconds | int | `5` | How often (in seconds) to perform the startup probe for teams-plugins. [Reference][probes]. |
+| pluginsSettings.service.startup.periodSeconds | int | `15` | How often (in seconds) to perform the startup probe for teams-plugins. [Reference][probes]. |
 | pluginsSettings.service.type | string | `"ClusterIP"` | Service type for teams-plugins. [Reference][service-type]. |
 | pluginsSettings.tolerations | list | `[]` | Allow the k8s scheduler to schedule teams-plugins pods with matching taints. [Reference][taints-and-tolerations]. |
 | pluginsSettings.topologySpreadConstraints | list | `[]` | Control how Pods are spread across your distributed footprint. Label selectors will be defaulted to those of the teams-plugins deployment. [Reference][topology-spread-constraints]. |
@@ -659,7 +659,7 @@ Kubernetes: `>=1.18-0`
 | teamsAppSettings.service.port | int | `80` | Service port. |
 | teamsAppSettings.service.shortname | string | `"teams-app"` | Port name (maximum length is 15 characters) for teams-app. [Reference][ports]. |
 | teamsAppSettings.service.startup.failureThreshold | int | `5` | Number of times to retry the startup probe for the teams-app. [Reference][probes]. |
-| teamsAppSettings.service.startup.periodSeconds | int | `5` | How often (in seconds) to perform the startup probe for teams-app. [Reference][probes]. |
+| teamsAppSettings.service.startup.periodSeconds | int | `15` | How often (in seconds) to perform the startup probe for teams-app. [Reference][probes]. |
 | teamsAppSettings.service.type | string | `"ClusterIP"` | Service type for teams-app. [Reference][service-type]. |
 | teamsAppSettings.tolerations | list | `[]` | Allow the k8s scheduler to schedule teams-app pods with matching taints. [Reference][taints-and-tolerations]. |
 | teamsAppSettings.topologySpreadConstraints | list | `[]` | Control how Pods are spread across your distributed footprint. Label selectors will be defaulted to those of the teams-app deployment. [Reference][topology-spread-constraints]. |

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -65,7 +65,7 @@ apiSettings:
       # -- Number of times to retry the startup probe for the teams-api. [Reference][probes].
       failureThreshold: 5
       # -- How often (in seconds) to perform the startup probe for teams-api. [Reference][probes].
-      periodSeconds: 5
+      periodSeconds: 15
     # -- Service type for teams-api. [Reference][service-type].
     type: ClusterIP
 
@@ -179,7 +179,7 @@ appSettings:
       # -- Number of times to retry the startup probe for the fiftyone-app. [Reference][probes].
       failureThreshold: 5
       # -- How often (in seconds) to perform the startup probe for fiftyone-app. [Reference][probes].
-      periodSeconds: 5
+      periodSeconds: 15
     # -- Service type for fiftyone-app. [Reference][service-type].
     type: ClusterIP
 
@@ -282,7 +282,7 @@ casSettings:
       # -- Number of times to retry the startup probe for the teams-cas. [Reference][probes].
       failureThreshold: 5
       # -- How often (in seconds) to perform the startup probe for teams-cas. [Reference][probes].
-      periodSeconds: 5
+      periodSeconds: 15
     # -- Service type for teams-cas. [Reference][service-type].
     type: ClusterIP
 
@@ -517,7 +517,7 @@ pluginsSettings:
       # -- Number of times to retry the startup probe for the teams-plugins. [Reference][probes].
       failureThreshold: 5
       # -- How often (in seconds) to perform the startup probe for teams-plugins. [Reference][probes].
-      periodSeconds: 5
+      periodSeconds: 15
     # -- Service type for teams-plugins. [Reference][service-type].
     type: ClusterIP
 
@@ -675,7 +675,7 @@ teamsAppSettings:
       # -- Number of times to retry the startup probe for the teams-app. [Reference][probes].
       failureThreshold: 5
       # -- How often (in seconds) to perform the startup probe for teams-app. [Reference][probes].
-      periodSeconds: 5
+      periodSeconds: 15
     # -- Service type for teams-app. [Reference][service-type].
     type: ClusterIP
 

--- a/tests/unit/helm/api-deployment_test.go
+++ b/tests/unit/helm/api-deployment_test.go
@@ -1019,7 +1019,7 @@ func (s *deploymentApiTemplateTest) TestContainerStartupProbe() {
             "port": "teams-api"
           },
           "failureThreshold": 5,
-          "periodSeconds": 5,
+          "periodSeconds": 15,
           "timeoutSeconds": 5
         }`
 				var expectedProbe *corev1.Probe

--- a/tests/unit/helm/app-deployment_test.go
+++ b/tests/unit/helm/app-deployment_test.go
@@ -1004,7 +1004,7 @@ func (s *deploymentAppTemplateTest) TestContainerStartupProbe() {
             "port": "fiftyone-app"
           },
           "failureThreshold": 5,
-          "periodSeconds": 5,
+          "periodSeconds": 15,
           "timeoutSeconds": 5
         }`
 				var expectedProbe *corev1.Probe

--- a/tests/unit/helm/cas-deployment_test.go
+++ b/tests/unit/helm/cas-deployment_test.go
@@ -1152,7 +1152,7 @@ func (s *deploymentCasTemplateTest) TestContainerStartupProbe() {
             "port": "teams-cas"
           },
           "failureThreshold": 5,
-          "periodSeconds": 5,
+          "periodSeconds": 15,
           "timeoutSeconds": 5
         }`
 				var expectedProbe *corev1.Probe

--- a/tests/unit/helm/plugins-deployment_test.go
+++ b/tests/unit/helm/plugins-deployment_test.go
@@ -1262,7 +1262,7 @@ func (s *deploymentPluginsTemplateTest) TestContainerStartupProbe() {
             "port": "teams-plugins"
           },
           "failureThreshold": 5,
-          "periodSeconds": 5,
+          "periodSeconds": 15,
           "timeoutSeconds": 5
         }`
 				var expectedProbe *corev1.Probe

--- a/tests/unit/helm/teams-app-deployment_test.go
+++ b/tests/unit/helm/teams-app-deployment_test.go
@@ -927,7 +927,7 @@ func (s *deploymentTeamsAppTemplateTest) TestContainerStartupProbe() {
             "port": "teams-app"
           },
           "failureThreshold": 5,
-          "periodSeconds": 5,
+          "periodSeconds": 15,
           "timeoutSeconds": 5
         }`
 				var expectedProbe *corev1.Probe


### PR DESCRIPTION
# Rationale

We've had lots of restarts during deployments lately, so I dove into it a little bit and we're being too agressive with our startup probe timeouts.  Our apps take just a little longer to start than we were allowing them.

## Changes

increase `startupProbe.periodSeconds` from `5` to `15`

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

N/A - Helm Only Configuration

## Testing

before change:
```
NAME                             READY   STATUS    RESTARTS        AGE
fiftyone-app-5bc55ff6d-pwpf2     1/1     Running   1 (3m30s ago)   4m26s
fiftyone-app-5bc55ff6d-qmkl2     1/1     Running   0               4m46s
teams-api-5bcbf68c89-4z5tp       1/1     Running   1 (3m51s ago)   4m47s
teams-app-779fb7cf5f-cnqsw       1/1     Running   0               4m46s
teams-app-779fb7cf5f-djjb7       1/1     Running   3 (2m11s ago)   4m17s
teams-cas-7c8cf75f8d-l4qgw       1/1     Running   0               3m16s
teams-cas-7c8cf75f8d-s5fzs       1/1     Running   0               4m46s
teams-plugins-556fbf8859-59gjn   0/1     Running   1 (9s ago)      65s
teams-plugins-556fbf8859-78lcd   1/1     Running   3 (95s ago)     4m46s
teams-plugins-c9666fbf7-5hwh2    1/1     Running   1 (8h ago)      8h
teams-plugins-c9666fbf7-pzdjj    1/1     Running   5 (8h ago)      8h
```

after change
```
NAME                             READY   STATUS    RESTARTS   AGE
fiftyone-app-796dd5495-47v28     1/1     Running   0          2m50s
fiftyone-app-796dd5495-dnpcm     1/1     Running   0          3m7s
teams-api-58fb467496-tdpkx       1/1     Running   0          3m7s
teams-app-7bb8f94794-29krp       1/1     Running   0          2m31s
teams-app-7bb8f94794-rsvnp       1/1     Running   0          3m6s
teams-cas-c8ccdc67f-65sw9        1/1     Running   0          22s
teams-cas-c8ccdc67f-g9rj5        1/1     Running   0          22s
teams-plugins-7944dc795b-84d65   1/1     Running   0          2m36s
teams-plugins-7944dc795b-jwmgr   1/1     Running   0          3m6s
teams-plugins-7944dc795b-ldmll   1/1     Running   0          2m5s
```

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
