### PR TITLE
feat: AS-288 Extra configurable secrets

### DIFF
--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -498,6 +498,7 @@ Kubernetes: `>=1.18-0`
 | apiSettings.podAnnotations | object | `{}` | Annotations for pods for teams-api. [Reference][annotations]. |
 | apiSettings.podSecurityContext | object | `{}` | Pod-level security attributes and common container settings for teams-api. [Reference][security-context]. |
 | apiSettings.resources | object | `{"limits":{},"requests":{}}` | Container resource requests and limits for teams-api. [Reference][resources]. |
+| apiSettings.secretEnv | object | `{}` | Secret variables to be passed to the teams-api containers. |
 | apiSettings.securityContext | object | `{}` | Container security configuration for teams-api. [Reference][container-security-context]. |
 | apiSettings.service.annotations | object | `{}` | Service annotations for teams-api. [Reference][annotations]. |
 | apiSettings.service.containerPort | int | `8000` | Service container port for teams-api. |
@@ -535,6 +536,7 @@ Kubernetes: `>=1.18-0`
 | appSettings.podSecurityContext | object | `{}` | Pod-level security attributes and common container settings for fiftyone-app. [Reference][security-context]. |
 | appSettings.replicaCount | int | `2` | Number of pods in the fiftyone-app deployment's ReplicaSet. Ignored when `appSettings.autoscaling.enabled: true`. [Reference][deployment]. |
 | appSettings.resources | object | `{"limits":{},"requests":{}}` | Container resource requests and limits for fiftyone-app. [Reference][resources]. |
+| appSettings.secretEnv | object | `{}` | Secret variables to be passed to the fiftyone-app containers. |
 | appSettings.securityContext | object | `{}` | Container security configuration for fiftyone-app. [Reference][container-security-context]. |
 | appSettings.service.annotations | object | `{}` | Service annotations for fiftyone-app. [Reference][annotations]. |
 | appSettings.service.containerPort | int | `5151` | Service container port for fiftyone-app. |
@@ -568,6 +570,7 @@ Kubernetes: `>=1.18-0`
 | casSettings.podSecurityContext | object | `{}` | Pod-level security attributes and common container settings for teams-cas. [Reference][security-context]. |
 | casSettings.replicaCount | int | `2` | Number of pods in the teams-cas deployment's ReplicaSet. [Reference][deployment]. |
 | casSettings.resources | object | `{"limits":{},"requests":{}}` | Container resource requests and limits for teams-cas. [Reference][resources]. |
+| casSettings.secretEnv | object | `{}` | Secret variables to be passed to the teams-cas containers. |
 | casSettings.securityContext | object | `{}` | Container security configuration for teams-cas. [Reference][container-security-context]. |
 | casSettings.service.annotations | object | `{}` | Service annotations for teams-cas. [Reference][annotations]. |
 | casSettings.service.containerPort | int | `3000` | Service container port for teams-cas. |
@@ -604,6 +607,7 @@ Kubernetes: `>=1.18-0`
 | delegatedOperatorExecutorSettings.readiness.timeoutSeconds | int | `30` | Timeout for the readiness probe for the teams-do. [Reference][probes]. |
 | delegatedOperatorExecutorSettings.replicaCount | int | `3` | Number of pods in the delegated-operator-executor deployment's ReplicaSet. This should not exceed the value set in the deployment's license file for  max concurrent delegated operators, which defaults to 3. |
 | delegatedOperatorExecutorSettings.resources | object | `{"limits":{},"requests":{}}` | Container resource requests and limits for delegated-operator-executor. [Reference][resources]. |
+| delegatedOperatorExecutorSettings.secretEnv | object | `{}` | Secret variables to be passed to the delegated-operator-executor containers. |
 | delegatedOperatorExecutorSettings.securityContext | object | `{}` |  |
 | delegatedOperatorExecutorSettings.startup.failureThreshold | int | `5` | Number of times to retry the startup probe for the teams-do. [Reference][probes]. |
 | delegatedOperatorExecutorSettings.startup.periodSeconds | int | `30` | How often (in seconds) to perform the startup probe for teams-do. [Reference][probes]. |
@@ -653,6 +657,7 @@ Kubernetes: `>=1.18-0`
 | pluginsSettings.podSecurityContext | object | `{}` | Pod-level security attributes and common container settings for teams-plugins. [Reference][security-context]. |
 | pluginsSettings.replicaCount | int | `2` | Number of pods in the teams-plugins deployment's ReplicaSet. Ignored when `pluginsSettings.autoscaling.enabled: true`. [Reference][deployment]. |
 | pluginsSettings.resources | object | `{"limits":{},"requests":{}}` | Container resource requests and limits for teams-plugins. [Reference][resources]. |
+| pluginsSettings.secretEnv | object | `{}` | Secret variables to be passed to the teams-plugins containers. |
 | pluginsSettings.securityContext | object | `{}` | Container security configuration for teams-plugins. [Reference][container-security-context]. |
 | pluginsSettings.service.annotations | object | `{}` | Service annotations for teams-plugins. [Reference][annotations]. |
 | pluginsSettings.service.containerPort | int | `5151` | Service container port for teams-plugins. |
@@ -705,6 +710,7 @@ Kubernetes: `>=1.18-0`
 | teamsAppSettings.podSecurityContext | object | `{}` | Pod-level security attributes and common container settings for teams-app. [Reference][security-context]. |
 | teamsAppSettings.replicaCount | int | `2` | Number of pods in the teams-app deployment's ReplicaSet. Ignored when `teamsAppSettings.autoscaling.enabled: true`. [Reference][deployment]. |
 | teamsAppSettings.resources | object | `{"limits":{},"requests":{}}` | Container resource requests and limits for teams-app. [Reference][resources]. |
+| teamsAppSettings.secretEnv | object | `{}` | Secret variables to be passed to the teams-app containers. |
 | teamsAppSettings.securityContext | object | `{}` | Container security configuration for teams-app. [Reference][container-security-context]. |
 | teamsAppSettings.service.annotations | object | `{}` | Service annotations for teams-app. [Reference][annotations]. |
 | teamsAppSettings.service.containerPort | int | `3000` | Service container port for teams-app. |

--- a/helm/fiftyone-teams-app/templates/_helpers.tpl
+++ b/helm/fiftyone-teams-app/templates/_helpers.tpl
@@ -312,6 +312,13 @@ Create a merged list of environment variables for delegated-operator-executor
 - name: {{ $key }}
   value: {{ $val | quote }}
 {{- end }}
+{{- range $key, $val := .Values.delegatedOperatorExecutorSettings.secretEnv }}
+- name: {{ $key }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $val.secretName }}
+      key: {{ $val.secretKey }}
+{{- end }}
 {{- end -}}
 
 {{/*
@@ -350,6 +357,13 @@ Create a merged list of environment variables for fiftyone-teams-api
 - name: {{ $key }}
   value: {{ $val | quote }}
 {{- end }}
+{{- range $key, $val := .Values.apiSettings.secretEnv }}
+- name: {{ $key }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $val.secretName }}
+      key: {{ $val.secretKey }}
+{{- end }}
 {{- end -}}
 
 {{/*
@@ -382,6 +396,13 @@ Create a merged list of environment variables for fiftyone-app
 {{- range $key, $val := .Values.appSettings.env }}
 - name: {{ $key }}
   value: {{ $val | quote }}
+{{- end }}
+{{- range $key, $val := .Values.appSettings.secretEnv }}
+- name: {{ $key }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $val.secretName }}
+      key: {{ $val.secretKey }}
 {{- end }}
 {{- end -}}
 
@@ -440,6 +461,13 @@ Create a merged list of environment variables for fiftyone-teams-cas
 - name: {{ $key }}
   value: {{ $val | quote }}
 {{- end }}
+{{- range $key, $val := .Values.casSettings.secretEnv }}
+- name: {{ $key }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $val.secretName }}
+      key: {{ $val.secretKey }}
+{{- end }}
 {{- end -}}
 
 {{/*
@@ -474,6 +502,13 @@ Create a merged list of environment variables for fiftyone-teams-plugins
 {{- range $key, $val := .Values.pluginsSettings.env }}
 - name: {{ $key }}
   value: {{ $val | quote }}
+{{- end }}
+{{- range $key, $val := .Values.pluginsSettings.secretEnv }}
+- name: {{ $key }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $val.secretName }}
+      key: {{ $val.secretKey }}
 {{- end }}
 {{- end -}}
 
@@ -513,5 +548,12 @@ Create a merged list of environment variables for fiftyone-teams-app
 {{- range $key, $val := .Values.teamsAppSettings.env }}
 - name: {{ $key }}
   value: {{ $val | quote }}
+{{- end }}
+{{- range $key, $val := .Values.teamsAppSettings.secretEnv }}
+- name: {{ $key }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $val.secretName }}
+      key: {{ $val.secretKey }}
 {{- end }}
 {{- end -}}

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -26,7 +26,7 @@ apiSettings:
 
   # -- Secret variables to be passed to the teams-api containers.
   secretEnv: {}
-  # ENV_VAR_NAME:
+  #   ENV_VAR_NAME:
   #     secretName: the-pre-existing-secret
   #     secretKey: the-key-in-the-secret
 

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -144,7 +144,7 @@ appSettings:
 
   # -- Secret variables to be passed to the fiftyone-app containers.
   secretEnv: {}
-  # ENV_VAR_NAME:
+  #   ENV_VAR_NAME:
   #     secretName: the-pre-existing-secret
   #     secretKey: the-key-in-the-secret
 
@@ -255,7 +255,7 @@ casSettings:
 
   # -- Secret variables to be passed to the teams-cas containers.
   secretEnv: {}
-  # ENV_VAR_NAME:
+  #   ENV_VAR_NAME:
   #     secretName: the-pre-existing-secret
   #     secretKey: the-key-in-the-secret
 
@@ -360,7 +360,7 @@ delegatedOperatorExecutorSettings:
 
   # -- Secret variables to be passed to the delegated-operator-executor containers.
   secretEnv: {}
-  # ENV_VAR_NAME:
+  #   ENV_VAR_NAME:
   #     secretName: the-pre-existing-secret
   #     secretKey: the-key-in-the-secret
 
@@ -528,7 +528,7 @@ pluginsSettings:
 
   # -- Secret variables to be passed to the teams-plugins containers.
   secretEnv: {}
-  # ENV_VAR_NAME:
+  #   ENV_VAR_NAME:
   #     secretName: the-pre-existing-secret
   #     secretKey: the-key-in-the-secret
 
@@ -692,7 +692,7 @@ teamsAppSettings:
 
   # -- Secret variables to be passed to the teams-app containers.
   secretEnv: {}
-  # ENV_VAR_NAME:
+  #   ENV_VAR_NAME:
   #     secretName: the-pre-existing-secret
   #     secretKey: the-key-in-the-secret
 

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -23,6 +23,13 @@ apiSettings:
     # -- Logging level. Overrides the value of `FIFTYONE_ENV`.
     # Can be one of "DEBUG", "INFO", "WARN", "ERROR", or "CRITICAL".
     LOGGING_LEVEL: INFO
+
+  # -- Secret variables to be passed to the teams-api containers.
+  secretEnv: {}
+  # ENV_VAR_NAME:
+  #     secretName: the-pre-existing-secret
+  #     secretKey: the-key-in-the-secret
+
   image:
     # -- Instruct when the kubelet should pull (download) the specified image.
     # One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy].
@@ -134,6 +141,13 @@ appSettings:
     # AWS_CONFIG_FILE=/opt/secrets/aws/aws-credentials-file
     # GOOGLE_APPLICATION_CREDENTIALS=/opt/secrets/google/service-account
     # MINIO_CONFIG_FILE=/opt/secrets/minio/minio-credentials-file
+
+  # -- Secret variables to be passed to the fiftyone-app containers.
+  secretEnv: {}
+  # ENV_VAR_NAME:
+  #     secretName: the-pre-existing-secret
+  #     secretKey: the-key-in-the-secret
+
   image:
     # -- Instruct when the kubelet should pull (download) the specified image.
     # One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy].
@@ -238,6 +252,13 @@ casSettings:
     # -- Configure Authentication Mode.
     # One of `legacy` or `internal`
     FIFTYONE_AUTH_MODE: legacy
+
+  # -- Secret variables to be passed to the teams-cas containers.
+  secretEnv: {}
+  # ENV_VAR_NAME:
+  #     secretName: the-pre-existing-secret
+  #     secretKey: the-key-in-the-secret
+
   image:
     # -- Instruct when the kubelet should pull (download) the specified image.
     # One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy].
@@ -336,6 +357,13 @@ delegatedOperatorExecutorSettings:
     # -- Whether the SDK is running in an internal service context.
     # When running in FiftyOne Teams, set to `true`.
     FIFTYONE_INTERNAL_SERVICE: true
+
+  # -- Secret variables to be passed to the delegated-operator-executor containers.
+  secretEnv: {}
+  # ENV_VAR_NAME:
+  #     secretName: the-pre-existing-secret
+  #     secretKey: the-key-in-the-secret
+
   image:
     # -- Instruct when the kubelet should pull (download) the specified image.
     # One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy].
@@ -497,6 +525,13 @@ pluginsSettings:
     # -- Whether the SDK is running in an internal service context.
     # When running in FiftyOne Teams, set to `true`.
     FIFTYONE_INTERNAL_SERVICE: true
+
+  # -- Secret variables to be passed to the teams-plugins containers.
+  secretEnv: {}
+  # ENV_VAR_NAME:
+  #     secretName: the-pre-existing-secret
+  #     secretKey: the-key-in-the-secret
+
   image:
     # -- Instruct when the kubelet should pull (download) the specified image.
     # One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy].
@@ -654,6 +689,13 @@ teamsAppSettings:
     # -- Controls whether Query Performance mode is enabled for the teams
     # application. Set to false to disable Query Performance mode for entire application.
     FIFTYONE_APP_ENABLE_QUERY_PERFORMANCE: true
+
+  # -- Secret variables to be passed to the teams-app containers.
+  secretEnv: {}
+  # ENV_VAR_NAME:
+  #     secretName: the-pre-existing-secret
+  #     secretKey: the-key-in-the-secret
+
   image:
     # -- Instruct when the kubelet should pull (download) the specified image.
     # One of `IfNotPresent`, `Always` or `Never`. Reference][image-pull-policy].

--- a/tests/integration/helm/helm-internal-auth_test.go
+++ b/tests/integration/helm/helm-internal-auth_test.go
@@ -56,12 +56,21 @@ func (s *internalAuthHelmTest) TestHelmInstall() {
 		values   map[string]string
 		expected []serviceValidations
 	}{
+		// The secretEnv values don't matter, just that they mount as expected
 		{
 			"builtinPlugins",
 			map[string]string{
-				"casSettings.env.FIFTYONE_AUTH_MODE":   "internal",
-				"casSettings.env.CAS_DATABASE_NAME":    "cas-int-bp-" + suffix,
-				"secret.fiftyone.fiftyoneDatabaseName": "fiftyone-int-bp-" + suffix,
+				"apiSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName":      "fiftyone-teams-secrets", // pragma: allowlist secret
+				"apiSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":       "cookieSecret",           // pragma: allowlist secret
+				"appSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName":      "fiftyone-teams-secrets", // pragma: allowlist secret
+				"appSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":       "cookieSecret",           // pragma: allowlist secret
+				"casSettings.env.FIFTYONE_AUTH_MODE":                             "internal",
+				"casSettings.env.CAS_DATABASE_NAME":                              "cas-int-bp-" + suffix,
+				"casSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName":      "fiftyone-teams-secrets", // pragma: allowlist secret
+				"casSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":       "cookieSecret",           // pragma: allowlist secret
+				"secret.fiftyone.fiftyoneDatabaseName":                           "fiftyone-int-bp-" + suffix,
+				"teamsAppSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName": "fiftyone-teams-secrets", // pragma: allowlist secret
+				"teamsAppSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":  "cookieSecret",           // pragma: allowlist secret
 			},
 			[]serviceValidations{
 				// ordering first, because teams-api startup connects to teams-cas
@@ -99,28 +108,38 @@ func (s *internalAuthHelmTest) TestHelmInstall() {
 		{
 			"sharedPlugins", // plugins run in fiftyone-app deployment
 			map[string]string{
-				"apiSettings.env.FIFTYONE_PLUGINS_DIR":                                         "/opt/plugins",
-				"apiSettings.volumes[0].name":                                                  "plugins-vol",
-				"apiSettings.volumes[0].persistentVolumeClaim.claimName":                       "pvc-int-sp-" + suffix,
-				"apiSettings.volumeMounts[0].name":                                             "plugins-vol",
-				"apiSettings.volumeMounts[0].mountPath":                                        "/opt/plugins",
-				"appSettings.env.FIFTYONE_PLUGINS_DIR":                                         "/opt/plugins",
-				"appSettings.volumes[0].name":                                                  "plugins-vol-ro",
-				"appSettings.volumes[0].persistentVolumeClaim.claimName":                       "pvc-int-sp-" + suffix,
-				"appSettings.volumes[0].persistentVolumeClaim.readOnly":                        "true",
-				"appSettings.volumeMounts[0].name":                                             "plugins-vol-ro",
-				"appSettings.volumeMounts[0].mountPath":                                        "/opt/plugins",
-				"casSettings.env.FIFTYONE_AUTH_MODE":                                           "internal",
-				"casSettings.env.CAS_DATABASE_NAME":                                            "cas-int-sp-" + suffix,
-				"delegatedOperatorExecutorSettings.enabled":                                    "true",
-				"delegatedOperatorExecutorSettings.env.FIFTYONE_PLUGINS_DIR":                   "/opt/plugins",
-				"delegatedOperatorExecutorSettings.replicaCount":                               "1",
-				"delegatedOperatorExecutorSettings.volumeMounts[0].mountPath":                  "/opt/plugins",
-				"delegatedOperatorExecutorSettings.volumeMounts[0].name":                       "plugins-vol-ro",
-				"delegatedOperatorExecutorSettings.volumes[0].name":                            "plugins-vol-ro",
-				"delegatedOperatorExecutorSettings.volumes[0].persistentVolumeClaim.claimName": "pvc-int-sp-" + suffix,
-				"delegatedOperatorExecutorSettings.volumes[0].persistentVolumeClaim.readOnly":  "true",
-				"secret.fiftyone.fiftyoneDatabaseName":                                         "fiftyone-int-sp-" + suffix,
+				"apiSettings.env.FIFTYONE_PLUGINS_DIR":                                            "/opt/plugins",
+				"apiSettings.volumes[0].name":                                                     "plugins-vol",
+				"apiSettings.volumes[0].persistentVolumeClaim.claimName":                          "pvc-int-sp-" + suffix,
+				"apiSettings.volumeMounts[0].name":                                                "plugins-vol",
+				"apiSettings.volumeMounts[0].mountPath":                                           "/opt/plugins",
+				"apiSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName":                       "fiftyone-teams-secrets", // pragma: allowlist secret
+				"apiSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":                        "cookieSecret",           // pragma: allowlist secret
+				"appSettings.env.FIFTYONE_PLUGINS_DIR":                                            "/opt/plugins",
+				"appSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName":                       "fiftyone-teams-secrets", // pragma: allowlist secret
+				"appSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":                        "cookieSecret",           // pragma: allowlist secret
+				"appSettings.volumes[0].name":                                                     "plugins-vol-ro",
+				"appSettings.volumes[0].persistentVolumeClaim.claimName":                          "pvc-int-sp-" + suffix,
+				"appSettings.volumes[0].persistentVolumeClaim.readOnly":                           "true",
+				"appSettings.volumeMounts[0].name":                                                "plugins-vol-ro",
+				"appSettings.volumeMounts[0].mountPath":                                           "/opt/plugins",
+				"casSettings.env.FIFTYONE_AUTH_MODE":                                              "internal",
+				"casSettings.env.CAS_DATABASE_NAME":                                               "cas-int-sp-" + suffix,
+				"casSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName":                       "fiftyone-teams-secrets", // pragma: allowlist secret
+				"casSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":                        "cookieSecret",           // pragma: allowlist secret
+				"delegatedOperatorExecutorSettings.enabled":                                       "true",
+				"delegatedOperatorExecutorSettings.env.FIFTYONE_PLUGINS_DIR":                      "/opt/plugins",
+				"delegatedOperatorExecutorSettings.replicaCount":                                  "1",
+				"delegatedOperatorExecutorSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName": "fiftyone-teams-secrets", // pragma: allowlist secret
+				"delegatedOperatorExecutorSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":  "cookieSecret",           // pragma: allowlist secret
+				"delegatedOperatorExecutorSettings.volumeMounts[0].mountPath":                     "/opt/plugins",
+				"delegatedOperatorExecutorSettings.volumeMounts[0].name":                          "plugins-vol-ro",
+				"delegatedOperatorExecutorSettings.volumes[0].name":                               "plugins-vol-ro",
+				"delegatedOperatorExecutorSettings.volumes[0].persistentVolumeClaim.claimName":    "pvc-int-sp-" + suffix,
+				"delegatedOperatorExecutorSettings.volumes[0].persistentVolumeClaim.readOnly":     "true",
+				"secret.fiftyone.fiftyoneDatabaseName":                                            "fiftyone-int-sp-" + suffix,
+				"teamsAppSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName":                  "fiftyone-teams-secrets", // pragma: allowlist secret
+				"teamsAppSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":                   "cookieSecret",           // pragma: allowlist secret
 			},
 			/* Why the ternary? This is a first iteration against a live kube
 			 * cluster. We don't have things like wildcard certificates,
@@ -174,29 +193,41 @@ func (s *internalAuthHelmTest) TestHelmInstall() {
 		{
 			"dedicatedPlugins", // plugins run in plugins deployment
 			map[string]string{
-				"apiSettings.env.FIFTYONE_PLUGINS_DIR":                                         "/opt/plugins",
-				"apiSettings.volumes[0].name":                                                  "plugins-vol",
-				"apiSettings.volumes[0].persistentVolumeClaim.claimName":                       "pvc-int-dp-" + suffix,
-				"apiSettings.volumeMounts[0].name":                                             "plugins-vol",
-				"apiSettings.volumeMounts[0].mountPath":                                        "/opt/plugins",
-				"casSettings.env.FIFTYONE_AUTH_MODE":                                           "internal",
-				"casSettings.env.CAS_DATABASE_NAME":                                            "cas-int-dp-" + suffix,
-				"delegatedOperatorExecutorSettings.enabled":                                    "true",
-				"delegatedOperatorExecutorSettings.env.FIFTYONE_PLUGINS_DIR":                   "/opt/plugins",
-				"delegatedOperatorExecutorSettings.replicaCount":                               "1",
-				"delegatedOperatorExecutorSettings.volumeMounts[0].mountPath":                  "/opt/plugins",
-				"delegatedOperatorExecutorSettings.volumeMounts[0].name":                       "plugins-vol-ro",
-				"delegatedOperatorExecutorSettings.volumes[0].name":                            "plugins-vol-ro",
-				"delegatedOperatorExecutorSettings.volumes[0].persistentVolumeClaim.claimName": "pvc-int-dp-" + suffix,
-				"delegatedOperatorExecutorSettings.volumes[0].persistentVolumeClaim.readOnly":  "true",
-				"pluginsSettings.enabled":                                                      "true",
-				"pluginsSettings.env.FIFTYONE_PLUGINS_DIR":                                     "/opt/plugins",
-				"pluginsSettings.volumes[0].name":                                              "plugins-vol-ro",
-				"pluginsSettings.volumes[0].persistentVolumeClaim.claimName":                   "pvc-int-dp-" + suffix,
-				"pluginsSettings.volumes[0].persistentVolumeClaim.readOnly":                    "true",
-				"pluginsSettings.volumeMounts[0].name":                                         "plugins-vol-ro",
-				"pluginsSettings.volumeMounts[0].mountPath":                                    "/opt/plugins",
-				"secret.fiftyone.fiftyoneDatabaseName":                                         "fiftyone-int-dp-" + suffix,
+				"apiSettings.env.FIFTYONE_PLUGINS_DIR":                                            "/opt/plugins",
+				"apiSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName":                       "fiftyone-teams-secrets", // pragma: allowlist secret
+				"apiSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":                        "cookieSecret",           // pragma: allowlist secret
+				"apiSettings.volumes[0].name":                                                     "plugins-vol",
+				"apiSettings.volumes[0].persistentVolumeClaim.claimName":                          "pvc-int-dp-" + suffix,
+				"apiSettings.volumeMounts[0].name":                                                "plugins-vol",
+				"apiSettings.volumeMounts[0].mountPath":                                           "/opt/plugins",
+				"appSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName":                       "fiftyone-teams-secrets", // pragma: allowlist secret
+				"appSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":                        "cookieSecret",           // pragma: allowlist secret
+				"casSettings.env.FIFTYONE_AUTH_MODE":                                              "internal",
+				"casSettings.env.CAS_DATABASE_NAME":                                               "cas-int-dp-" + suffix,
+				"casSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName":                       "fiftyone-teams-secrets", // pragma: allowlist secret
+				"casSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":                        "cookieSecret",           // pragma: allowlist secret
+				"delegatedOperatorExecutorSettings.enabled":                                       "true",
+				"delegatedOperatorExecutorSettings.env.FIFTYONE_PLUGINS_DIR":                      "/opt/plugins",
+				"delegatedOperatorExecutorSettings.replicaCount":                                  "1",
+				"delegatedOperatorExecutorSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName": "fiftyone-teams-secrets", // pragma: allowlist secret
+				"delegatedOperatorExecutorSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":  "cookieSecret",           // pragma: allowlist secret
+				"delegatedOperatorExecutorSettings.volumeMounts[0].mountPath":                     "/opt/plugins",
+				"delegatedOperatorExecutorSettings.volumeMounts[0].name":                          "plugins-vol-ro",
+				"delegatedOperatorExecutorSettings.volumes[0].name":                               "plugins-vol-ro",
+				"delegatedOperatorExecutorSettings.volumes[0].persistentVolumeClaim.claimName":    "pvc-int-dp-" + suffix,
+				"delegatedOperatorExecutorSettings.volumes[0].persistentVolumeClaim.readOnly":     "true",
+				"pluginsSettings.enabled":                                                         "true",
+				"pluginsSettings.env.FIFTYONE_PLUGINS_DIR":                                        "/opt/plugins",
+				"pluginsSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName":                   "fiftyone-teams-secrets", // pragma: allowlist secret
+				"pluginsSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":                    "cookieSecret",           // pragma: allowlist secret
+				"pluginsSettings.volumes[0].name":                                                 "plugins-vol-ro",
+				"pluginsSettings.volumes[0].persistentVolumeClaim.claimName":                      "pvc-int-dp-" + suffix,
+				"pluginsSettings.volumes[0].persistentVolumeClaim.readOnly":                       "true",
+				"pluginsSettings.volumeMounts[0].name":                                            "plugins-vol-ro",
+				"pluginsSettings.volumeMounts[0].mountPath":                                       "/opt/plugins",
+				"secret.fiftyone.fiftyoneDatabaseName":                                            "fiftyone-int-dp-" + suffix,
+				"teamsAppSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName":                  "fiftyone-teams-secrets", // pragma: allowlist secret
+				"teamsAppSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":                   "cookieSecret",           // pragma: allowlist secret
 			},
 			[]serviceValidations{
 				// ordering teams-cas first, because teams-api startup connects to teams-cas

--- a/tests/integration/helm/helm-legacy-auth_test.go
+++ b/tests/integration/helm/helm-legacy-auth_test.go
@@ -58,9 +58,17 @@ func (s *legacyAuthHelmTest) TestHelmInstall() {
 		{
 			"builtinPlugins",
 			map[string]string{
-				"casSettings.env.FIFTYONE_AUTH_MODE":   "legacy",
-				"casSettings.env.CAS_DATABASE_NAME":    "cas-leg-bp-" + suffix,
-				"secret.fiftyone.fiftyoneDatabaseName": "fiftyone-leg-bp-" + suffix,
+				"apiSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName":      "fiftyone-teams-secrets", // pragma: allowlist secret
+				"apiSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":       "cookieSecret",           // pragma: allowlist secret
+				"appSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName":      "fiftyone-teams-secrets", // pragma: allowlist secret
+				"appSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":       "cookieSecret",           // pragma: allowlist secret
+				"casSettings.env.FIFTYONE_AUTH_MODE":                             "legacy",
+				"casSettings.env.CAS_DATABASE_NAME":                              "cas-leg-bp-" + suffix,
+				"casSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName":      "fiftyone-teams-secrets", // pragma: allowlist secret
+				"casSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":       "cookieSecret",           // pragma: allowlist secret
+				"secret.fiftyone.fiftyoneDatabaseName":                           "fiftyone-leg-bp-" + suffix,
+				"teamsAppSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName": "fiftyone-teams-secrets", // pragma: allowlist secret
+				"teamsAppSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":  "cookieSecret",           // pragma: allowlist secret
 			},
 			/* Why the ternary? This is a first iteration against a live kube
 			 * cluster. We don't have things like wildcard certificates,
@@ -106,28 +114,38 @@ func (s *legacyAuthHelmTest) TestHelmInstall() {
 		{
 			"sharedPlugins", // plugins run in fiftyone-app deployment
 			map[string]string{
-				"apiSettings.env.FIFTYONE_PLUGINS_DIR":                                         "/opt/plugins",
-				"apiSettings.volumes[0].name":                                                  "plugins-vol",
-				"apiSettings.volumes[0].persistentVolumeClaim.claimName":                       "pvc-leg-sp-" + suffix,
-				"apiSettings.volumeMounts[0].name":                                             "plugins-vol",
-				"apiSettings.volumeMounts[0].mountPath":                                        "/opt/plugins",
-				"appSettings.env.FIFTYONE_PLUGINS_DIR":                                         "/opt/plugins",
-				"appSettings.volumes[0].name":                                                  "plugins-vol-ro",
-				"appSettings.volumes[0].persistentVolumeClaim.claimName":                       "pvc-leg-sp-" + suffix,
-				"appSettings.volumes[0].persistentVolumeClaim.readOnly":                        "true",
-				"appSettings.volumeMounts[0].name":                                             "plugins-vol-ro",
-				"appSettings.volumeMounts[0].mountPath":                                        "/opt/plugins",
-				"casSettings.env.FIFTYONE_AUTH_MODE":                                           "legacy",
-				"casSettings.env.CAS_DATABASE_NAME":                                            "cas-leg-sp-" + suffix,
-				"delegatedOperatorExecutorSettings.enabled":                                    "true",
-				"delegatedOperatorExecutorSettings.env.FIFTYONE_PLUGINS_DIR":                   "/opt/plugins",
-				"delegatedOperatorExecutorSettings.replicaCount":                               "1",
-				"delegatedOperatorExecutorSettings.volumeMounts[0].mountPath":                  "/opt/plugins",
-				"delegatedOperatorExecutorSettings.volumeMounts[0].name":                       "plugins-vol-ro",
-				"delegatedOperatorExecutorSettings.volumes[0].name":                            "plugins-vol-ro",
-				"delegatedOperatorExecutorSettings.volumes[0].persistentVolumeClaim.claimName": "pvc-leg-sp-" + suffix,
-				"delegatedOperatorExecutorSettings.volumes[0].persistentVolumeClaim.readOnly":  "true",
-				"secret.fiftyone.fiftyoneDatabaseName":                                         "fiftyone-leg-sp-" + suffix,
+				"apiSettings.env.FIFTYONE_PLUGINS_DIR":                                            "/opt/plugins",
+				"apiSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName":                       "fiftyone-teams-secrets", // pragma: allowlist secret
+				"apiSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":                        "cookieSecret",           // pragma: allowlist secret
+				"apiSettings.volumes[0].name":                                                     "plugins-vol",
+				"apiSettings.volumes[0].persistentVolumeClaim.claimName":                          "pvc-leg-sp-" + suffix,
+				"apiSettings.volumeMounts[0].name":                                                "plugins-vol",
+				"apiSettings.volumeMounts[0].mountPath":                                           "/opt/plugins",
+				"appSettings.env.FIFTYONE_PLUGINS_DIR":                                            "/opt/plugins",
+				"appSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName":                       "fiftyone-teams-secrets", // pragma: allowlist secret
+				"appSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":                        "cookieSecret",           // pragma: allowlist secret
+				"appSettings.volumes[0].name":                                                     "plugins-vol-ro",
+				"appSettings.volumes[0].persistentVolumeClaim.claimName":                          "pvc-leg-sp-" + suffix,
+				"appSettings.volumes[0].persistentVolumeClaim.readOnly":                           "true",
+				"appSettings.volumeMounts[0].name":                                                "plugins-vol-ro",
+				"appSettings.volumeMounts[0].mountPath":                                           "/opt/plugins",
+				"casSettings.env.FIFTYONE_AUTH_MODE":                                              "legacy",
+				"casSettings.env.CAS_DATABASE_NAME":                                               "cas-leg-sp-" + suffix,
+				"casSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName":                       "fiftyone-teams-secrets", // pragma: allowlist secret
+				"casSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":                        "cookieSecret",           // pragma: allowlist secret
+				"delegatedOperatorExecutorSettings.enabled":                                       "true",
+				"delegatedOperatorExecutorSettings.env.FIFTYONE_PLUGINS_DIR":                      "/opt/plugins",
+				"delegatedOperatorExecutorSettings.replicaCount":                                  "1",
+				"delegatedOperatorExecutorSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName": "fiftyone-teams-secrets", // pragma: allowlist secret
+				"delegatedOperatorExecutorSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":  "cookieSecret",           // pragma: allowlist secret
+				"delegatedOperatorExecutorSettings.volumeMounts[0].mountPath":                     "/opt/plugins",
+				"delegatedOperatorExecutorSettings.volumeMounts[0].name":                          "plugins-vol-ro",
+				"delegatedOperatorExecutorSettings.volumes[0].name":                               "plugins-vol-ro",
+				"delegatedOperatorExecutorSettings.volumes[0].persistentVolumeClaim.claimName":    "pvc-leg-sp-" + suffix,
+				"delegatedOperatorExecutorSettings.volumes[0].persistentVolumeClaim.readOnly":     "true",
+				"secret.fiftyone.fiftyoneDatabaseName":                                            "fiftyone-leg-sp-" + suffix,
+				"teamsAppSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName":                  "fiftyone-teams-secrets", // pragma: allowlist secret
+				"teamsAppSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":                   "cookieSecret",           // pragma: allowlist secret
 			},
 			[]serviceValidations{
 				{
@@ -171,29 +189,41 @@ func (s *legacyAuthHelmTest) TestHelmInstall() {
 		{
 			"dedicatedPlugins", // plugins run in plugins deployment
 			map[string]string{
-				"apiSettings.env.FIFTYONE_PLUGINS_DIR":                                         "/opt/plugins",
-				"apiSettings.volumes[0].name":                                                  "plugins-vol",
-				"apiSettings.volumes[0].persistentVolumeClaim.claimName":                       "pv-fiftyone-leg-dp-" + suffix,
-				"apiSettings.volumeMounts[0].name":                                             "plugins-vol",
-				"apiSettings.volumeMounts[0].mountPath":                                        "/opt/plugins",
-				"casSettings.env.FIFTYONE_AUTH_MODE":                                           "legacy",
-				"casSettings.env.CAS_DATABASE_NAME":                                            "cas-leg-dp-" + suffix,
-				"delegatedOperatorExecutorSettings.enabled":                                    "true",
-				"delegatedOperatorExecutorSettings.env.FIFTYONE_PLUGINS_DIR":                   "/opt/plugins",
-				"delegatedOperatorExecutorSettings.replicaCount":                               "1",
-				"delegatedOperatorExecutorSettings.volumeMounts[0].mountPath":                  "/opt/plugins",
-				"delegatedOperatorExecutorSettings.volumeMounts[0].name":                       "plugins-vol-ro",
-				"delegatedOperatorExecutorSettings.volumes[0].name":                            "plugins-vol-ro",
-				"delegatedOperatorExecutorSettings.volumes[0].persistentVolumeClaim.claimName": "pv-fiftyone-leg-dp-" + suffix,
-				"delegatedOperatorExecutorSettings.volumes[0].persistentVolumeClaim.readOnly":  "true",
-				"pluginsSettings.enabled":                                                      "true",
-				"pluginsSettings.env.FIFTYONE_PLUGINS_DIR":                                     "/opt/plugins",
-				"pluginsSettings.volumes[0].name":                                              "plugins-vol-ro",
-				"pluginsSettings.volumes[0].persistentVolumeClaim.claimName":                   "pv-fiftyone-leg-dp-" + suffix,
-				"pluginsSettings.volumes[0].persistentVolumeClaim.readOnly":                    "true",
-				"pluginsSettings.volumeMounts[0].name":                                         "plugins-vol-ro",
-				"pluginsSettings.volumeMounts[0].mountPath":                                    "/opt/plugins",
-				"secret.fiftyone.fiftyoneDatabaseName":                                         "fiftyone-leg-dp-" + suffix,
+				"apiSettings.env.FIFTYONE_PLUGINS_DIR":                                            "/opt/plugins",
+				"apiSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName":                       "fiftyone-teams-secrets", // pragma: allowlist secret
+				"apiSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":                        "cookieSecret",           // pragma: allowlist secret
+				"apiSettings.volumes[0].name":                                                     "plugins-vol",
+				"apiSettings.volumes[0].persistentVolumeClaim.claimName":                          "pv-fiftyone-leg-dp-" + suffix,
+				"apiSettings.volumeMounts[0].name":                                                "plugins-vol",
+				"apiSettings.volumeMounts[0].mountPath":                                           "/opt/plugins",
+				"appSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName":                       "fiftyone-teams-secrets", // pragma: allowlist secret
+				"appSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":                        "cookieSecret",           // pragma: allowlist secret
+				"casSettings.env.FIFTYONE_AUTH_MODE":                                              "legacy",
+				"casSettings.env.CAS_DATABASE_NAME":                                               "cas-leg-dp-" + suffix,
+				"casSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName":                       "fiftyone-teams-secrets", // pragma: allowlist secret
+				"casSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":                        "cookieSecret",           // pragma: allowlist secret
+				"delegatedOperatorExecutorSettings.enabled":                                       "true",
+				"delegatedOperatorExecutorSettings.env.FIFTYONE_PLUGINS_DIR":                      "/opt/plugins",
+				"delegatedOperatorExecutorSettings.replicaCount":                                  "1",
+				"delegatedOperatorExecutorSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName": "fiftyone-teams-secrets", // pragma: allowlist secret
+				"delegatedOperatorExecutorSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":  "cookieSecret",           // pragma: allowlist secret
+				"delegatedOperatorExecutorSettings.volumeMounts[0].mountPath":                     "/opt/plugins",
+				"delegatedOperatorExecutorSettings.volumeMounts[0].name":                          "plugins-vol-ro",
+				"delegatedOperatorExecutorSettings.volumes[0].name":                               "plugins-vol-ro",
+				"delegatedOperatorExecutorSettings.volumes[0].persistentVolumeClaim.claimName":    "pv-fiftyone-leg-dp-" + suffix,
+				"delegatedOperatorExecutorSettings.volumes[0].persistentVolumeClaim.readOnly":     "true",
+				"pluginsSettings.enabled":                                                         "true",
+				"pluginsSettings.env.FIFTYONE_PLUGINS_DIR":                                        "/opt/plugins",
+				"pluginsSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName":                   "fiftyone-teams-secrets", // pragma: allowlist secret
+				"pluginsSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":                    "cookieSecret",           // pragma: allowlist secret
+				"pluginsSettings.volumes[0].name":                                                 "plugins-vol-ro",
+				"pluginsSettings.volumes[0].persistentVolumeClaim.claimName":                      "pv-fiftyone-leg-dp-" + suffix,
+				"pluginsSettings.volumeås[0].persistentVolumeClaim.readOnly":                      "true",
+				"pluginsSettings.volumeMounts[0].name":                                            "plugins-vol-ro",
+				"pluginsSettings.volumeMounts[0].mountPath":                                       "/opt/plugins",
+				"secret.fiftyone.fiftyoneDatabaseName":                                            "fiftyone-leg-dp-" + suffix,
+				"teamsAppSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName":                  "fiftyone-teams-secrets", // pragma: allowlist secret
+				"teamsAppSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":                   "cookieSecret",           // pragma: allowlist secret
 			},
 			[]serviceValidations{
 				{

--- a/tests/unit/helm/api-deployment_test.go
+++ b/tests/unit/helm/api-deployment_test.go
@@ -493,7 +493,9 @@ func (s *deploymentApiTemplateTest) TestContainerEnv() {
 		{
 			"overrideEnv", // legacy auth mode
 			map[string]string{
-				"apiSettings.env.TEST_KEY": "TEST_VALUE",
+				"apiSettings.env.TEST_KEY":                                  "TEST_VALUE",
+				"apiSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName": "an-existing-secret", // pragma: allowlist secret
+				"apiSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":  "anExistingKey",      // pragma: allowlist secret
 			},
 			func(envVars []corev1.EnvVar) {
 				expectedEnvVarJSON := `[
@@ -565,6 +567,15 @@ func (s *deploymentApiTemplateTest) TestContainerEnv() {
           {
             "name": "TEST_KEY",
             "value": "TEST_VALUE"
+          },
+          {
+            "name": "AN_ADDITIONAL_SECRET_ENV",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "an-existing-secret",
+                "key": "anExistingKey"
+              }
+            }
           }
         ]`
 				var expectedEnvVars []corev1.EnvVar
@@ -576,8 +587,10 @@ func (s *deploymentApiTemplateTest) TestContainerEnv() {
 		{
 			"internalAuthMode",
 			map[string]string{
-				"casSettings.env.FIFTYONE_AUTH_MODE": "internal",
-				"apiSettings.env.TEST_KEY":           "TEST_VALUE",
+				"casSettings.env.FIFTYONE_AUTH_MODE":                        "internal",
+				"apiSettings.env.TEST_KEY":                                  "TEST_VALUE",
+				"apiSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName": "an-existing-secret", // pragma: allowlist secret
+				"apiSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":  "anExistingKey",      // pragma: allowlist secret
 			},
 			func(envVars []corev1.EnvVar) {
 				expectedEnvVarJSON := `[
@@ -649,6 +662,15 @@ func (s *deploymentApiTemplateTest) TestContainerEnv() {
           {
             "name": "TEST_KEY",
             "value": "TEST_VALUE"
+          },
+          {
+            "name": "AN_ADDITIONAL_SECRET_ENV",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "an-existing-secret",
+                "key": "anExistingKey"
+              }
+            }
           }
         ]`
 				var expectedEnvVars []corev1.EnvVar

--- a/tests/unit/helm/app-deployment_test.go
+++ b/tests/unit/helm/app-deployment_test.go
@@ -493,7 +493,9 @@ func (s *deploymentAppTemplateTest) TestContainerEnv() {
 		{
 			"overrideEnv", // legacy auth mode
 			map[string]string{
-				"appSettings.env.TEST_KEY": "TEST_VALUE",
+				"appSettings.env.TEST_KEY":                                  "TEST_VALUE",
+				"appSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName": "an-existing-secret", // pragma: allowlist secret
+				"appSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":  "anExistingKey",      // pragma: allowlist secret
 			},
 			func(envVars []corev1.EnvVar) {
 				expectedEnvVarJSON := `[
@@ -560,6 +562,15 @@ func (s *deploymentAppTemplateTest) TestContainerEnv() {
           {
             "name": "TEST_KEY",
             "value": "TEST_VALUE"
+          },
+          {
+            "name": "AN_ADDITIONAL_SECRET_ENV",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "an-existing-secret",
+                "key": "anExistingKey"
+              }
+            }
           }
         ]`
 				var expectedEnvVars []corev1.EnvVar
@@ -571,8 +582,10 @@ func (s *deploymentAppTemplateTest) TestContainerEnv() {
 		{
 			"internalAuthMode",
 			map[string]string{
-				"casSettings.env.FIFTYONE_AUTH_MODE": "internal",
-				"appSettings.env.TEST_KEY":           "TEST_VALUE",
+				"casSettings.env.FIFTYONE_AUTH_MODE":                        "internal",
+				"appSettings.env.TEST_KEY":                                  "TEST_VALUE",
+				"appSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName": "an-existing-secret", // pragma: allowlist secret
+				"appSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":  "anExistingKey",      // pragma: allowlist secret
 			},
 			func(envVars []corev1.EnvVar) {
 				expectedEnvVarJSON := `[
@@ -639,6 +652,15 @@ func (s *deploymentAppTemplateTest) TestContainerEnv() {
           {
             "name": "TEST_KEY",
             "value": "TEST_VALUE"
+          },
+          {
+            "name": "AN_ADDITIONAL_SECRET_ENV",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "an-existing-secret",
+                "key": "anExistingKey"
+              }
+            }
           }
         ]`
 				var expectedEnvVars []corev1.EnvVar

--- a/tests/unit/helm/cas-deployment_test.go
+++ b/tests/unit/helm/cas-deployment_test.go
@@ -510,7 +510,9 @@ func (s *deploymentCasTemplateTest) TestContainerEnv() {
 		{
 			"overrideEnv", // legacy auth mode
 			map[string]string{
-				"casSettings.env.TEST_KEY": "TEST_VALUE",
+				"casSettings.env.TEST_KEY":                                  "TEST_VALUE",
+				"casSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName": "an-existing-secret", // pragma: allowlist secret
+				"casSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":  "anExistingKey",      // pragma: allowlist secret
 			},
 			func(envVars []corev1.EnvVar) {
 				expectedEnvVarJSON := `[
@@ -594,6 +596,15 @@ func (s *deploymentCasTemplateTest) TestContainerEnv() {
           {
             "name": "TEST_KEY",
             "value": "TEST_VALUE"
+          },
+          {
+            "name": "AN_ADDITIONAL_SECRET_ENV",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "an-existing-secret",
+                "key": "anExistingKey"
+              }
+            }
           }
         ]`
 				var expectedEnvVars []corev1.EnvVar
@@ -605,8 +616,10 @@ func (s *deploymentCasTemplateTest) TestContainerEnv() {
 		{
 			"internalAuthMode",
 			map[string]string{
-				"casSettings.env.FIFTYONE_AUTH_MODE": "internal",
-				"casSettings.env.TEST_KEY":           "TEST_VALUE",
+				"casSettings.env.FIFTYONE_AUTH_MODE":                        "internal",
+				"casSettings.env.TEST_KEY":                                  "TEST_VALUE",
+				"casSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName": "an-existing-secret", // pragma: allowlist secret
+				"casSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":  "anExistingKey",      // pragma: allowlist secret
 			},
 			func(envVars []corev1.EnvVar) {
 				expectedEnvVarJSON := `[
@@ -690,6 +703,15 @@ func (s *deploymentCasTemplateTest) TestContainerEnv() {
           {
             "name": "TEST_KEY",
             "value": "TEST_VALUE"
+          },
+          {
+            "name": "AN_ADDITIONAL_SECRET_ENV",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "an-existing-secret",
+                "key": "anExistingKey"
+              }
+            }
           }
         ]`
 				var expectedEnvVars []corev1.EnvVar

--- a/tests/unit/helm/delegated-operator-executor-deployment_test.go
+++ b/tests/unit/helm/delegated-operator-executor-deployment_test.go
@@ -422,8 +422,10 @@ func (s *deploymentDelegatedOperatorExecutorTemplateTest) TestContainerEnv() {
 		{
 			"overrideEnv",
 			map[string]string{
-				"delegatedOperatorExecutorSettings.enabled":      "true",
-				"delegatedOperatorExecutorSettings.env.TEST_KEY": "TEST_VALUE",
+				"delegatedOperatorExecutorSettings.enabled":                                       "true",
+				"delegatedOperatorExecutorSettings.env.TEST_KEY":                                  "TEST_VALUE",
+				"delegatedOperatorExecutorSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName": "an-existing-secret", // pragma: allowlist secret
+				"delegatedOperatorExecutorSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":  "anExistingKey",      // pragma: allowlist secret
 			},
 			func(envVars []corev1.EnvVar) {
 				expectedEnvVarJSON := `[
@@ -477,6 +479,15 @@ func (s *deploymentDelegatedOperatorExecutorTemplateTest) TestContainerEnv() {
           {
             "name": "TEST_KEY",
             "value": "TEST_VALUE"
+          },
+          {
+            "name": "AN_ADDITIONAL_SECRET_ENV",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "an-existing-secret",
+                "key": "anExistingKey"
+              }
+            }
           }
         ]`
 				var expectedEnvVars []corev1.EnvVar

--- a/tests/unit/helm/plugins-deployment_test.go
+++ b/tests/unit/helm/plugins-deployment_test.go
@@ -602,8 +602,10 @@ func (s *deploymentPluginsTemplateTest) TestContainerEnv() {
 		{
 			"overrideEnv", // legacy auth mode
 			map[string]string{
-				"pluginsSettings.enabled":      "true",
-				"pluginsSettings.env.TEST_KEY": "TEST_VALUE",
+				"pluginsSettings.enabled":                                       "true",
+				"pluginsSettings.env.TEST_KEY":                                  "TEST_VALUE",
+				"pluginsSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName": "an-existing-secret", // pragma: allowlist secret
+				"pluginsSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":  "anExistingKey",      // pragma: allowlist secret
 			},
 			func(envVars []corev1.EnvVar) {
 				expectedEnvVarJSON := `[
@@ -666,6 +668,15 @@ func (s *deploymentPluginsTemplateTest) TestContainerEnv() {
           {
             "name": "TEST_KEY",
             "value": "TEST_VALUE"
+          },
+          {
+            "name": "AN_ADDITIONAL_SECRET_ENV",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "an-existing-secret",
+                "key": "anExistingKey"
+              }
+            }
           }
         ]`
 				var expectedEnvVars []corev1.EnvVar
@@ -677,9 +688,11 @@ func (s *deploymentPluginsTemplateTest) TestContainerEnv() {
 		{
 			"internalAuthMode",
 			map[string]string{
-				"casSettings.env.FIFTYONE_AUTH_MODE": "internal",
-				"pluginsSettings.enabled":            "true",
-				"pluginsSettings.env.TEST_KEY":       "TEST_VALUE",
+				"casSettings.env.FIFTYONE_AUTH_MODE":                            "internal",
+				"pluginsSettings.enabled":                                       "true",
+				"pluginsSettings.env.TEST_KEY":                                  "TEST_VALUE",
+				"pluginsSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName": "an-existing-secret", // pragma: allowlist secret
+				"pluginsSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":  "anExistingKey",      // pragma: allowlist secret
 			},
 			func(envVars []corev1.EnvVar) {
 				expectedEnvVarJSON := `[
@@ -742,6 +755,15 @@ func (s *deploymentPluginsTemplateTest) TestContainerEnv() {
           {
             "name": "TEST_KEY",
             "value": "TEST_VALUE"
+          },
+          {
+            "name": "AN_ADDITIONAL_SECRET_ENV",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "an-existing-secret",
+                "key": "anExistingKey"
+              }
+            }
           }
         ]`
 				var expectedEnvVars []corev1.EnvVar

--- a/tests/unit/helm/teams-app-deployment_test.go
+++ b/tests/unit/helm/teams-app-deployment_test.go
@@ -513,7 +513,9 @@ func (s *deploymentTeamsAppTemplateTest) TestContainerEnv() {
 		{
 			"overrideEnv",
 			map[string]string{
-				"teamsAppSettings.env.TEST_KEY": "TEST_VALUE",
+				"teamsAppSettings.env.TEST_KEY":                                  "TEST_VALUE",
+				"teamsAppSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretName": "an-existing-secret", // pragma: allowlist secret
+				"teamsAppSettings.secretEnv.AN_ADDITIONAL_SECRET_ENV.secretKey":  "anExistingKey",      // pragma: allowlist secret
 			},
 			func(envVars []corev1.EnvVar) {
 				expectedEnvVarJSON := fmt.Sprintf(`[
@@ -585,6 +587,15 @@ func (s *deploymentTeamsAppTemplateTest) TestContainerEnv() {
           {
             "name": "TEST_KEY",
             "value": "TEST_VALUE"
+          },
+          {
+            "name": "AN_ADDITIONAL_SECRET_ENV",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "an-existing-secret",
+                "key": "anExistingKey"
+              }
+            }
           }
         ]`, chartVersion)
 				var expectedEnvVars []corev1.EnvVar


### PR DESCRIPTION
# Rationale

We have been asked to add extra additional secret environment variables into our deployments. This PR aims to do that following a similar pattern that we already use for regular environment variables.

Because the existing functionality behaves like:

```yaml
env:
  ENV_VAR_NAME: env-var-value
```

the secret environment variables try to follow a similar pattern:

```yaml
secretEnv:
  ENV_VAR_NAME: 
    secretName: an-existing-secret
    secretKey: the-key-in-the-secret
```

These will then be appended to the `env` list in our helpers.

I am also making a conscious decision not to add support for `envFrom` in this as that seems out of scope for this change.

## Changes

* In `_helpers.tpl`: Add range loops for `secretEnv` for each application
* Update `values.yaml` accordingly with the new values and example structures
* Update tests accordingly
* Update readme accordingly (with helm docs)

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

```shell
helm template # visual inspection
make helm-test-unit # unit testing
```

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
