### PR TITLE
Fix typo "namepace"

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -22,7 +22,7 @@ install and configure FiftyoneTeams on Docker.
 This page assumes general knowledge of FiftyoneTeams and how to use it.
 Please contact Voxel51 for more information regarding Fiftyone Teams.
 
-## :warning: Important :warning:
+## Important
 
 ### Version 2.0+ License File Requirement
 

--- a/helm/docs/upgrading.md
+++ b/helm/docs/upgrading.md
@@ -176,7 +176,7 @@ For a full list of settings, please refer to the
    a new kubernetes secret:
 
     ```shell
-    kubectl --namespace your-namepace-here create secret generic \
+    kubectl --namespace your-namespace-here create secret generic \
       fiftyone-license --from-file=license=./your-license-file
     ```
 
@@ -251,7 +251,7 @@ For a full list of settings, please refer to the
    a new kubernetes secret:
 
     ```shell
-    kubectl --namespace your-namepace-here create secret generic \
+    kubectl --namespace your-namespace-here create secret generic \
       fiftyone-license --from-file=license=./your-license-file
     ```
 
@@ -345,7 +345,7 @@ For a full list of settings, please refer to the
    a new kubernetes secret:
 
     ```shell
-    kubectl --namespace your-namepace-here create secret generic \
+    kubectl --namespace your-namespace-here create secret generic \
       fiftyone-license --from-file=license=./your-license-file
     ```
 

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -25,7 +25,7 @@ The FiftyoneTeams Helm chart is the recommended way to install and configure Fif
 This page assumes general knowledge of Fiftyone Teams and how to use it.
 Please contact Voxel51 for more information regarding Fiftyone Teams.
 
-## :warning: Important :warning:
+## Important
 
 ### Version 2.0+ License File Requirement
 

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -107,7 +107,7 @@ a new license file secret:
 
 ```shell
 kubectl create namespace your-namespace-here
-kubectl --namespace your-namepace-here create secret generic fiftyone-license \
+kubectl --namespace your-namespace-here create secret generic fiftyone-license \
 --from-file=license=./your-license-file
 ```
 

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -25,7 +25,7 @@
 This page assumes general knowledge of Fiftyone Teams and how to use it.
 Please contact Voxel51 for more information regarding Fiftyone Teams.
 
-## :warning: Important :warning:
+## Important
 
 ### Version 2.0+ License File Requirement
 

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -107,7 +107,7 @@ a new license file secret:
 
 ```shell
 kubectl create namespace your-namespace-here
-kubectl --namespace your-namepace-here create secret generic fiftyone-license \
+kubectl --namespace your-namespace-here create secret generic fiftyone-license \
 --from-file=license=./your-license-file
 ```
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -14,7 +14,7 @@
 # # to create a fiftyoneLicenseSecret:
 # #
 # # ```shell
-# #  kubectl --namespace your-namepace create secret generic fiftyone-license \
+# #  kubectl --namespace your-namespace create secret generic fiftyone-license \
 # #    --from-file=license=./your-license-file
 # # ```
 # # Then set the name(s) of your license file secret(s) here (one per org):


### PR DESCRIPTION
# Rationale

While looking at the docs, noticed a typo. Let's fix that.

## Changes

* replace typo "namepace" with "namespace"

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

## Testing

n/a it's just comments and docs.

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
