### PR TITLE
bump chart version [AS-363]

### DIFF
--- a/helm/fiftyone-teams-app/Chart.yaml
+++ b/helm/fiftyone-teams-app/Chart.yaml
@@ -4,7 +4,7 @@ name: fiftyone-teams-app
 namespace: fiftyone-teams
 description: FiftyOne Teams is the enterprise version of the open source [FiftyOne](https://github.com/voxel51/fiftyone) project.
 type: application
-version: 2.2.0
+version: 2.3.0
 appVersion: "v2.3.0"
 icon: https://voxel51.com/images/logo/voxel51-logo-horz-color-600dpi.png
 kubeVersion: ">=1.18-0"

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -15,7 +15,7 @@
 # fiftyone-teams-app
 
 <!-- markdownlint-disable line-length -->
-![Version: 2.2.0](https://img.shields.io/badge/Version-2.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.3.0](https://img.shields.io/badge/AppVersion-v2.3.0-informational?style=flat-square)
+![Version: 2.3.0](https://img.shields.io/badge/Version-2.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.3.0](https://img.shields.io/badge/AppVersion-v2.3.0-informational?style=flat-square)
 
 FiftyOne Teams is the enterprise version of the open source [FiftyOne](https://github.com/voxel51/fiftyone) project.
 <!-- markdownlint-enable line-length -->


### PR DESCRIPTION
# Rationale

In https://github.com/voxel51/fiftyone-teams-app-deploy/pull/259 I didn't notice that we didn't bump the `chart.yaml`'s version to `2.3.0`.  This means that for this PR those that follow, we used the 2.2.0 version base instead of 2.3.0.

For example https://github.com/voxel51/fiftyone-teams-app-deploy/actions/runs/12276403801/job/34253529629#step:4:2 created a version string "2.2.0-rc-788cabb" which resulted in https://console.cloud.google.com/artifacts/docker/computer-vision-team/us-central1/helm-internal/fiftyone-teams-app/sha256:42d7a985df7e4e2b25a7fe3743e66e3bfca20f8131a80704bf4f9f07e59a68dc?project=computer-vision-team being published to our GAR.

Let's fix that.

## Changes

* helm chart version

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->