### PR TITLE
fix: AS-328 Default Backends

### DIFF
--- a/helm/docs/expose-teams-api.md
+++ b/helm/docs/expose-teams-api.md
@@ -99,11 +99,6 @@ To use this chart's ingress object
               pathType: Prefix
               serviceName: teams-cas
               servicePort: 80
-            # Note: the ordering matters. This root path must be last.
-            - path: /
-              pathType: Prefix
-              serviceName: teams-app
-              servicePort: 80
         ```
 
 1. Upgrade the deployment using the latest Helm chart

--- a/helm/fiftyone-teams-app/templates/ingress.yaml
+++ b/helm/fiftyone-teams-app/templates/ingress.yaml
@@ -24,7 +24,7 @@ spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
-  backend:
+  defaultBackend:
     serviceName: {{ include "teams-app.name" . }}
     servicePort: {{ .Values.teamsAppSettings.service.port }}
   {{- if .Values.ingress.tlsEnabled }}

--- a/helm/fiftyone-teams-app/templates/ingress.yaml
+++ b/helm/fiftyone-teams-app/templates/ingress.yaml
@@ -24,6 +24,9 @@ spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
+  backend:
+    serviceName: {{ include "teams-app.name" . }}
+    servicePort: {{ .Values.teamsAppSettings.service.port }}
   {{- if .Values.ingress.tlsEnabled }}
   tls:
     - hosts:

--- a/helm/fiftyone-teams-app/templates/ingress.yaml
+++ b/helm/fiftyone-teams-app/templates/ingress.yaml
@@ -25,8 +25,10 @@ spec:
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
   defaultBackend:
-    serviceName: {{ include "teams-app.name" . }}
-    servicePort: {{ .Values.teamsAppSettings.service.port }}
+    service:
+      name: {{ include "teams-app.name" . }}
+      port: 
+        number: {{ .Values.teamsAppSettings.service.port }}
   {{- if .Values.ingress.tlsEnabled }}
   tls:
     - hosts:

--- a/helm/fiftyone-teams-app/templates/ingress.yaml
+++ b/helm/fiftyone-teams-app/templates/ingress.yaml
@@ -27,7 +27,7 @@ spec:
   defaultBackend:
     service:
       name: {{ include "teams-app.name" . }}
-      port: 
+      port:
         number: {{ .Values.teamsAppSettings.service.port }}
   {{- if .Values.ingress.tlsEnabled }}
   tls:


### PR DESCRIPTION
# Rationale

We shouldn't be setting a catch all `/` as the last route in path-based routing. It can technically lead to non-deterministic routing in very niche cases.

According to [K8s Docs](https://kubernetes.io/docs/concepts/services-networking/ingress/#multiple-matches):

> In some cases, multiple paths within an Ingress will match a request. In those cases precedence will be given first to the longest matching path. If two paths are still equally matched, precedence will be given to paths with an exact path type over prefix path type.

So, the ordering doesn't really matter and if we have two paths that match each other and the `/` route, it could cause issues in certain circumstances. We should just utilize the `defaultBackend` which will handle un-matched routes.

## Changes

Remove the block about a default `/` in our docs.
Adds a `.spec.defaultBackend` to our ingress controller.

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

Tested via ephemeral environments as well as staging env.

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
