### PR TITLE
chore: `pre-commit autoupdate`, fix for markdownlint findings, fix co…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -19,7 +19,7 @@ repos:
       - id: pretty-format-json
       - id: trailing-whitespace
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.4
+    rev: v1.5.5
     hooks:
       - id: forbid-tabs
         exclude_types:
@@ -38,17 +38,17 @@ repos:
           # A base filename makes it relative to each chart directory found
           - --template-files=README.md.gotmpl
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.36.0
+    rev: v0.43.0
     hooks:
       - id: markdownlint
       - id: markdownlint-fix
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.5
+    rev: v2.3.0
     hooks:
       - id: codespell
         exclude: helm/local-self-signed-example/cert-manger-crds|tests/go.sum
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.32.0
+    rev: v1.35.1
     hooks:
       - id: yamllint
         entry: yamllint --config-file .yamllint.yaml
@@ -67,11 +67,11 @@ repos:
           - helm/README.md
           - CONTRIBUTING.md
   - repo: https://github.com/gruntwork-io/pre-commit
-    rev: v0.1.23
+    rev: v0.1.25
     hooks:
       - id: helmlint
   - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.4.0
+    rev: v1.5.0
     hooks:
       - id: detect-secrets
         args:
@@ -83,7 +83,7 @@ repos:
       - id: go-fmt
       - id: go-mod-tidy
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.0
+    rev: v1.7.6
     hooks:
       - id: actionlint
   - repo: https://github.com/syntaqx/git-hooks
@@ -95,7 +95,7 @@ repos:
           - -w
           - -s
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v3.4.0
+    rev: v4.0.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]

--- a/.tool-versions
+++ b/.tool-versions
@@ -5,7 +5,7 @@ helm-docs 1.14.2
 jq 1.7.1
 kubectl 1.30.1
 minikube 1.33.1
-pre-commit 3.8.0
+pre-commit 4.0.1
 python 3.10.14
 shellcheck 0.10.0
 shfmt 3.8.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,13 +1,13 @@
 cmctl 2.1.1
 golang 1.22.3
-helm 3.15.4
+helm 3.16.4
 helm-docs 1.14.2
 jq 1.7.1
-kubectl 1.30.1
-minikube 1.33.1
+kubectl 1.32.0
+minikube 1.34.0
 pre-commit 4.0.1
 python 3.10.14
 shellcheck 0.10.0
-shfmt 3.8.0
+shfmt 3.10.0
 skaffold 2.13.2
 yq 4.44.6

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable no-inline-html line-length -->
+<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
@@ -6,7 +6,7 @@
 <!-- prettier-ignore -->
 <img src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
 <img src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
-<!-- markdownlint-enable no-inline-html line-length -->
+<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
 
 ## Fiftyone Teams Deployment Assets
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable no-inline-html line-length -->
+<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
@@ -8,7 +8,7 @@
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length -->
+<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
 
 # fiftyone-teams-app
 

--- a/docker/docs/configuring-delegated-operators.md
+++ b/docker/docs/configuring-delegated-operators.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable no-inline-html line-length -->
+<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
@@ -8,7 +8,7 @@
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length -->
+<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
 
 ---
 

--- a/docker/docs/configuring-plugins.md
+++ b/docker/docs/configuring-plugins.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable no-inline-html line-length -->
+<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
@@ -8,7 +8,7 @@
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length -->
+<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
 
 ---
 

--- a/docker/docs/configuring-proxies.md
+++ b/docker/docs/configuring-proxies.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable no-inline-html line-length -->
+<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
@@ -8,7 +8,7 @@
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length -->
+<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
 
 ---
 

--- a/docker/docs/configuring-snapshot-archival.md
+++ b/docker/docs/configuring-snapshot-archival.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable no-inline-html line-length -->
+<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
@@ -8,7 +8,7 @@
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length -->
+<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
 
 ---
 

--- a/docker/docs/expose-teams-api.md
+++ b/docker/docs/expose-teams-api.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable no-inline-html line-length -->
+<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
@@ -8,7 +8,7 @@
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length -->
+<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
 
 ---
 

--- a/docs/custom-plugins.md
+++ b/docs/custom-plugins.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable no-inline-html line-length -->
+<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
@@ -8,7 +8,7 @@
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length -->
+<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
 
 ---
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable no-inline-html line-length -->
+<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
@@ -8,7 +8,7 @@
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length -->
+<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
 
 <!-- toc -->
 

--- a/helm/docs/configuring-delegated-operators.md
+++ b/helm/docs/configuring-delegated-operators.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable no-inline-html line-length -->
+<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
@@ -8,7 +8,7 @@
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length -->
+<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
 
 ---
 

--- a/helm/docs/configuring-plugins.md
+++ b/helm/docs/configuring-plugins.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable no-inline-html line-length -->
+<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
@@ -8,7 +8,7 @@
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length -->
+<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
 
 ---
 

--- a/helm/docs/configuring-proxies.md
+++ b/helm/docs/configuring-proxies.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable no-inline-html line-length -->
+<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
@@ -8,7 +8,7 @@
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length -->
+<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
 
 ---
 

--- a/helm/docs/configuring-snapshot-archival.md
+++ b/helm/docs/configuring-snapshot-archival.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable no-inline-html line-length -->
+<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
@@ -8,7 +8,7 @@
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length -->
+<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
 
 ---
 

--- a/helm/docs/expose-teams-api.md
+++ b/helm/docs/expose-teams-api.md
@@ -1,15 +1,14 @@
-<!-- markdownlint-disable-next-line first-line-heading no-inline-html -->
+<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
-<!-- markdownlint-disable-next-line no-inline-html -->
 <p align="center">
 
-<!-- markdownlint-disable-next-line no-inline-html line-length -->
 <img src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
-<!-- markdownlint-disable-next-line no-inline-html line-length -->
 <img src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
 
 </p>
 </div>
+<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
 
 ---
 

--- a/helm/docs/plugins-storage.md
+++ b/helm/docs/plugins-storage.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable no-inline-html line-length -->
+<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
@@ -8,7 +8,7 @@
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length -->
+<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
 
 ---
 

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable no-inline-html line-length -->
+<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
@@ -8,7 +8,7 @@
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length -->
+<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
 
 ---
 

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable no-inline-html line-length -->
+<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
@@ -8,7 +8,7 @@
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length -->
+<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
 
 ---
 

--- a/tests/testing.md
+++ b/tests/testing.md
@@ -171,7 +171,7 @@ See
     ```
 
 The helm integration tests may be run multiple times by invoking the previous step.
-It will re-use the cert-manager and mongodb deployed.
+It will reuse the cert-manager and mongodb deployed.
 
 ## Additional Links
 


### PR DESCRIPTION
# Rationale

While looking an issue with pre-commit, noticed that we could bump some of the versions.  

<details>
<summary>New markdownlint findings</summary>

```
markdownlint.........................................................................Failed
- hook id: markdownlint
- exit code: 1

docker/docs/expose-teams-api.md:6:1 MD045/no-alt-text Images should have alternate text (alt text)
docker/docs/expose-teams-api.md:7:1 MD045/no-alt-text Images should have alternate text (alt text)
helm/docs/configuring-delegated-operators.md:6:1 MD045/no-alt-text Images should have alternate text (alt text)
helm/docs/configuring-delegated-operators.md:7:1 MD045/no-alt-text Images should have alternate text (alt text)
README.md:7:1 MD045/no-alt-text Images should have alternate text (alt text)
README.md:8:1 MD045/no-alt-text Images should have alternate text (alt text)
docker/README.md:6:1 MD045/no-alt-text Images should have alternate text (alt text)
docker/README.md:7:1 MD045/no-alt-text Images should have alternate text (alt text)
docs/custom-plugins.md:6:1 MD045/no-alt-text Images should have alternate text (alt text)
docs/custom-plugins.md:7:1 MD045/no-alt-text Images should have alternate text (alt text)
helm/docs/configuring-proxies.md:6:1 MD045/no-alt-text Images should have alternate text (alt text)
helm/docs/configuring-proxies.md:7:1 MD045/no-alt-text Images should have alternate text (alt text)
helm/README.md:6:1 MD045/no-alt-text Images should have alternate text (alt text)
helm/README.md:7:1 MD045/no-alt-text Images should have alternate text (alt text)
docker/docs/configuring-delegated-operators.md:6:1 MD045/no-alt-text Images should have alternate text (alt text)
docker/docs/configuring-delegated-operators.md:7:1 MD045/no-alt-text Images should have alternate text (alt text)
docker/docs/configuring-snapshot-archival.md:6:1 MD045/no-alt-text Images should have alternate text (alt text)
docker/docs/configuring-snapshot-archival.md:7:1 MD045/no-alt-text Images should have alternate text (alt text)
helm/docs/configuring-snapshot-archival.md:6:1 MD045/no-alt-text Images should have alternate text (alt text)
helm/docs/configuring-snapshot-archival.md:7:1 MD045/no-alt-text Images should have alternate text (alt text)
docker/docs/configuring-proxies.md:6:1 MD045/no-alt-text Images should have alternate text (alt text)
docker/docs/configuring-proxies.md:7:1 MD045/no-alt-text Images should have alternate text (alt text)
helm/docs/plugins-storage.md:6:1 MD045/no-alt-text Images should have alternate text (alt text)
helm/docs/plugins-storage.md:7:1 MD045/no-alt-text Images should have alternate text (alt text)
helm/fiftyone-teams-app/README.md:6:1 MD045/no-alt-text Images should have alternate text (alt text)
helm/fiftyone-teams-app/README.md:7:1 MD045/no-alt-text Images should have alternate text (alt text)
helm/docs/configuring-plugins.md:6:1 MD045/no-alt-text Images should have alternate text (alt text)
helm/docs/configuring-plugins.md:7:1 MD045/no-alt-text Images should have alternate text (alt text)
helm/docs/expose-teams-api.md:7:1 MD045/no-alt-text Images should have alternate text (alt text)
helm/docs/expose-teams-api.md:9:1 MD045/no-alt-text Images should have alternate text (alt text)
```

</details>

<details>
<summary>New codespell findings</summary>

```
codespell............................................................................Failed
- hook id: codespell
- exit code: 65

tests/testing.md:174: re-use ==> reuse
```

</details>

While here, let's update most of the asdf tool versions (without updating go and python).

## Changes

1. <details>
    <summary>`pre-commit autoupdate`</summary>

    [fiftyone-teams-app-deploy]$ pre-commit autoupdate
    [https://github.com/pre-commit/pre-commit-hooks] updating v4.4.0 -> v5.0.0
    [https://github.com/Lucas-C/pre-commit-hooks] updating v1.5.4 -> v1.5.5
    [https://github.com/norwoodj/helm-docs] already up to date!
    [https://github.com/igorshubovych/markdownlint-cli] updating v0.36.0 -> v0.43.0
    [https://github.com/codespell-project/codespell] updating v2.2.5 -> v2.3.0
    [https://github.com/adrienverge/yamllint] updating v1.32.0 -> v1.35.1
    [https://github.com/Lucas-C/pre-commit-hooks-nodejs] already up to date!
    [https://github.com/gruntwork-io/pre-commit] updating v0.1.23 -> v0.1.25
    [https://github.com/Yelp/detect-secrets] updating v1.4.0 -> v1.5.0
    [https://github.com/dnephin/pre-commit-golang] already up to date!
    [https://github.com/rhysd/actionlint] updating v1.7.0 -> v1.7.6
    [https://github.com/syntaqx/git-hooks] already up to date!
    [https://github.com/compilerla/conventional-pre-commit] updating v3.4.0 -> v4.0.0
    </details>
1. Add `no-alt-text` to markdown files where we use our images 
1. Update pre-commit in .tool-versions to 4.0.1 (like was recently updated in voxel-hub)
1. typo


Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
