### PR TITLE
chore: changing to port short names

### DIFF
--- a/helm/fiftyone-teams-app/templates/api-service.yaml
+++ b/helm/fiftyone-teams-app/templates/api-service.yaml
@@ -13,7 +13,7 @@ spec:
   type: {{ .Values.apiSettings.service.type }}
   ports:
     - port: {{ .Values.apiSettings.service.port }}
-      targetPort: {{ .Values.apiSettings.service.containerPort | default 8000 }}
+      targetPort: {{ .Values.apiSettings.service.shortname }}
       protocol: TCP
       name: http
       {{- if and (eq .Values.apiSettings.service.type "NodePort") (.Values.apiSettings.service.nodePort) }}

--- a/helm/fiftyone-teams-app/templates/app-service.yaml
+++ b/helm/fiftyone-teams-app/templates/app-service.yaml
@@ -13,7 +13,7 @@ spec:
   type: {{ .Values.appSettings.service.type }}
   ports:
     - port: {{ .Values.appSettings.service.port }}
-      targetPort: {{ .Values.appSettings.service.containerPort | default 5151 }}
+      targetPort: {{ .Values.appSettings.service.shortname }}
       protocol: TCP
       name: http
       {{- if and (eq .Values.appSettings.service.type "NodePort") (.Values.appSettings.service.nodePort) }}

--- a/helm/fiftyone-teams-app/templates/cas-service.yaml
+++ b/helm/fiftyone-teams-app/templates/cas-service.yaml
@@ -13,7 +13,7 @@ spec:
   type: {{ .Values.casSettings.service.type }}
   ports:
     - port: {{ .Values.casSettings.service.port }}
-      targetPort: {{ .Values.casSettings.service.containerPort | default 3000 }}
+      targetPort: {{ .Values.casSettings.service.shortname }}
       protocol: TCP
       name: http
       {{- if and (eq .Values.casSettings.service.type "NodePort") (.Values.casSettings.service.nodePort) }}

--- a/helm/fiftyone-teams-app/templates/plugins-service.yaml
+++ b/helm/fiftyone-teams-app/templates/plugins-service.yaml
@@ -14,7 +14,7 @@ spec:
   type: {{ .Values.pluginsSettings.service.type }}
   ports:
     - port: {{ .Values.pluginsSettings.service.port }}
-      targetPort: {{ .Values.pluginsSettings.service.containerPort | default 5151 }}
+      targetPort: {{ .Values.pluginsSettings.service.shortname }}
       protocol: TCP
       name: http
       {{- if and (eq .Values.pluginsSettings.service.type "NodePort") (.Values.pluginsSettings.service.nodePort) }}

--- a/helm/fiftyone-teams-app/templates/teams-app-service.yaml
+++ b/helm/fiftyone-teams-app/templates/teams-app-service.yaml
@@ -13,7 +13,7 @@ spec:
   type: {{ .Values.teamsAppSettings.service.type }}
   ports:
     - port: {{ .Values.teamsAppSettings.service.port }}
-      targetPort: {{ .Values.teamsAppSettings.service.containerPort | default 3000 }}
+      targetPort: {{ .Values.teamsAppSettings.service.shortname }}
       protocol: TCP
       name: http
       {{- if and (eq .Values.teamsAppSettings.service.type "NodePort") (.Values.teamsAppSettings.service.nodePort) }}

--- a/tests/unit/helm/api-service_test.go
+++ b/tests/unit/helm/api-service_test.go
@@ -242,7 +242,7 @@ func (s *serviceApiTemplateTest) TestPorts() {
 				expectedPortsJSON := `[
           {
             "port": 80,
-            "targetPort": 8000,
+            "targetPort": "teams-api",
             "protocol": "TCP",
             "name": "http"
           }
@@ -262,7 +262,7 @@ func (s *serviceApiTemplateTest) TestPorts() {
 				expectedPortsJSON := `[
           {
             "port": 80,
-            "targetPort": 8000,
+            "targetPort": "teams-api",
             "protocol": "TCP",
             "name": "http"
           }
@@ -283,7 +283,7 @@ func (s *serviceApiTemplateTest) TestPorts() {
 				expectedPortsJSON := `[
           {
             "port": 80,
-            "targetPort": 8000,
+            "targetPort": "teams-api",
             "protocol": "TCP",
             "name": "http",
             "nodePort": 9999
@@ -305,7 +305,28 @@ func (s *serviceApiTemplateTest) TestPorts() {
 				expectedPortsJSON := `[
           {
             "port": 88,
-            "targetPort": 8001,
+            "targetPort": "teams-api",
+            "protocol": "TCP",
+            "name": "http"
+          }
+        ]`
+				var expectedPorts []corev1.ServicePort
+				err := json.Unmarshal([]byte(expectedPortsJSON), &expectedPorts)
+				s.NoError(err)
+				s.Equal(expectedPorts, ports, "Ports should be equal")
+			},
+		},
+		{
+			"overrideServiceServiceShortnameValues",
+			map[string]string{
+				"apiSettings.service.shortname": "teams-override",
+				"apiSettings.service.port":      "88",
+			},
+			func(ports []corev1.ServicePort) {
+				expectedPortsJSON := `[
+          {
+            "port": 88,
+            "targetPort": "teams-override",
             "protocol": "TCP",
             "name": "http"
           }

--- a/tests/unit/helm/app-service_test.go
+++ b/tests/unit/helm/app-service_test.go
@@ -242,7 +242,7 @@ func (s *serviceAppTemplateTest) TestPorts() {
 				expectedPortsJSON := `[
           {
             "port": 80,
-            "targetPort": 5151,
+            "targetPort": "fiftyone-app",
             "protocol": "TCP",
             "name": "http"
           }
@@ -262,7 +262,7 @@ func (s *serviceAppTemplateTest) TestPorts() {
 				expectedPortsJSON := `[
           {
             "port": 80,
-            "targetPort": 5151,
+            "targetPort": "fiftyone-app",
             "protocol": "TCP",
             "name": "http"
           }
@@ -283,7 +283,7 @@ func (s *serviceAppTemplateTest) TestPorts() {
 				expectedPortsJSON := `[
           {
             "port": 80,
-            "targetPort": 5151,
+            "targetPort": "fiftyone-app",
             "protocol": "TCP",
             "name": "http",
             "nodePort": 9999
@@ -305,7 +305,28 @@ func (s *serviceAppTemplateTest) TestPorts() {
 				expectedPortsJSON := `[
           {
             "port": 88,
-            "targetPort": 8001,
+            "targetPort": "fiftyone-app",
+            "protocol": "TCP",
+            "name": "http"
+          }
+        ]`
+				var expectedPorts []corev1.ServicePort
+				err := json.Unmarshal([]byte(expectedPortsJSON), &expectedPorts)
+				s.NoError(err)
+				s.Equal(expectedPorts, ports, "Ports should be equal")
+			},
+		},
+		{
+			"overrideServiceServiceShortnameValues",
+			map[string]string{
+				"appSettings.service.shortname": "teams-override",
+				"appSettings.service.port":      "88",
+			},
+			func(ports []corev1.ServicePort) {
+				expectedPortsJSON := `[
+          {
+            "port": 88,
+            "targetPort": "teams-override",
             "protocol": "TCP",
             "name": "http"
           }

--- a/tests/unit/helm/cas-service_test.go
+++ b/tests/unit/helm/cas-service_test.go
@@ -242,7 +242,7 @@ func (s *serviceCasTemplateTest) TestPorts() {
 				expectedPortsJSON := `[
           {
             "port": 80,
-            "targetPort": 3000,
+            "targetPort": "teams-cas",
             "protocol": "TCP",
             "name": "http"
           }
@@ -262,7 +262,7 @@ func (s *serviceCasTemplateTest) TestPorts() {
 				expectedPortsJSON := `[
           {
             "port": 80,
-            "targetPort": 3000,
+            "targetPort": "teams-cas",
             "protocol": "TCP",
             "name": "http"
           }
@@ -283,7 +283,7 @@ func (s *serviceCasTemplateTest) TestPorts() {
 				expectedPortsJSON := `[
           {
             "port": 80,
-            "targetPort": 3000,
+            "targetPort": "teams-cas",
             "protocol": "TCP",
             "name": "http",
             "nodePort": 9999
@@ -305,7 +305,28 @@ func (s *serviceCasTemplateTest) TestPorts() {
 				expectedPortsJSON := `[
           {
             "port": 88,
-            "targetPort": 3001,
+            "targetPort": "teams-cas",
+            "protocol": "TCP",
+            "name": "http"
+          }
+        ]`
+				var expectedPorts []corev1.ServicePort
+				err := json.Unmarshal([]byte(expectedPortsJSON), &expectedPorts)
+				s.NoError(err)
+				s.Equal(expectedPorts, ports, "Ports should be equal")
+			},
+		},
+		{
+			"overrideServiceServiceShortnameValues",
+			map[string]string{
+				"casSettings.service.shortname": "teams-override",
+				"casSettings.service.port":      "88",
+			},
+			func(ports []corev1.ServicePort) {
+				expectedPortsJSON := `[
+          {
+            "port": 88,
+            "targetPort": "teams-override",
             "protocol": "TCP",
             "name": "http"
           }

--- a/tests/unit/helm/plugins-service_test.go
+++ b/tests/unit/helm/plugins-service_test.go
@@ -335,7 +335,7 @@ func (s *servicePluginsTemplateTest) TestPorts() {
 				expectedPortsJSON := `[
           {
             "port": 80,
-            "targetPort": 5151,
+            "targetPort": "teams-plugins",
             "protocol": "TCP",
             "name": "http"
           }
@@ -356,7 +356,7 @@ func (s *servicePluginsTemplateTest) TestPorts() {
 				expectedPortsJSON := `[
           {
             "port": 80,
-            "targetPort": 5151,
+            "targetPort": "teams-plugins",
             "protocol": "TCP",
             "name": "http"
           }
@@ -378,7 +378,7 @@ func (s *servicePluginsTemplateTest) TestPorts() {
 				expectedPortsJSON := `[
           {
             "port": 80,
-            "targetPort": 5151,
+            "targetPort": "teams-plugins",
             "protocol": "TCP",
             "name": "http",
             "nodePort": 9999
@@ -401,7 +401,29 @@ func (s *servicePluginsTemplateTest) TestPorts() {
 				expectedPortsJSON := `[
           {
             "port": 88,
-            "targetPort": 8001,
+            "targetPort": "teams-plugins",
+            "protocol": "TCP",
+            "name": "http"
+          }
+        ]`
+				var expectedPorts []corev1.ServicePort
+				err := json.Unmarshal([]byte(expectedPortsJSON), &expectedPorts)
+				s.NoError(err)
+				s.Equal(expectedPorts, ports, "Ports should be equal")
+			},
+		},
+		{
+			"overrideServiceServiceShortnameValues",
+			map[string]string{
+				"pluginsSettings.enabled":           "true",
+				"pluginsSettings.service.shortname": "teams-override",
+				"pluginsSettings.service.port":      "88",
+			},
+			func(ports []corev1.ServicePort) {
+				expectedPortsJSON := `[
+          {
+            "port": 88,
+            "targetPort": "teams-override",
             "protocol": "TCP",
             "name": "http"
           }

--- a/tests/unit/helm/teams-app-service_test.go
+++ b/tests/unit/helm/teams-app-service_test.go
@@ -245,7 +245,7 @@ func (s *serviceTeamsAppTemplateTest) TestPorts() {
 				expectedPortsJSON := `[
           {
             "port": 80,
-            "targetPort": 3000,
+            "targetPort": "teams-app",
             "protocol": "TCP",
             "name": "http"
           }
@@ -265,7 +265,7 @@ func (s *serviceTeamsAppTemplateTest) TestPorts() {
 				expectedPortsJSON := `[
           {
             "port": 80,
-            "targetPort": 3000,
+            "targetPort": "teams-app",
             "protocol": "TCP",
             "name": "http"
           }
@@ -286,7 +286,7 @@ func (s *serviceTeamsAppTemplateTest) TestPorts() {
 				expectedPortsJSON := `[
           {
             "port": 80,
-            "targetPort": 3000,
+            "targetPort": "teams-app",
             "protocol": "TCP",
             "name": "http",
             "nodePort": 9999
@@ -308,7 +308,28 @@ func (s *serviceTeamsAppTemplateTest) TestPorts() {
 				expectedPortsJSON := `[
           {
             "port": 88,
-            "targetPort": 3001,
+            "targetPort": "teams-app",
+            "protocol": "TCP",
+            "name": "http"
+          }
+        ]`
+				var expectedPorts []corev1.ServicePort
+				err := json.Unmarshal([]byte(expectedPortsJSON), &expectedPorts)
+				s.NoError(err)
+				s.Equal(expectedPorts, ports, "Ports should be equal")
+			},
+		},
+		{
+			"overrideServiceServiceShortnameValues",
+			map[string]string{
+				"teamsAppSettings.service.shortname": "teams-override",
+				"teamsAppSettings.service.port":      "88",
+			},
+			func(ports []corev1.ServicePort) {
+				expectedPortsJSON := `[
+          {
+            "port": 88,
+            "targetPort": "teams-override",
             "protocol": "TCP",
             "name": "http"
           }


### PR DESCRIPTION
# Rationale

We would like to update `targetPort` in our services to reference the container pod __names__ instead of port numbers ([reference](https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports)). This will allow upstream tools, such as telepresence, to intercept or monitor traffic without needing NET_ADMIN privileges.

## Changes

Updates services to use `shortname` instead of `containerPort`.
Updates tests accordingly and adds additional name override tests.

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

## Testing

```shell
make test-unit-helm
```

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
