### PR TITLE
Update custom plugins readme

### DIFF
--- a/docs/custom-plugins.md
+++ b/docs/custom-plugins.md
@@ -48,7 +48,7 @@ build, and publish, your image to your internal registry
 ```shell
 TEAMS_VERSION=v2.1.3
 docker buildx build --push \
-  --build-arg TEAMS_IMAGE_NAME='voxel51/fiftyone-app:${TEAMS_VERSION}' \
+  --build-arg TEAMS_IMAGE_NAME="voxel51/fiftyone-app:${TEAMS_VERSION}" \
   -t your-internal-registry/fiftyone-app-internal:${TEAMS_VERSION} .
 ```
 


### PR DESCRIPTION
Trying to execute this raised this error `ERROR: failed to solve: failed to parse stage name "voxel51/fiftyone-app:${TEAMS_VERSION}": invalid reference format` unless I changed the `'` to `"`.

Is this expected?