### PR TITLE
fix: AS-330 Adding Probes For teams-do

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,6 +7,10 @@ on:
       - opened
       - synchronize
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -15,6 +15,10 @@ on:
       - tests/integration/compose/**
       - tests/unit/compose/**
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit-compose:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-helm.yml
+++ b/.github/workflows/test-helm.yml
@@ -13,6 +13,10 @@ on:
       - tests/integration/helm/**
       - tests/unit/helm/**
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit-helm:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-integration-helm.yml
+++ b/.github/workflows/test-integration-helm.yml
@@ -13,6 +13,10 @@ on:
       - tests/integration/helm/**
       - tests/unit/helm/**
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   integration-helm:
     runs-on: ubuntu-latest

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -591,15 +591,20 @@ Kubernetes: `>=1.18-0`
 | delegatedOperatorExecutorSettings.image.repository | string | `"voxel51/fiftyone-app"` | Container image for delegated-operator-executor. |
 | delegatedOperatorExecutorSettings.image.tag | string | `""` | Image tag for delegated-operator-executor. Defaults to the chart version. |
 | delegatedOperatorExecutorSettings.labels | object | `{}` | Additional labels for the `delegated-operator-executor` deployment. [Reference][labels-and-selectors]. |
+| delegatedOperatorExecutorSettings.liveness.failureThreshold | int | `5` | Number of times to retry the readiness probe for the teams-do. [Reference][probes]. |
+| delegatedOperatorExecutorSettings.liveness.periodSeconds | int | `30` | How often (in seconds) to perform the readiness probe for teams-do. [Reference][probes]. |
 | delegatedOperatorExecutorSettings.name | string | `"teams-do"` | Deployment name |
 | delegatedOperatorExecutorSettings.nodeSelector | object | `{}` | nodeSelector for delegated-operator-executor. [Reference][node-selector]. |
 | delegatedOperatorExecutorSettings.podAnnotations | object | `{}` | Annotations for delegated-operator-executor pods. [Reference][annotations]. |
 | delegatedOperatorExecutorSettings.podSecurityContext | object | `{}` | Pod-level security attributes and common container settings for delegated-operator-executor. [Reference][security-context]. |
+| delegatedOperatorExecutorSettings.readiness | object | `{"failureThreshold":5,"periodSeconds":30}` | Container security configuration for delegated-operator-executor. [Reference][container-security-context]. |
+| delegatedOperatorExecutorSettings.readiness.failureThreshold | int | `5` | Number of times to retry the readiness probe for the teams-do. [Reference][probes]. |
+| delegatedOperatorExecutorSettings.readiness.periodSeconds | int | `30` | How often (in seconds) to perform the readiness probe for teams-do. [Reference][probes]. |
 | delegatedOperatorExecutorSettings.replicaCount | int | `3` | Number of pods in the delegated-operator-executor deployment's ReplicaSet. This should not exceed the value set in the deployment's license file for  max concurrent delegated operators, which defaults to 3. |
 | delegatedOperatorExecutorSettings.resources | object | `{"limits":{},"requests":{}}` | Container resource requests and limits for delegated-operator-executor. [Reference][resources]. |
-| delegatedOperatorExecutorSettings.securityContext | object | `{}` | Container security configuration for delegated-operator-executor. [Reference][container-security-context]. |
+| delegatedOperatorExecutorSettings.securityContext | object | `{}` |  |
 | delegatedOperatorExecutorSettings.startup.failureThreshold | int | `5` | Number of times to retry the startup probe for the teams-do. [Reference][probes]. |
-| delegatedOperatorExecutorSettings.startup.periodSeconds | int | `15` | How often (in seconds) to perform the startup probe for teams-do. [Reference][probes]. |
+| delegatedOperatorExecutorSettings.startup.periodSeconds | int | `30` | How often (in seconds) to perform the startup probe for teams-do. [Reference][probes]. |
 | delegatedOperatorExecutorSettings.tolerations | list | `[]` | Allow the k8s scheduler to schedule delegated-operator-executor pods with matching taints. [Reference][taints-and-tolerations]. |
 | delegatedOperatorExecutorSettings.volumeMounts | list | `[]` | Volume mounts for delegated-operator-executor pods. [Reference][volumes]. |
 | delegatedOperatorExecutorSettings.volumes | list | `[]` | Volumes for delegated-operator-executor. [Reference][volumes]. |

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -591,20 +591,23 @@ Kubernetes: `>=1.18-0`
 | delegatedOperatorExecutorSettings.image.repository | string | `"voxel51/fiftyone-app"` | Container image for delegated-operator-executor. |
 | delegatedOperatorExecutorSettings.image.tag | string | `""` | Image tag for delegated-operator-executor. Defaults to the chart version. |
 | delegatedOperatorExecutorSettings.labels | object | `{}` | Additional labels for the `delegated-operator-executor` deployment. [Reference][labels-and-selectors]. |
-| delegatedOperatorExecutorSettings.liveness.failureThreshold | int | `5` | Number of times to retry the readiness probe for the teams-do. [Reference][probes]. |
-| delegatedOperatorExecutorSettings.liveness.periodSeconds | int | `30` | How often (in seconds) to perform the readiness probe for teams-do. [Reference][probes]. |
+| delegatedOperatorExecutorSettings.liveness.failureThreshold | int | `5` | Number of times to retry the liveness probe for the teams-do. [Reference][probes]. |
+| delegatedOperatorExecutorSettings.liveness.periodSeconds | int | `30` | How often (in seconds) to perform the liveness probe for teams-do. [Reference][probes]. |
+| delegatedOperatorExecutorSettings.liveness.timeoutSeconds | int | `30` | Timeout for the liveness probe for the teams-do. [Reference][probes]. |
 | delegatedOperatorExecutorSettings.name | string | `"teams-do"` | Deployment name |
 | delegatedOperatorExecutorSettings.nodeSelector | object | `{}` | nodeSelector for delegated-operator-executor. [Reference][node-selector]. |
 | delegatedOperatorExecutorSettings.podAnnotations | object | `{}` | Annotations for delegated-operator-executor pods. [Reference][annotations]. |
 | delegatedOperatorExecutorSettings.podSecurityContext | object | `{}` | Pod-level security attributes and common container settings for delegated-operator-executor. [Reference][security-context]. |
-| delegatedOperatorExecutorSettings.readiness | object | `{"failureThreshold":5,"periodSeconds":30}` | Container security configuration for delegated-operator-executor. [Reference][container-security-context]. |
+| delegatedOperatorExecutorSettings.readiness | object | `{"failureThreshold":5,"periodSeconds":30,"timeoutSeconds":30}` | Container security configuration for delegated-operator-executor. [Reference][container-security-context]. |
 | delegatedOperatorExecutorSettings.readiness.failureThreshold | int | `5` | Number of times to retry the readiness probe for the teams-do. [Reference][probes]. |
 | delegatedOperatorExecutorSettings.readiness.periodSeconds | int | `30` | How often (in seconds) to perform the readiness probe for teams-do. [Reference][probes]. |
+| delegatedOperatorExecutorSettings.readiness.timeoutSeconds | int | `30` | Timeout for the readiness probe for the teams-do. [Reference][probes]. |
 | delegatedOperatorExecutorSettings.replicaCount | int | `3` | Number of pods in the delegated-operator-executor deployment's ReplicaSet. This should not exceed the value set in the deployment's license file for  max concurrent delegated operators, which defaults to 3. |
 | delegatedOperatorExecutorSettings.resources | object | `{"limits":{},"requests":{}}` | Container resource requests and limits for delegated-operator-executor. [Reference][resources]. |
 | delegatedOperatorExecutorSettings.securityContext | object | `{}` |  |
 | delegatedOperatorExecutorSettings.startup.failureThreshold | int | `5` | Number of times to retry the startup probe for the teams-do. [Reference][probes]. |
 | delegatedOperatorExecutorSettings.startup.periodSeconds | int | `30` | How often (in seconds) to perform the startup probe for teams-do. [Reference][probes]. |
+| delegatedOperatorExecutorSettings.startup.timeoutSeconds | int | `30` | Timeout for the startup probe for the teams-do. [Reference][probes]. |
 | delegatedOperatorExecutorSettings.tolerations | list | `[]` | Allow the k8s scheduler to schedule delegated-operator-executor pods with matching taints. [Reference][taints-and-tolerations]. |
 | delegatedOperatorExecutorSettings.volumeMounts | list | `[]` | Volume mounts for delegated-operator-executor pods. [Reference][volumes]. |
 | delegatedOperatorExecutorSettings.volumes | list | `[]` | Volumes for delegated-operator-executor. [Reference][volumes]. |

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -598,6 +598,8 @@ Kubernetes: `>=1.18-0`
 | delegatedOperatorExecutorSettings.replicaCount | int | `3` | Number of pods in the delegated-operator-executor deployment's ReplicaSet. This should not exceed the value set in the deployment's license file for  max concurrent delegated operators, which defaults to 3. |
 | delegatedOperatorExecutorSettings.resources | object | `{"limits":{},"requests":{}}` | Container resource requests and limits for delegated-operator-executor. [Reference][resources]. |
 | delegatedOperatorExecutorSettings.securityContext | object | `{}` | Container security configuration for delegated-operator-executor. [Reference][container-security-context]. |
+| delegatedOperatorExecutorSettings.startup.failureThreshold | int | `5` | Number of times to retry the startup probe for the teams-do. [Reference][probes]. |
+| delegatedOperatorExecutorSettings.startup.periodSeconds | int | `15` | How often (in seconds) to perform the startup probe for teams-do. [Reference][probes]. |
 | delegatedOperatorExecutorSettings.tolerations | list | `[]` | Allow the k8s scheduler to schedule delegated-operator-executor pods with matching taints. [Reference][taints-and-tolerations]. |
 | delegatedOperatorExecutorSettings.volumeMounts | list | `[]` | Volume mounts for delegated-operator-executor pods. [Reference][volumes]. |
 | delegatedOperatorExecutorSettings.volumes | list | `[]` | Volumes for delegated-operator-executor. [Reference][volumes]. |

--- a/helm/fiftyone-teams-app/templates/delegated-operator-executor-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/delegated-operator-executor-deployment.yaml
@@ -54,6 +54,7 @@ spec:
                 - fiftyone delegated list --limit 1 -o liveness
             failureThreshold: {{ .Values.delegatedOperatorExecutorSettings.liveness.failureThreshold }}
             periodSeconds: {{ .Values.delegatedOperatorExecutorSettings.liveness.periodSeconds }}
+            timeoutSeconds: 30
           readinessProbe:
             exec:
               command:
@@ -62,6 +63,7 @@ spec:
                 - fiftyone delegated list --limit 1 -o readiness
             failureThreshold: {{ .Values.delegatedOperatorExecutorSettings.readiness.failureThreshold }}
             periodSeconds: {{ .Values.delegatedOperatorExecutorSettings.readiness.periodSeconds }}
+            timeoutSeconds: 30
           startupProbe:
             exec:
               command:
@@ -70,7 +72,7 @@ spec:
                 - fiftyone delegated list --limit 1 -o startup
             failureThreshold: {{ .Values.delegatedOperatorExecutorSettings.startup.failureThreshold }}
             periodSeconds: {{ .Values.delegatedOperatorExecutorSettings.startup.periodSeconds }}
-            timeoutSeconds: 5
+            timeoutSeconds: 30
       {{- with .Values.delegatedOperatorExecutorSettings.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/fiftyone-teams-app/templates/delegated-operator-executor-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/delegated-operator-executor-deployment.yaml
@@ -46,6 +46,27 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - fiftyone delegated list --limit 1 -o liveness
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - fiftyone delegated list --limit 1 -o readiness
+          startupProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - fiftyone delegated list --limit 1 -o startup
+            failureThreshold: {{ .Values.delegatedOperatorExecutorSettings.startup.failureThreshold }}
+            periodSeconds: {{ .Values.delegatedOperatorExecutorSettings.startup.periodSeconds }}
+            timeoutSeconds: 5
       {{- with .Values.delegatedOperatorExecutorSettings.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/fiftyone-teams-app/templates/delegated-operator-executor-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/delegated-operator-executor-deployment.yaml
@@ -52,12 +52,16 @@ spec:
                 - sh
                 - -c
                 - fiftyone delegated list --limit 1 -o liveness
+            failureThreshold: {{ .Values.delegatedOperatorExecutorSettings.liveness.failureThreshold }}
+            periodSeconds: {{ .Values.delegatedOperatorExecutorSettings.liveness.periodSeconds }}
           readinessProbe:
             exec:
               command:
                 - sh
                 - -c
                 - fiftyone delegated list --limit 1 -o readiness
+            failureThreshold: {{ .Values.delegatedOperatorExecutorSettings.readiness.failureThreshold }}
+            periodSeconds: {{ .Values.delegatedOperatorExecutorSettings.readiness.periodSeconds }}
           startupProbe:
             exec:
               command:

--- a/helm/fiftyone-teams-app/templates/delegated-operator-executor-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/delegated-operator-executor-deployment.yaml
@@ -54,7 +54,7 @@ spec:
                 - fiftyone delegated list --limit 1 -o liveness
             failureThreshold: {{ .Values.delegatedOperatorExecutorSettings.liveness.failureThreshold }}
             periodSeconds: {{ .Values.delegatedOperatorExecutorSettings.liveness.periodSeconds }}
-            timeoutSeconds: 30
+            timeoutSeconds: {{ .Values.delegatedOperatorExecutorSettings.liveness.timeoutSeconds }}
           readinessProbe:
             exec:
               command:
@@ -63,7 +63,7 @@ spec:
                 - fiftyone delegated list --limit 1 -o readiness
             failureThreshold: {{ .Values.delegatedOperatorExecutorSettings.readiness.failureThreshold }}
             periodSeconds: {{ .Values.delegatedOperatorExecutorSettings.readiness.periodSeconds }}
-            timeoutSeconds: 30
+            timeoutSeconds: {{ .Values.delegatedOperatorExecutorSettings.readiness.timeoutSeconds }}
           startupProbe:
             exec:
               command:
@@ -72,7 +72,7 @@ spec:
                 - fiftyone delegated list --limit 1 -o startup
             failureThreshold: {{ .Values.delegatedOperatorExecutorSettings.startup.failureThreshold }}
             periodSeconds: {{ .Values.delegatedOperatorExecutorSettings.startup.periodSeconds }}
-            timeoutSeconds: 30
+            timeoutSeconds: {{ .Values.delegatedOperatorExecutorSettings.startup.timeoutSeconds }}
       {{- with .Values.delegatedOperatorExecutorSettings.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -347,10 +347,12 @@ delegatedOperatorExecutorSettings:
   # -- Additional labels for the `delegated-operator-executor` deployment. [Reference][labels-and-selectors].
   labels: {}
   liveness:
-    # -- Number of times to retry the readiness probe for the teams-do. [Reference][probes].
+    # -- Number of times to retry the liveness probe for the teams-do. [Reference][probes].
     failureThreshold: 5
-    # -- How often (in seconds) to perform the readiness probe for teams-do. [Reference][probes].
+    # -- How often (in seconds) to perform the liveness probe for teams-do. [Reference][probes].
     periodSeconds: 30
+    # -- Timeout for the liveness probe for the teams-do. [Reference][probes].
+    timeoutSeconds: 30
   # -- Number of pods in the delegated-operator-executor deployment's ReplicaSet.
   # This should not exceed the value set in the deployment's license file for
   #  max concurrent delegated operators, which defaults to 3.
@@ -386,12 +388,16 @@ delegatedOperatorExecutorSettings:
     failureThreshold: 5
     # -- How often (in seconds) to perform the readiness probe for teams-do. [Reference][probes].
     periodSeconds: 30
+    # -- Timeout for the readiness probe for the teams-do. [Reference][probes].
+    timeoutSeconds: 30
   securityContext: {}
   startup:
     # -- Number of times to retry the startup probe for the teams-do. [Reference][probes].
     failureThreshold: 5
     # -- How often (in seconds) to perform the startup probe for teams-do. [Reference][probes].
     periodSeconds: 30
+    # -- Timeout for the startup probe for the teams-do. [Reference][probes].
+    timeoutSeconds: 30
   # -- Allow the k8s scheduler to schedule delegated-operator-executor pods with matching taints. [Reference][taints-and-tolerations].
   tolerations: []
   # -- Volume mounts for delegated-operator-executor pods. [Reference][volumes].

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -377,6 +377,11 @@ delegatedOperatorExecutorSettings:
   # TODO: Kevin/topher - Consider renaming `securityContext` to `containerSecurityContext`
   # -- Container security configuration for delegated-operator-executor. [Reference][container-security-context].
   securityContext: {}
+  startup:
+    # -- Number of times to retry the startup probe for the teams-do. [Reference][probes].
+    failureThreshold: 5
+    # -- How often (in seconds) to perform the startup probe for teams-do. [Reference][probes].
+    periodSeconds: 15
   # -- Allow the k8s scheduler to schedule delegated-operator-executor pods with matching taints. [Reference][taints-and-tolerations].
   tolerations: []
   # -- Volume mounts for delegated-operator-executor pods. [Reference][volumes].

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -346,6 +346,11 @@ delegatedOperatorExecutorSettings:
     tag: ""
   # -- Additional labels for the `delegated-operator-executor` deployment. [Reference][labels-and-selectors].
   labels: {}
+  liveness:
+    # -- Number of times to retry the readiness probe for the teams-do. [Reference][probes].
+    failureThreshold: 5
+    # -- How often (in seconds) to perform the readiness probe for teams-do. [Reference][probes].
+    periodSeconds: 30
   # -- Number of pods in the delegated-operator-executor deployment's ReplicaSet.
   # This should not exceed the value set in the deployment's license file for
   #  max concurrent delegated operators, which defaults to 3.
@@ -376,12 +381,17 @@ delegatedOperatorExecutorSettings:
   podSecurityContext: {}
   # TODO: Kevin/topher - Consider renaming `securityContext` to `containerSecurityContext`
   # -- Container security configuration for delegated-operator-executor. [Reference][container-security-context].
+  readiness:
+    # -- Number of times to retry the readiness probe for the teams-do. [Reference][probes].
+    failureThreshold: 5
+    # -- How often (in seconds) to perform the readiness probe for teams-do. [Reference][probes].
+    periodSeconds: 30
   securityContext: {}
   startup:
     # -- Number of times to retry the startup probe for the teams-do. [Reference][probes].
     failureThreshold: 5
     # -- How often (in seconds) to perform the startup probe for teams-do. [Reference][probes].
-    periodSeconds: 15
+    periodSeconds: 30
   # -- Allow the k8s scheduler to schedule delegated-operator-executor pods with matching taints. [Reference][taints-and-tolerations].
   tolerations: []
   # -- Volume mounts for delegated-operator-executor pods. [Reference][volumes].

--- a/tests/unit/helm/delegated-operator-executor-deployment_test.go
+++ b/tests/unit/helm/delegated-operator-executor-deployment_test.go
@@ -1712,7 +1712,7 @@ func (s *deploymentDelegatedOperatorExecutorTemplateTest) TestContainerLivenessP
           },
           "failureThreshold": 5,
           "periodSeconds": 30,
-		  "timeoutSeconds": 30
+          "timeoutSeconds": 30
         }`
 				var expectedProbe *corev1.Probe
 				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
@@ -1739,7 +1739,7 @@ func (s *deploymentDelegatedOperatorExecutorTemplateTest) TestContainerLivenessP
           },
           "failureThreshold": 10,
           "periodSeconds": 10,
-		  "timeoutSeconds": 10
+          "timeoutSeconds": 10
         }`
 				var expectedProbe *corev1.Probe
 				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
@@ -1789,7 +1789,7 @@ func (s *deploymentDelegatedOperatorExecutorTemplateTest) TestContainerReadiness
           },
           "failureThreshold": 5,
           "periodSeconds": 30,
-		  "timeoutSeconds": 30
+          "timeoutSeconds": 30
         }`
 				var expectedProbe *corev1.Probe
 				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
@@ -1816,7 +1816,7 @@ func (s *deploymentDelegatedOperatorExecutorTemplateTest) TestContainerReadiness
           },
           "failureThreshold": 10,
           "periodSeconds": 10,
-		  "timeoutSeconds": 10
+          "timeoutSeconds": 10
         }`
 				var expectedProbe *corev1.Probe
 				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
@@ -1866,7 +1866,7 @@ func (s *deploymentDelegatedOperatorExecutorTemplateTest) TestContainerStartupPr
           },
           "failureThreshold": 5,
           "periodSeconds": 30,
-		  "timeoutSeconds": 30
+          "timeoutSeconds": 30
         }`
 				var expectedProbe *corev1.Probe
 				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
@@ -1893,7 +1893,7 @@ func (s *deploymentDelegatedOperatorExecutorTemplateTest) TestContainerStartupPr
           },
           "failureThreshold": 10,
           "periodSeconds": 10,
-		  "timeoutSeconds": 10
+          "timeoutSeconds": 10
         }`
 				var expectedProbe *corev1.Probe
 				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)

--- a/tests/unit/helm/delegated-operator-executor-deployment_test.go
+++ b/tests/unit/helm/delegated-operator-executor-deployment_test.go
@@ -1711,7 +1711,8 @@ func (s *deploymentDelegatedOperatorExecutorTemplateTest) TestContainerLivenessP
               ]
           },
           "failureThreshold": 5,
-          "periodSeconds": 30
+          "periodSeconds": 30,
+		  "timeoutSeconds": 30
         }`
 				var expectedProbe *corev1.Probe
 				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
@@ -1736,7 +1737,8 @@ func (s *deploymentDelegatedOperatorExecutorTemplateTest) TestContainerLivenessP
               ]
           },
           "failureThreshold": 10,
-          "periodSeconds": 10
+          "periodSeconds": 10,
+		  "timeoutSeconds": 30
         }`
 				var expectedProbe *corev1.Probe
 				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
@@ -1785,7 +1787,8 @@ func (s *deploymentDelegatedOperatorExecutorTemplateTest) TestContainerReadiness
               ]
           },
           "failureThreshold": 5,
-          "periodSeconds": 30
+          "periodSeconds": 30,
+		  "timeoutSeconds": 30
         }`
 				var expectedProbe *corev1.Probe
 				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
@@ -1810,7 +1813,8 @@ func (s *deploymentDelegatedOperatorExecutorTemplateTest) TestContainerReadiness
               ]
           },
           "failureThreshold": 10,
-          "periodSeconds": 10
+          "periodSeconds": 10,
+		  "timeoutSeconds": 30
         }`
 				var expectedProbe *corev1.Probe
 				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
@@ -1860,7 +1864,7 @@ func (s *deploymentDelegatedOperatorExecutorTemplateTest) TestContainerStartupPr
           },
           "failureThreshold": 5,
           "periodSeconds": 30,
-          "timeoutSeconds": 5
+		  "timeoutSeconds": 30
         }`
 				var expectedProbe *corev1.Probe
 				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
@@ -1886,7 +1890,7 @@ func (s *deploymentDelegatedOperatorExecutorTemplateTest) TestContainerStartupPr
           },
           "failureThreshold": 10,
           "periodSeconds": 10,
-          "timeoutSeconds": 5
+		  "timeoutSeconds": 30
         }`
 				var expectedProbe *corev1.Probe
 				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)

--- a/tests/unit/helm/delegated-operator-executor-deployment_test.go
+++ b/tests/unit/helm/delegated-operator-executor-deployment_test.go
@@ -1726,6 +1726,7 @@ func (s *deploymentDelegatedOperatorExecutorTemplateTest) TestContainerLivenessP
 				"delegatedOperatorExecutorSettings.enabled":                   "true",
 				"delegatedOperatorExecutorSettings.liveness.failureThreshold": "10",
 				"delegatedOperatorExecutorSettings.liveness.periodSeconds":    "10",
+				"delegatedOperatorExecutorSettings.liveness.timeoutSeconds":   "10",
 			},
 			func(probe *corev1.Probe) {
 				expectedProbeJSON := `{
@@ -1738,7 +1739,7 @@ func (s *deploymentDelegatedOperatorExecutorTemplateTest) TestContainerLivenessP
           },
           "failureThreshold": 10,
           "periodSeconds": 10,
-		  "timeoutSeconds": 30
+		  "timeoutSeconds": 10
         }`
 				var expectedProbe *corev1.Probe
 				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
@@ -1802,6 +1803,7 @@ func (s *deploymentDelegatedOperatorExecutorTemplateTest) TestContainerReadiness
 				"delegatedOperatorExecutorSettings.enabled":                    "true",
 				"delegatedOperatorExecutorSettings.readiness.failureThreshold": "10",
 				"delegatedOperatorExecutorSettings.readiness.periodSeconds":    "10",
+				"delegatedOperatorExecutorSettings.readiness.timeoutSeconds":   "10",
 			},
 			func(probe *corev1.Probe) {
 				expectedProbeJSON := `{
@@ -1814,7 +1816,7 @@ func (s *deploymentDelegatedOperatorExecutorTemplateTest) TestContainerReadiness
           },
           "failureThreshold": 10,
           "periodSeconds": 10,
-		  "timeoutSeconds": 30
+		  "timeoutSeconds": 10
         }`
 				var expectedProbe *corev1.Probe
 				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
@@ -1878,6 +1880,7 @@ func (s *deploymentDelegatedOperatorExecutorTemplateTest) TestContainerStartupPr
 				"delegatedOperatorExecutorSettings.enabled":                  "true",
 				"delegatedOperatorExecutorSettings.startup.failureThreshold": "10",
 				"delegatedOperatorExecutorSettings.startup.periodSeconds":    "10",
+				"delegatedOperatorExecutorSettings.startup.timeoutSeconds":   "10",
 			},
 			func(probe *corev1.Probe) {
 				expectedProbeJSON := `{
@@ -1890,7 +1893,7 @@ func (s *deploymentDelegatedOperatorExecutorTemplateTest) TestContainerStartupPr
           },
           "failureThreshold": 10,
           "periodSeconds": 10,
-		  "timeoutSeconds": 30
+		  "timeoutSeconds": 10
         }`
 				var expectedProbe *corev1.Probe
 				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)

--- a/tests/unit/helm/delegated-operator-executor-deployment_test.go
+++ b/tests/unit/helm/delegated-operator-executor-deployment_test.go
@@ -1709,12 +1709,39 @@ func (s *deploymentDelegatedOperatorExecutorTemplateTest) TestContainerLivenessP
                 "-c",
                 "fiftyone delegated list --limit 1 -o liveness"
               ]
-          }
+          },
+          "failureThreshold": 5,
+          "periodSeconds": 30
         }`
 				var expectedProbe *corev1.Probe
 				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
 				s.NoError(err)
 				s.Equal(expectedProbe, probe, "Liveness Probes should be equal")
+			},
+		},
+		{
+			"overrideServiceStartupFailureThresholdAndPeriodSecondsAndShortName",
+			map[string]string{
+				"delegatedOperatorExecutorSettings.enabled":                   "true",
+				"delegatedOperatorExecutorSettings.liveness.failureThreshold": "10",
+				"delegatedOperatorExecutorSettings.liveness.periodSeconds":    "10",
+			},
+			func(probe *corev1.Probe) {
+				expectedProbeJSON := `{
+          "exec": {
+              "command": [
+                "sh",
+                "-c",
+                "fiftyone delegated list --limit 1 -o liveness"
+              ]
+          },
+          "failureThreshold": 10,
+          "periodSeconds": 10
+        }`
+				var expectedProbe *corev1.Probe
+				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
+				s.NoError(err)
+				s.Equal(expectedProbe, probe, "Startup Probes should be equal")
 			},
 		},
 	}
@@ -1756,12 +1783,39 @@ func (s *deploymentDelegatedOperatorExecutorTemplateTest) TestContainerReadiness
                 "-c",
                 "fiftyone delegated list --limit 1 -o readiness"
               ]
-          }
+          },
+          "failureThreshold": 5,
+          "periodSeconds": 30
         }`
 				var expectedProbe *corev1.Probe
 				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
 				s.NoError(err)
 				s.Equal(expectedProbe, probe, "Readiness Probes should be equal")
+			},
+		},
+		{
+			"overrideServiceStartupFailureThresholdAndPeriodSecondsAndShortName",
+			map[string]string{
+				"delegatedOperatorExecutorSettings.enabled":                    "true",
+				"delegatedOperatorExecutorSettings.readiness.failureThreshold": "10",
+				"delegatedOperatorExecutorSettings.readiness.periodSeconds":    "10",
+			},
+			func(probe *corev1.Probe) {
+				expectedProbeJSON := `{
+          "exec": {
+              "command": [
+                "sh",
+                "-c",
+                "fiftyone delegated list --limit 1 -o readiness"
+              ]
+          },
+          "failureThreshold": 10,
+          "periodSeconds": 10
+        }`
+				var expectedProbe *corev1.Probe
+				err := json.Unmarshal([]byte(expectedProbeJSON), &expectedProbe)
+				s.NoError(err)
+				s.Equal(expectedProbe, probe, "Startup Probes should be equal")
 			},
 		},
 	}
@@ -1805,7 +1859,7 @@ func (s *deploymentDelegatedOperatorExecutorTemplateTest) TestContainerStartupPr
               ]
           },
           "failureThreshold": 5,
-          "periodSeconds": 15,
+          "periodSeconds": 30,
           "timeoutSeconds": 5
         }`
 				var expectedProbe *corev1.Probe


### PR DESCRIPTION
# Rationale

Adds liveness, readiness, and startup probes to teams-do. This will be a must-have for some users of FOT in order to comply with certain policies.

## Changes

Adds probes to run `fiftyone delegated list --limit 1 -o liveness`. The `-o liveness` should return 0 results. This will test database connectivity from the pod and should be expanded upon and changed when true liveness/readiness probes are supported from the applciation.

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

## Testing

Tests updated accordingly.

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
