### PR TITLE
feat: AS-352 Updating fixture version numbers

### DIFF
--- a/utils/bump-fixtures-common.sh
+++ b/utils/bump-fixtures-common.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Check if a variable is empty
+check_empty() {
+  local var_name="$1"
+  local var_value="$2"
+  if [[ -z $var_value ]]; then
+    echo "Error: $var_name must not be empty." >&2
+    print_usage
+    exit 1
+  fi
+}

--- a/utils/bump-fixtures-docker.sh
+++ b/utils/bump-fixtures-docker.sh
@@ -29,7 +29,6 @@ print_usage() {
 
 # Parse command-line options
 parse_arguments() {
-  local parent_script="${1:-false}"
 
   while test $# -gt 0; do
     case "$1" in
@@ -37,49 +36,62 @@ parse_arguments() {
         print_usage
         exit 0
         ;;
-      -a | --app-version)
-        check_empty "--app-version" "$2"
-        FIFTYONE_APP_VERSION="$2"
-        shift 2
-        ;;
-      -i | --api-version)
-        check_empty "--api-version" "$2"
-        FIFTYONE_TEAMS_API_VERSION="$2"
-        shift 2
-        ;;
-      -t | --teams-app-version)
-        check_empty "--teams-app-version" "$2"
-        FIFTYONE_TEAMS_APP_VERSION="$2"
-        shift 2
-        ;;
-      -c | --cas-version)
-        check_empty "--cas-version" "$2"
-        FIFTYONE_TEAMS_CAS_VERSION="$2"
-        shift 2
-        ;;
-      -f | --file)
-        if [[ $parent_script == "true" ]]; then
-          # Skip processing the -f flag if this is the parent script
-          echo "Skipping -f flag processing for parent script."
+      -a | --app-version*)
+        shift
+        if test $# -gt 0; then
+          FIFTYONE_APP_VERSION=$1
         else
-          check_empty "--file" "$2"
-          INPUT_FILE="$2"
-          if [[ ! -f $INPUT_FILE ]]; then
-            echo "Error: File '$INPUT_FILE' does not exist." >&2
-            print_usage
-            exit 1
-          fi
+          print_usage
+          exit 1
         fi
-        shift 2
+        shift
+        ;;
+      -i | --api-version*)
+        shift
+        if test $# -gt 0; then
+          FIFTYONE_TEAMS_API_VERSION=$1
+        else
+          print_usage
+          exit 1
+        fi
+        shift
+        ;;
+      -t | --teams-app-version*)
+        shift
+        if test $# -gt 0; then
+          FIFTYONE_TEAMS_APP_VERSION=$1
+        else
+          print_usage
+          exit 1
+        fi
+        shift
+        ;;
+      -f | --file*)
+        shift
+        INPUT_FILE="$1"
+        if [[ ! -f $INPUT_FILE ]]; then
+          echo "Error: File '$INPUT_FILE' does not exist." >&2
+          print_usage
+          exit 1
+        fi
+        shift
+        ;;
+      -c | --cas-version*)
+        shift
+        if test $# -gt 0; then
+          FIFTYONE_TEAMS_CAS_VERSION=$1
+        else
+          print_usage
+          exit 1
+        fi
+        shift
         ;;
       -d | --dry-run)
         DRY_RUN="true"
         shift
         ;;
       *)
-        echo "Error: Unknown option: $1" >&2
-        print_usage
-        exit 1
+        break
         ;;
     esac
   done

--- a/utils/bump-fixtures-docker.sh
+++ b/utils/bump-fixtures-docker.sh
@@ -13,7 +13,7 @@ DRY_RUN='false'
 print_usage() {
   local package
   package=$(basename "$0")
-  echo "$package - Bump versions in docker-compose fixture."
+  echo "$package - Bump versions in a docker-compose fixture."
   echo " "
   echo "$package [options]"
   echo " "

--- a/utils/bump-fixtures-docker.sh
+++ b/utils/bump-fixtures-docker.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Default values for the version variables (can be empty, but will need to be set by the user)
+FIFTYONE_APP_VERSION=''
+FIFTYONE_TEAMS_API_VERSION=''
+FIFTYONE_TEAMS_APP_VERSION=''
+FIFTYONE_TEAMS_CAS_VERSION=''
+INPUT_FILE=''
+DRY_RUN='false'
+
+print_usage() {
+  local package
+  package=$(basename "$0")
+  echo "$package - Bump versions in docker-compose fixture."
+  echo " "
+  echo "$package [options]"
+  echo " "
+  echo "options:"
+  echo "-h, --help                                          show brief help"
+  echo "-a, --app-version=FIFTYONE_APP_VERSION              Set Fiftyone App Version"
+  echo "-i, --api-version=FIFTYONE_TEAMS_API_VERSION        Set Fiftyone Teams API Version"
+  echo "-t, --teams-app-version=FIFTYONE_TEAMS_APP_VERSION  Set Fiftyone Teams App Version"
+  echo "-c, --cas-version=FIFTYONE_TEAMS_CAS_VERSION        Set Fiftyone CAS Version"
+  echo "-f, --file=INPUT_FILE                               .env file to update"
+  echo "-d, --dry-run                                       Perform a dry-run (print to stdout instead of modifying the file)"
+}
+
+# Parse command-line options
+parse_arguments() {
+  local parent_script="${1:-false}"
+
+  while test $# -gt 0; do
+    case "$1" in
+      -h | --help)
+        print_usage
+        exit 0
+        ;;
+      -a | --app-version)
+        check_empty "--app-version" "$2"
+        FIFTYONE_APP_VERSION="$2"
+        shift 2
+        ;;
+      -i | --api-version)
+        check_empty "--api-version" "$2"
+        FIFTYONE_TEAMS_API_VERSION="$2"
+        shift 2
+        ;;
+      -t | --teams-app-version)
+        check_empty "--teams-app-version" "$2"
+        FIFTYONE_TEAMS_APP_VERSION="$2"
+        shift 2
+        ;;
+      -c | --cas-version)
+        check_empty "--cas-version" "$2"
+        FIFTYONE_TEAMS_CAS_VERSION="$2"
+        shift 2
+        ;;
+      -f | --file)
+        if [[ $parent_script == "true" ]]; then
+          # Skip processing the -f flag if this is the parent script
+          echo "Skipping -f flag processing for parent script."
+        else
+          check_empty "--file" "$2"
+          INPUT_FILE="$2"
+          if [[ ! -f $INPUT_FILE ]]; then
+            echo "Error: File '$INPUT_FILE' does not exist." >&2
+            print_usage
+            exit 1
+          fi
+        fi
+        shift 2
+        ;;
+      -d | --dry-run)
+        DRY_RUN="true"
+        shift
+        ;;
+      *)
+        echo "Error: Unknown option: $1" >&2
+        print_usage
+        exit 1
+        ;;
+    esac
+  done
+
+  # Check that all version variables are set
+  check_empty "FIFTYONE_APP_VERSION" "$FIFTYONE_APP_VERSION"
+  check_empty "FIFTYONE_TEAMS_API_VERSION" "$FIFTYONE_TEAMS_API_VERSION"
+  check_empty "FIFTYONE_TEAMS_APP_VERSION" "$FIFTYONE_TEAMS_APP_VERSION"
+  check_empty "FIFTYONE_TEAMS_CAS_VERSION" "$FIFTYONE_TEAMS_CAS_VERSION"
+  check_empty "INPUT_FILE" "$INPUT_FILE"
+}
+
+source ./utils/bump-fixtures-common.sh
+
+# Parse the arguments
+parse_arguments "$@"
+
+# Set up temporary file handling for dry run
+file="$INPUT_FILE"
+if [[ $DRY_RUN == "true" ]]; then
+  tempfile=$(mktemp)
+  cp "$INPUT_FILE" "$tempfile"
+  file="$tempfile"
+  echo "Performing dry-run: Changes will be printed but not saved."
+fi
+
+# Determine the appropriate `sed` flags based on the OS type
+sed_flags="-i"
+delete_backups="false"
+if [[ $OSTYPE == "darwin"* ]]; then
+  sed_flags="-ib" # macOS requires a backup extension when using `-i`
+  delete_backups="true"
+fi
+
+# Perform replacements in the file
+sed "$sed_flags" "s/^FIFTYONE_APP_VERSION=.*/FIFTYONE_APP_VERSION=$FIFTYONE_APP_VERSION/" "$file"
+sed "$sed_flags" "s/^FIFTYONE_TEAMS_API_VERSION=.*/FIFTYONE_TEAMS_API_VERSION=$FIFTYONE_TEAMS_API_VERSION/" "$file"
+sed "$sed_flags" "s/^FIFTYONE_TEAMS_APP_VERSION=.*/FIFTYONE_TEAMS_APP_VERSION=$FIFTYONE_TEAMS_APP_VERSION/" "$file"
+sed "$sed_flags" "s/^FIFTYONE_TEAMS_CAS_VERSION=.*/FIFTYONE_TEAMS_CAS_VERSION=$FIFTYONE_TEAMS_CAS_VERSION/" "$file"
+
+# Output the file contents (dry-run will print the content)
+cat "$file"
+
+# Clean up backup file if on macOS
+if [[ $delete_backups == "true" ]]; then
+  rm "${file}b"
+fi
+
+# Remove temporary file if dry-run
+if [[ $DRY_RUN == "true" ]]; then
+  rm "$tempfile"
+fi

--- a/utils/bump-fixtures-docker.sh
+++ b/utils/bump-fixtures-docker.sh
@@ -42,7 +42,7 @@ parse_arguments() {
           print_usage
           exit 1
         fi
-        FIFTYONE_APP_VERSION="$2"
+        FIFTYONE_APP_VERSION="${2}"
         shift 2
         ;;
       -i | --api-version)
@@ -51,7 +51,7 @@ parse_arguments() {
           print_usage
           exit 1
         fi
-        FIFTYONE_TEAMS_API_VERSION="$2"
+        FIFTYONE_TEAMS_API_VERSION="${2}"
         shift 2
         ;;
       -t | --teams-app-version)
@@ -60,7 +60,7 @@ parse_arguments() {
           print_usage
           exit 1
         fi
-        FIFTYONE_TEAMS_APP_VERSION="$2"
+        FIFTYONE_TEAMS_APP_VERSION="${2}"
         shift 2
         ;;
       -c | --cas-version)
@@ -69,7 +69,7 @@ parse_arguments() {
           print_usage
           exit 1
         fi
-        FIFTYONE_TEAMS_CAS_VERSION="$2"
+        FIFTYONE_TEAMS_CAS_VERSION="${2}"
         shift 2
         ;;
       -f | --file*)
@@ -79,8 +79,8 @@ parse_arguments() {
           exit 1
         fi
         INPUT_FILE="$2"
-        if [[ ! -f $INPUT_FILE ]]; then
-          echo "Error: File '$INPUT_FILE' does not exist." >&2
+        if [[ ! -f ${INPUT_FILE} ]]; then
+          echo "Error: File '${INPUT_FILE}' does not exist." >&2
           print_usage
           exit 1
         fi
@@ -95,13 +95,12 @@ parse_arguments() {
         ;;
     esac
   done
-
   # Check that all version variables are set
-  check_empty "FIFTYONE_APP_VERSION" "$FIFTYONE_APP_VERSION"
-  check_empty "FIFTYONE_TEAMS_API_VERSION" "$FIFTYONE_TEAMS_API_VERSION"
-  check_empty "FIFTYONE_TEAMS_APP_VERSION" "$FIFTYONE_TEAMS_APP_VERSION"
-  check_empty "FIFTYONE_TEAMS_CAS_VERSION" "$FIFTYONE_TEAMS_CAS_VERSION"
-  check_empty "INPUT_FILE" "$INPUT_FILE"
+  check_empty "FIFTYONE_APP_VERSION" "${FIFTYONE_APP_VERSION}"
+  check_empty "FIFTYONE_TEAMS_API_VERSION" "${FIFTYONE_TEAMS_API_VERSION}"
+  check_empty "FIFTYONE_TEAMS_APP_VERSION" "${FIFTYONE_TEAMS_APP_VERSION}"
+  check_empty "FIFTYONE_TEAMS_CAS_VERSION" "${FIFTYONE_TEAMS_CAS_VERSION}"
+  check_empty "INPUT_FILE" "${INPUT_FILE}"
 }
 
 source "$(git rev-parse --show-toplevel)/utils/bump-fixtures-common.sh"
@@ -110,30 +109,30 @@ source "$(git rev-parse --show-toplevel)/utils/bump-fixtures-common.sh"
 parse_arguments "$@"
 
 # Set up temporary file handling for dry run
-file="$INPUT_FILE"
-if [[ $DRY_RUN == "true" ]]; then
-  tempfile=$(mktemp)
-  cp "$INPUT_FILE" "$tempfile"
-  file="$tempfile"
+file="${INPUT_FILE}"
+if [[ ${DRY_RUN} == "true" ]]; then
+  tempfile="$(mktemp)"
+  cp "${INPUT_FILE}" "${tempfile}"
+  file="${tempfile}"
   echo "Performing dry-run: Changes will be printed but not saved."
 fi
 
 # Determine the appropriate `sed` flags based on the OS type
 sed_flags="-i"
 delete_backups="false"
-if [[ $OSTYPE == "darwin"* ]]; then
+if [[ ${OSTYPE} == "darwin"* ]]; then
   sed_flags="-ib" # macOS requires a backup extension when using `-i`
   delete_backups="true"
 fi
 
 # Perform replacements in the file
-sed "$sed_flags" "s/^FIFTYONE_APP_VERSION=.*/FIFTYONE_APP_VERSION=$FIFTYONE_APP_VERSION/" "$file"
-sed "$sed_flags" "s/^FIFTYONE_TEAMS_API_VERSION=.*/FIFTYONE_TEAMS_API_VERSION=$FIFTYONE_TEAMS_API_VERSION/" "$file"
-sed "$sed_flags" "s/^FIFTYONE_TEAMS_APP_VERSION=.*/FIFTYONE_TEAMS_APP_VERSION=$FIFTYONE_TEAMS_APP_VERSION/" "$file"
-sed "$sed_flags" "s/^FIFTYONE_TEAMS_CAS_VERSION=.*/FIFTYONE_TEAMS_CAS_VERSION=$FIFTYONE_TEAMS_CAS_VERSION/" "$file"
+sed "${sed_flags}" "s/^FIFTYONE_APP_VERSION=.*/FIFTYONE_APP_VERSION=${FIFTYONE_APP_VERSION}/" "${file}"
+sed "${sed_flags}" "s/^FIFTYONE_TEAMS_API_VERSION=.*/FIFTYONE_TEAMS_API_VERSION=${FIFTYONE_TEAMS_API_VERSION}/" "${file}"
+sed "${sed_flags}" "s/^FIFTYONE_TEAMS_APP_VERSION=.*/FIFTYONE_TEAMS_APP_VERSION=${FIFTYONE_TEAMS_APP_VERSION}/" "${file}"
+sed "${sed_flags}" "s/^FIFTYONE_TEAMS_CAS_VERSION=.*/FIFTYONE_TEAMS_CAS_VERSION=${FIFTYONE_TEAMS_CAS_VERSION}/" "${file}"
 
 # Output the file contents (dry-run will print the content)
-cat "$file"
+cat "${file}"
 
 # Clean up backup file if on macOS
 if [[ $delete_backups == "true" ]]; then
@@ -142,5 +141,5 @@ fi
 
 # Remove temporary file if dry-run
 if [[ $DRY_RUN == "true" ]]; then
-  rm "$tempfile"
+  rm "${tempfile}"
 fi

--- a/utils/bump-fixtures-docker.sh
+++ b/utils/bump-fixtures-docker.sh
@@ -126,6 +126,7 @@ if [[ ${OSTYPE} == "darwin"* ]]; then
 fi
 
 # Perform replacements in the file
+sed "${sed_flags}" "s/^VERSION=.*/VERSION=${FIFTYONE_APP_VERSION}/" "${file}"
 sed "${sed_flags}" "s/^FIFTYONE_APP_VERSION=.*/FIFTYONE_APP_VERSION=${FIFTYONE_APP_VERSION}/" "${file}"
 sed "${sed_flags}" "s/^FIFTYONE_TEAMS_API_VERSION=.*/FIFTYONE_TEAMS_API_VERSION=${FIFTYONE_TEAMS_API_VERSION}/" "${file}"
 sed "${sed_flags}" "s/^FIFTYONE_TEAMS_APP_VERSION=.*/FIFTYONE_TEAMS_APP_VERSION=${FIFTYONE_TEAMS_APP_VERSION}/" "${file}"

--- a/utils/bump-fixtures-docker.sh
+++ b/utils/bump-fixtures-docker.sh
@@ -36,55 +36,55 @@ parse_arguments() {
         print_usage
         exit 0
         ;;
-      -a | --app-version*)
-        shift
-        if test $# -gt 0; then
-          FIFTYONE_APP_VERSION=$1
-        else
+      -a | --app-version)
+        if [[ -z ${2-} ]]; then
+          echo "Error: --app-version requires a value" >&2
           print_usage
           exit 1
         fi
-        shift
+        FIFTYONE_APP_VERSION="$2"
+        shift 2
         ;;
-      -i | --api-version*)
-        shift
-        if test $# -gt 0; then
-          FIFTYONE_TEAMS_API_VERSION=$1
-        else
+      -i | --api-version)
+        if [[ -z ${2-} ]]; then
+          echo "Error: --api-version requires a value" >&2
           print_usage
           exit 1
         fi
-        shift
+        FIFTYONE_TEAMS_API_VERSION="$2"
+        shift 2
         ;;
-      -t | --teams-app-version*)
-        shift
-        if test $# -gt 0; then
-          FIFTYONE_TEAMS_APP_VERSION=$1
-        else
+      -t | --teams-app-version)
+        if [[ -z ${2-} ]]; then
+          echo "Error: --teams-app-version requires a value" >&2
           print_usage
           exit 1
         fi
-        shift
+        FIFTYONE_TEAMS_APP_VERSION="$2"
+        shift 2
+        ;;
+      -c | --cas-version)
+        if [[ -z ${2-} ]]; then
+          echo "Error: --cas-version requires a value" >&2
+          print_usage
+          exit 1
+        fi
+        FIFTYONE_TEAMS_CAS_VERSION="$2"
+        shift 2
         ;;
       -f | --file*)
-        shift
-        INPUT_FILE="$1"
+        if [[ -z ${2-} ]]; then
+          echo "Error: -file requires a file" >&2
+          print_usage
+          exit 1
+        fi
+        INPUT_FILE="$2"
         if [[ ! -f $INPUT_FILE ]]; then
           echo "Error: File '$INPUT_FILE' does not exist." >&2
           print_usage
           exit 1
         fi
-        shift
-        ;;
-      -c | --cas-version*)
-        shift
-        if test $# -gt 0; then
-          FIFTYONE_TEAMS_CAS_VERSION=$1
-        else
-          print_usage
-          exit 1
-        fi
-        shift
+        shift 2
         ;;
       -d | --dry-run)
         DRY_RUN="true"
@@ -104,7 +104,7 @@ parse_arguments() {
   check_empty "INPUT_FILE" "$INPUT_FILE"
 }
 
-source ./utils/bump-fixtures-common.sh
+source "$(git rev-parse --show-toplevel)/utils/bump-fixtures-common.sh"
 
 # Parse the arguments
 parse_arguments "$@"

--- a/utils/bump-fixtures-helm.sh
+++ b/utils/bump-fixtures-helm.sh
@@ -42,7 +42,7 @@ parse_arguments() {
           print_usage
           exit 1
         fi
-        FIFTYONE_APP_VERSION="$2"
+        FIFTYONE_APP_VERSION="${2}"
         shift 2
         ;;
       -i | --api-version)
@@ -51,7 +51,7 @@ parse_arguments() {
           print_usage
           exit 1
         fi
-        FIFTYONE_TEAMS_API_VERSION="$2"
+        FIFTYONE_TEAMS_API_VERSION="${2}"
         shift 2
         ;;
       -t | --teams-app-version)
@@ -60,7 +60,7 @@ parse_arguments() {
           print_usage
           exit 1
         fi
-        FIFTYONE_TEAMS_APP_VERSION="$2"
+        FIFTYONE_TEAMS_APP_VERSION="${2}"
         shift 2
         ;;
       -c | --cas-version)
@@ -69,7 +69,7 @@ parse_arguments() {
           print_usage
           exit 1
         fi
-        FIFTYONE_TEAMS_CAS_VERSION="$2"
+        FIFTYONE_TEAMS_CAS_VERSION="${2}"
         shift 2
         ;;
       -f | --file*)
@@ -79,8 +79,8 @@ parse_arguments() {
           exit 1
         fi
         INPUT_FILE="$2"
-        if [[ ! -f $INPUT_FILE ]]; then
-          echo "Error: File '$INPUT_FILE' does not exist." >&2
+        if [[ ! -f ${INPUT_FILE} ]]; then
+          echo "Error: File '${INPUT_FILE}' does not exist." >&2
           print_usage
           exit 1
         fi
@@ -96,11 +96,11 @@ parse_arguments() {
     esac
   done
   # Check that all version variables are set
-  check_empty "FIFTYONE_APP_VERSION" "$FIFTYONE_APP_VERSION"
-  check_empty "FIFTYONE_TEAMS_API_VERSION" "$FIFTYONE_TEAMS_API_VERSION"
-  check_empty "FIFTYONE_TEAMS_APP_VERSION" "$FIFTYONE_TEAMS_APP_VERSION"
-  check_empty "FIFTYONE_TEAMS_CAS_VERSION" "$FIFTYONE_TEAMS_CAS_VERSION"
-  check_empty "INPUT_FILE" "$INPUT_FILE"
+  check_empty "FIFTYONE_APP_VERSION" "${FIFTYONE_APP_VERSION}"
+  check_empty "FIFTYONE_TEAMS_API_VERSION" "${FIFTYONE_TEAMS_API_VERSION}"
+  check_empty "FIFTYONE_TEAMS_APP_VERSION" "${FIFTYONE_TEAMS_APP_VERSION}"
+  check_empty "FIFTYONE_TEAMS_CAS_VERSION" "${FIFTYONE_TEAMS_CAS_VERSION}"
+  check_empty "INPUT_FILE" "${INPUT_FILE}"
 }
 
 source "$(git rev-parse --show-toplevel)/utils/bump-fixtures-common.sh"
@@ -108,11 +108,11 @@ source "$(git rev-parse --show-toplevel)/utils/bump-fixtures-common.sh"
 parse_arguments "$@"
 
 # Set up temporary file handling for dry run
-file="$INPUT_FILE"
-if [[ $DRY_RUN == "true" ]]; then
-  tempfile=$(mktemp)
-  cp "$INPUT_FILE" "$tempfile"
-  file="$tempfile"
+file="${INPUT_FILE}"
+if [[ ${DRY_RUN} == "true" ]]; then
+  tempfile="$(mktemp)"
+  cp "${INPUT_FILE}" "${tempfile}"
+  file="${tempfile}"
   echo "Performing dry-run: Changes will be printed but not saved."
 fi
 
@@ -120,25 +120,25 @@ fi
 yq_flags="-i"
 
 # Perform replacements in the file
-yq "$yq_flags" ".appSettings.image.tag = \"$FIFTYONE_APP_VERSION\"" "$file"
-yq "$yq_flags" ".apiSettings.image.tag = \"$FIFTYONE_TEAMS_API_VERSION\"" "$file"
-yq "$yq_flags" ".teamsAppSettings.image.tag = \"$FIFTYONE_TEAMS_APP_VERSION\"" "$file"
-yq "$yq_flags" ".casSettings.image.tag = \"$FIFTYONE_TEAMS_CAS_VERSION\"" "$file"
-yq "$yq_flags" ".casSettings.image.tag = \"$FIFTYONE_TEAMS_CAS_VERSION\"" "$file"
-yq "$yq_flags" ".casSettings.image.tag = \"$FIFTYONE_TEAMS_CAS_VERSION\"" "$file"
+yq "$yq_flags" ".appSettings.image.tag = \"${FIFTYONE_APP_VERSION}\"" "${file}"
+yq "$yq_flags" ".apiSettings.image.tag = \"${FIFTYONE_TEAMS_API_VERSION}\"" "${file}"
+yq "$yq_flags" ".teamsAppSettings.image.tag = \"${FIFTYONE_TEAMS_APP_VERSION}\"" "${file}"
+yq "$yq_flags" ".casSettings.image.tag = \"${FIFTYONE_TEAMS_CAS_VERSION}\"" "${file}"
+yq "$yq_flags" ".casSettings.image.tag = \"${FIFTYONE_TEAMS_CAS_VERSION}\"" "${file}"
+yq "$yq_flags" ".casSettings.image.tag = \"${FIFTYONE_TEAMS_CAS_VERSION}\"" "${file}"
 
 if yq -e ".pluginsSettings" "${file}" >/dev/null; then
-  yq "$yq_flags" ".pluginsSettings.image.tag = \"v${FIFTYONE_APP_VERSION//+/_}\"" "${file}"
+  yq "$yq_flags" ".pluginsSettings.image.tag = \"${FIFTYONE_APP_VERSION}\"" "${file}"
 fi
 
 if yq -e ".delegatedOperatorExecutorSettings" "${file}" >/dev/null; then
-  yq "$yq_flags" ".delegatedOperatorExecutorSettings.image.tag = \"v${FIFTYONE_APP_VERSION//+/_}\"" "${file}"
+  yq "$yq_flags" ".delegatedOperatorExecutorSettings.image.tag = \"${FIFTYONE_APP_VERSION}\"" "${file}"
 fi
 
 # Output the file contents (dry-run will print the content)
-cat "$file"
+cat "${file}"
 
 # Remove temporary file if dry-run
 if [[ $DRY_RUN == "true" ]]; then
-  rm "$tempfile"
+  rm "${tempfile}"
 fi

--- a/utils/bump-fixtures-helm.sh
+++ b/utils/bump-fixtures-helm.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Default values for the version variables (can be empty, but will need to be set by the user)
+FIFTYONE_APP_VERSION=''
+FIFTYONE_TEAMS_API_VERSION=''
+FIFTYONE_TEAMS_APP_VERSION=''
+FIFTYONE_TEAMS_CAS_VERSION=''
+INPUT_FILE=''
+DRY_RUN='false'
+
+print_usage() {
+  local package
+  package=$(basename "$0")
+  echo "$package - Bump versions in docker-compose fixture."
+  echo " "
+  echo "$package [options]"
+  echo " "
+  echo "options:"
+  echo "-h, --help                                          show brief help"
+  echo "-a, --app-version=FIFTYONE_APP_VERSION              Set Fiftyone App Version"
+  echo "-i, --api-version=FIFTYONE_TEAMS_API_VERSION        Set Fiftyone Teams API Version"
+  echo "-t, --teams-app-version=FIFTYONE_TEAMS_APP_VERSION  Set Fiftyone Teams App Version"
+  echo "-c, --cas-version=FIFTYONE_TEAMS_CAS_VERSION        Set Fiftyone CAS Version"
+  echo "-f, --file=INPUT_FILE                               .env file to update"
+  echo "-d, --dry-run                                       Perform a dry-run (print to stdout instead of modifying the file)"
+}
+
+# Parse command-line options
+parse_arguments() {
+  while test $# -gt 0; do
+    case "$1" in
+      -h | --help)
+        print_usage
+        exit 0
+        ;;
+      -a | --app-version)
+        check_empty "--app-version" "$2"
+        FIFTYONE_APP_VERSION="$2"
+        shift 2
+        ;;
+      -i | --api-version)
+        check_empty "--api-version" "$2"
+        FIFTYONE_TEAMS_API_VERSION="$2"
+        shift 2
+        ;;
+      -t | --teams-app-version)
+        check_empty "--teams-app-version" "$2"
+        FIFTYONE_TEAMS_APP_VERSION="$2"
+        shift 2
+        ;;
+      -c | --cas-version)
+        check_empty "--cas-version" "$2"
+        FIFTYONE_TEAMS_CAS_VERSION="$2"
+        shift 2
+        ;;
+      -f | --file)
+        check_empty "--file" "$2"
+        INPUT_FILE="$2"
+        if [[ ! -f $INPUT_FILE ]]; then
+          echo "Error: File '$INPUT_FILE' does not exist." >&2
+          print_usage
+          exit 1
+        fi
+        shift 2
+        ;;
+      -d | --dry-run)
+        DRY_RUN="true"
+        shift
+        ;;
+      *)
+        echo "Error: Unknown option: $1" >&2
+        print_usage
+        exit 1
+        ;;
+    esac
+  done
+
+  # Check that all version variables are set
+  check_empty "FIFTYONE_APP_VERSION" "$FIFTYONE_APP_VERSION"
+  check_empty "FIFTYONE_TEAMS_API_VERSION" "$FIFTYONE_TEAMS_API_VERSION"
+  check_empty "FIFTYONE_TEAMS_APP_VERSION" "$FIFTYONE_TEAMS_APP_VERSION"
+  check_empty "FIFTYONE_TEAMS_CAS_VERSION" "$FIFTYONE_TEAMS_CAS_VERSION"
+  check_empty "INPUT_FILE" "$INPUT_FILE"
+}
+
+source ./utils/bump-fixtures-common.sh
+
+parse_arguments "$@"
+
+# Set up temporary file handling for dry run
+file="$INPUT_FILE"
+if [[ $DRY_RUN == "true" ]]; then
+  tempfile=$(mktemp)
+  cp "$INPUT_FILE" "$tempfile"
+  file="$tempfile"
+  echo "Performing dry-run: Changes will be printed but not saved."
+fi
+
+# Determine the appropriate `sed` flags based on the OS type
+yq_flags="-i"
+
+# Perform replacements in the file
+yq "$yq_flags" ".appSettings.image.tag = \"$FIFTYONE_APP_VERSION\"" "$file"
+yq "$yq_flags" ".apiSettings.image.tag = \"$FIFTYONE_TEAMS_API_VERSION\"" "$file"
+yq "$yq_flags" ".teamsAppSettings.image.tag = \"$FIFTYONE_TEAMS_APP_VERSION\"" "$file"
+yq "$yq_flags" ".casSettings.image.tag = \"$FIFTYONE_TEAMS_CAS_VERSION\"" "$file"
+yq "$yq_flags" ".casSettings.image.tag = \"$FIFTYONE_TEAMS_CAS_VERSION\"" "$file"
+yq "$yq_flags" ".casSettings.image.tag = \"$FIFTYONE_TEAMS_CAS_VERSION\"" "$file"
+
+if yq -e ".pluginsSettings" "${file}" >/dev/null; then
+  yq "$yq_flags" ".pluginsSettings.image.tag = \"v${FIFTYONE_APP_VERSION//+/_}\"" "${file}"
+fi
+
+if yq -e ".delegatedOperatorExecutorSettings" "${file}" >/dev/null; then
+  yq "$yq_flags" ".delegatedOperatorExecutorSettings.image.tag = \"v${FIFTYONE_APP_VERSION//+/_}\"" "${file}"
+fi
+
+# Output the file contents (dry-run will print the content)
+cat "$file"
+
+# Remove temporary file if dry-run
+if [[ $DRY_RUN == "true" ]]; then
+  rm "$tempfile"
+fi

--- a/utils/bump-fixtures-helm.sh
+++ b/utils/bump-fixtures-helm.sh
@@ -13,7 +13,7 @@ DRY_RUN='false'
 print_usage() {
   local package
   package=$(basename "$0")
-  echo "$package - Bump versions in docker-compose fixture."
+  echo "$package - Bump versions in a helm fixture."
   echo " "
   echo "$package [options]"
   echo " "

--- a/utils/bump-fixtures-helm.sh
+++ b/utils/bump-fixtures-helm.sh
@@ -36,55 +36,55 @@ parse_arguments() {
         print_usage
         exit 0
         ;;
-      -a | --app-version*)
-        shift
-        if test $# -gt 0; then
-          FIFTYONE_APP_VERSION=$1
-        else
+      -a | --app-version)
+        if [[ -z ${2-} ]]; then
+          echo "Error: --app-version requires a value" >&2
           print_usage
           exit 1
         fi
-        shift
+        FIFTYONE_APP_VERSION="$2"
+        shift 2
         ;;
-      -i | --api-version*)
-        shift
-        if test $# -gt 0; then
-          FIFTYONE_TEAMS_API_VERSION=$1
-        else
+      -i | --api-version)
+        if [[ -z ${2-} ]]; then
+          echo "Error: --api-version requires a value" >&2
           print_usage
           exit 1
         fi
-        shift
+        FIFTYONE_TEAMS_API_VERSION="$2"
+        shift 2
         ;;
-      -t | --teams-app-version*)
-        shift
-        if test $# -gt 0; then
-          FIFTYONE_TEAMS_APP_VERSION=$1
-        else
+      -t | --teams-app-version)
+        if [[ -z ${2-} ]]; then
+          echo "Error: --teams-app-version requires a value" >&2
           print_usage
           exit 1
         fi
-        shift
+        FIFTYONE_TEAMS_APP_VERSION="$2"
+        shift 2
+        ;;
+      -c | --cas-version)
+        if [[ -z ${2-} ]]; then
+          echo "Error: --cas-version requires a value" >&2
+          print_usage
+          exit 1
+        fi
+        FIFTYONE_TEAMS_CAS_VERSION="$2"
+        shift 2
         ;;
       -f | --file*)
-        shift
-        INPUT_FILE="$1"
+        if [[ -z ${2-} ]]; then
+          echo "Error: -file requires a file" >&2
+          print_usage
+          exit 1
+        fi
+        INPUT_FILE="$2"
         if [[ ! -f $INPUT_FILE ]]; then
           echo "Error: File '$INPUT_FILE' does not exist." >&2
           print_usage
           exit 1
         fi
-        shift
-        ;;
-      -c | --cas-version*)
-        shift
-        if test $# -gt 0; then
-          FIFTYONE_TEAMS_CAS_VERSION=$1
-        else
-          print_usage
-          exit 1
-        fi
-        shift
+        shift 2
         ;;
       -d | --dry-run)
         DRY_RUN="true"
@@ -95,7 +95,6 @@ parse_arguments() {
         ;;
     esac
   done
-
   # Check that all version variables are set
   check_empty "FIFTYONE_APP_VERSION" "$FIFTYONE_APP_VERSION"
   check_empty "FIFTYONE_TEAMS_API_VERSION" "$FIFTYONE_TEAMS_API_VERSION"
@@ -104,7 +103,7 @@ parse_arguments() {
   check_empty "INPUT_FILE" "$INPUT_FILE"
 }
 
-source ./utils/bump-fixtures-common.sh
+source "$(git rev-parse --show-toplevel)/utils/bump-fixtures-common.sh"
 
 parse_arguments "$@"
 

--- a/utils/bump-fixtures-helm.sh
+++ b/utils/bump-fixtures-helm.sh
@@ -29,50 +29,69 @@ print_usage() {
 
 # Parse command-line options
 parse_arguments() {
+
   while test $# -gt 0; do
     case "$1" in
       -h | --help)
         print_usage
         exit 0
         ;;
-      -a | --app-version)
-        check_empty "--app-version" "$2"
-        FIFTYONE_APP_VERSION="$2"
-        shift 2
+      -a | --app-version*)
+        shift
+        if test $# -gt 0; then
+          FIFTYONE_APP_VERSION=$1
+        else
+          print_usage
+          exit 1
+        fi
+        shift
         ;;
-      -i | --api-version)
-        check_empty "--api-version" "$2"
-        FIFTYONE_TEAMS_API_VERSION="$2"
-        shift 2
+      -i | --api-version*)
+        shift
+        if test $# -gt 0; then
+          FIFTYONE_TEAMS_API_VERSION=$1
+        else
+          print_usage
+          exit 1
+        fi
+        shift
         ;;
-      -t | --teams-app-version)
-        check_empty "--teams-app-version" "$2"
-        FIFTYONE_TEAMS_APP_VERSION="$2"
-        shift 2
+      -t | --teams-app-version*)
+        shift
+        if test $# -gt 0; then
+          FIFTYONE_TEAMS_APP_VERSION=$1
+        else
+          print_usage
+          exit 1
+        fi
+        shift
         ;;
-      -c | --cas-version)
-        check_empty "--cas-version" "$2"
-        FIFTYONE_TEAMS_CAS_VERSION="$2"
-        shift 2
-        ;;
-      -f | --file)
-        check_empty "--file" "$2"
-        INPUT_FILE="$2"
+      -f | --file*)
+        shift
+        INPUT_FILE="$1"
         if [[ ! -f $INPUT_FILE ]]; then
           echo "Error: File '$INPUT_FILE' does not exist." >&2
           print_usage
           exit 1
         fi
-        shift 2
+        shift
+        ;;
+      -c | --cas-version*)
+        shift
+        if test $# -gt 0; then
+          FIFTYONE_TEAMS_CAS_VERSION=$1
+        else
+          print_usage
+          exit 1
+        fi
+        shift
         ;;
       -d | --dry-run)
         DRY_RUN="true"
         shift
         ;;
       *)
-        echo "Error: Unknown option: $1" >&2
-        print_usage
-        exit 1
+        break
         ;;
     esac
   done

--- a/utils/bump-fixtures.sh
+++ b/utils/bump-fixtures.sh
@@ -26,7 +26,7 @@ print_usage() {
   echo "-d, --dry-run                                       Perform a dry-run (print to stdout instead of modifying the file)"
 }
 
-source "$GIT_ROOT/utils/bump-fixtures-common.sh"
+source "${GIT_ROOT}/utils/bump-fixtures-common.sh"
 
 parse_arguments() {
   while test $# -gt 0; do

--- a/utils/bump-fixtures.sh
+++ b/utils/bump-fixtures.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+FIFTYONE_APP_VERSION=''
+FIFTYONE_TEAMS_API_VERSION=''
+FIFTYONE_TEAMS_APP_VERSION=''
+FIFTYONE_TEAMS_CAS_VERSION=''
+DRY_RUN='false'
+
+print_usage() {
+  local package
+  package=$(basename "$0")
+  echo "$package - Bump versions in docker-compose fixture."
+  echo " "
+  echo "$package [options]"
+  echo " "
+  echo "options:"
+  echo "-h, --help                                          show brief help"
+  echo "-a, --app-version=FIFTYONE_APP_VERSION              Set Fiftyone App Version"
+  echo "-i, --api-version=FIFTYONE_TEAMS_API_VERSION        Set Fiftyone Teams API Version"
+  echo "-t, --teams-app-version=FIFTYONE_TEAMS_APP_VERSION  Set Fiftyone Teams App Version"
+  echo "-c, --cas-version=FIFTYONE_TEAMS_CAS_VERSION        Set Fiftyone CAS Version"
+  echo "-d, --dry-run                                       Perform a dry-run (print to stdout instead of modifying the file)"
+}
+
+source ./utils/bump-fixtures-common.sh
+
+parse_arguments() {
+  while test $# -gt 0; do
+    case "$1" in
+      -h | --help)
+        print_usage
+        exit 0
+        ;;
+      -a | --app-version)
+        check_empty "--app-version" "$2"
+        FIFTYONE_APP_VERSION="$2"
+        shift 2
+        ;;
+      -i | --api-version)
+        check_empty "--api-version" "$2"
+        FIFTYONE_TEAMS_API_VERSION="$2"
+        shift 2
+        ;;
+      -t | --teams-app-version)
+        check_empty "--teams-app-version" "$2"
+        FIFTYONE_TEAMS_APP_VERSION="$2"
+        shift 2
+        ;;
+      -c | --cas-version)
+        check_empty "--cas-version" "$2"
+        FIFTYONE_TEAMS_CAS_VERSION="$2"
+        shift 2
+        ;;
+      -d | --dry-run)
+        DRY_RUN="true"
+        shift
+        ;;
+      *)
+        echo "Error: Unknown option: $1" >&2
+        print_usage
+        exit 1
+        ;;
+    esac
+  done
+
+  # Check that all version variables are set
+  check_empty "FIFTYONE_APP_VERSION" "$FIFTYONE_APP_VERSION"
+  check_empty "FIFTYONE_TEAMS_API_VERSION" "$FIFTYONE_TEAMS_API_VERSION"
+  check_empty "FIFTYONE_TEAMS_APP_VERSION" "$FIFTYONE_TEAMS_APP_VERSION"
+  check_empty "FIFTYONE_TEAMS_CAS_VERSION" "$FIFTYONE_TEAMS_CAS_VERSION"
+}
+
+# Parse the arguments
+parse_arguments "$@"
+
+DOCKER_FIXTURES=(
+  tests/fixtures/docker/integration_legacy_auth.env
+  tests/fixtures/docker/integration_internal_auth.env
+)
+
+HELM_FIXTURES=(
+  tests/fixtures/helm/integration_values.yaml
+)
+
+dry_run_flag=""
+if [[ $DRY_RUN == "true" ]]; then
+  dry_run_flag="-d"
+fi
+
+for fixture in "${DOCKER_FIXTURES[@]}"; do
+  ./utils/bump-fixtures-docker.sh \
+    -a "$FIFTYONE_APP_VERSION" \
+    -i "$FIFTYONE_TEAMS_API_VERSION" \
+    -t "$FIFTYONE_TEAMS_APP_VERSION" \
+    -c "$FIFTYONE_TEAMS_CAS_VERSION" \
+    -f "$fixture" $dry_run_flag
+done
+
+for fixture in "${HELM_FIXTURES[@]}"; do
+  ./utils/bump-fixtures-helm.sh \
+    -a "$FIFTYONE_APP_VERSION" \
+    -i "$FIFTYONE_TEAMS_API_VERSION" \
+    -t "$FIFTYONE_TEAMS_APP_VERSION" \
+    -c "$FIFTYONE_TEAMS_CAS_VERSION" \
+    -f "$fixture" $dry_run_flag
+done

--- a/utils/bump-fixtures.sh
+++ b/utils/bump-fixtures.sh
@@ -33,34 +33,52 @@ parse_arguments() {
         print_usage
         exit 0
         ;;
-      -a | --app-version)
-        check_empty "--app-version" "$2"
-        FIFTYONE_APP_VERSION="$2"
-        shift 2
+      -a | --app-version*)
+        shift
+        if test $# -gt 0; then
+          FIFTYONE_APP_VERSION=$1
+        else
+          print_usage
+          exit 1
+        fi
+        shift
         ;;
-      -i | --api-version)
-        check_empty "--api-version" "$2"
-        FIFTYONE_TEAMS_API_VERSION="$2"
-        shift 2
+      -i | --api-version*)
+        shift
+        if test $# -gt 0; then
+          FIFTYONE_TEAMS_API_VERSION=$1
+        else
+          print_usage
+          exit 1
+        fi
+        shift
         ;;
-      -t | --teams-app-version)
-        check_empty "--teams-app-version" "$2"
-        FIFTYONE_TEAMS_APP_VERSION="$2"
-        shift 2
+      -t | --teams-app-version*)
+        shift
+        if test $# -gt 0; then
+          FIFTYONE_TEAMS_APP_VERSION=$1
+        else
+          print_usage
+          exit 1
+        fi
+        shift
         ;;
-      -c | --cas-version)
-        check_empty "--cas-version" "$2"
-        FIFTYONE_TEAMS_CAS_VERSION="$2"
-        shift 2
+      -c | --cas-version*)
+        shift
+        if test $# -gt 0; then
+          FIFTYONE_TEAMS_CAS_VERSION=$1
+        else
+          print_usage
+          exit 1
+        fi
+        shift
         ;;
       -d | --dry-run)
         DRY_RUN="true"
         shift
         ;;
       *)
-        echo "Error: Unknown option: $1" >&2
-        print_usage
-        exit 1
+        break
         ;;
     esac
   done

--- a/utils/bump-fixtures.sh
+++ b/utils/bump-fixtures.sh
@@ -13,7 +13,7 @@ GIT_ROOT=$(git rev-parse --show-toplevel)
 print_usage() {
   local package
   package=$(basename "$0")
-  echo "$package - Bump versions in docker-compose fixture."
+  echo "$package - Bump versions in docker-compose and helm fixtures."
   echo " "
   echo "$package [options]"
   echo " "

--- a/utils/bump-fixtures.sh
+++ b/utils/bump-fixtures.sh
@@ -41,7 +41,7 @@ parse_arguments() {
           print_usage
           exit 1
         fi
-        FIFTYONE_APP_VERSION="$2"
+        FIFTYONE_APP_VERSION="${2}"
         shift 2
         ;;
       -i | --api-version)
@@ -50,7 +50,7 @@ parse_arguments() {
           print_usage
           exit 1
         fi
-        FIFTYONE_TEAMS_API_VERSION="$2"
+        FIFTYONE_TEAMS_API_VERSION="${2}"
         shift 2
         ;;
       -t | --teams-app-version)
@@ -59,7 +59,7 @@ parse_arguments() {
           print_usage
           exit 1
         fi
-        FIFTYONE_TEAMS_APP_VERSION="$2"
+        FIFTYONE_TEAMS_APP_VERSION="${2}"
         shift 2
         ;;
       -c | --cas-version)
@@ -68,7 +68,7 @@ parse_arguments() {
           print_usage
           exit 1
         fi
-        FIFTYONE_TEAMS_CAS_VERSION="$2"
+        FIFTYONE_TEAMS_CAS_VERSION="${2}"
         shift 2
         ;;
       -d | --dry-run)
@@ -84,10 +84,10 @@ parse_arguments() {
   done
 
   # Check that all version variables are set
-  check_empty "FIFTYONE_APP_VERSION" "$FIFTYONE_APP_VERSION"
-  check_empty "FIFTYONE_TEAMS_API_VERSION" "$FIFTYONE_TEAMS_API_VERSION"
-  check_empty "FIFTYONE_TEAMS_APP_VERSION" "$FIFTYONE_TEAMS_APP_VERSION"
-  check_empty "FIFTYONE_TEAMS_CAS_VERSION" "$FIFTYONE_TEAMS_CAS_VERSION"
+  check_empty "FIFTYONE_APP_VERSION" "${FIFTYONE_APP_VERSION}"
+  check_empty "FIFTYONE_TEAMS_API_VERSION" "${FIFTYONE_TEAMS_API_VERSION}"
+  check_empty "FIFTYONE_TEAMS_APP_VERSION" "${FIFTYONE_TEAMS_APP_VERSION}"
+  check_empty "FIFTYONE_TEAMS_CAS_VERSION" "${FIFTYONE_TEAMS_CAS_VERSION}"
 }
 
 # Parse the arguments
@@ -108,19 +108,19 @@ if [[ $DRY_RUN == "true" ]]; then
 fi
 
 for fixture in "${DOCKER_FIXTURES[@]}"; do
-  "$GIT_ROOT/utils/bump-fixtures-docker.sh" \
-    -a "$FIFTYONE_APP_VERSION" \
-    -i "$FIFTYONE_TEAMS_API_VERSION" \
-    -t "$FIFTYONE_TEAMS_APP_VERSION" \
-    -c "$FIFTYONE_TEAMS_CAS_VERSION" \
-    -f "$fixture" $dry_run_flag
+  "${GIT_ROOT}/utils/bump-fixtures-docker.sh" \
+    -a "${FIFTYONE_APP_VERSION}" \
+    -i "${FIFTYONE_TEAMS_API_VERSION}" \
+    -t "${FIFTYONE_TEAMS_APP_VERSION}" \
+    -c "${FIFTYONE_TEAMS_CAS_VERSION}" \
+    -f "${fixture}" $dry_run_flag
 done
 
 for fixture in "${HELM_FIXTURES[@]}"; do
-  "$GIT_ROOT/utils/bump-fixtures-helm.sh" \
-    -a "$FIFTYONE_APP_VERSION" \
-    -i "$FIFTYONE_TEAMS_API_VERSION" \
-    -t "$FIFTYONE_TEAMS_APP_VERSION" \
-    -c "$FIFTYONE_TEAMS_CAS_VERSION" \
-    -f "$fixture" $dry_run_flag
+  "${GIT_ROOT}/utils/bump-fixtures-helm.sh" \
+    -a "${FIFTYONE_APP_VERSION}" \
+    -i "${FIFTYONE_TEAMS_API_VERSION}" \
+    -t "${FIFTYONE_TEAMS_APP_VERSION}" \
+    -c "${FIFTYONE_TEAMS_CAS_VERSION}" \
+    -f "${fixture}" $dry_run_flag
 done

--- a/utils/bump-fixtures.sh
+++ b/utils/bump-fixtures.sh
@@ -8,6 +8,8 @@ FIFTYONE_TEAMS_APP_VERSION=''
 FIFTYONE_TEAMS_CAS_VERSION=''
 DRY_RUN='false'
 
+GIT_ROOT=$(git rev-parse --show-toplevel)
+
 print_usage() {
   local package
   package=$(basename "$0")
@@ -24,7 +26,7 @@ print_usage() {
   echo "-d, --dry-run                                       Perform a dry-run (print to stdout instead of modifying the file)"
 }
 
-source ./utils/bump-fixtures-common.sh
+source "$GIT_ROOT/utils/bump-fixtures-common.sh"
 
 parse_arguments() {
   while test $# -gt 0; do
@@ -33,52 +35,50 @@ parse_arguments() {
         print_usage
         exit 0
         ;;
-      -a | --app-version*)
-        shift
-        if test $# -gt 0; then
-          FIFTYONE_APP_VERSION=$1
-        else
+      -a | --app-version)
+        if [[ -z ${2-} ]]; then
+          echo "Error: --app-version requires a value" >&2
           print_usage
           exit 1
         fi
-        shift
+        FIFTYONE_APP_VERSION="$2"
+        shift 2
         ;;
-      -i | --api-version*)
-        shift
-        if test $# -gt 0; then
-          FIFTYONE_TEAMS_API_VERSION=$1
-        else
+      -i | --api-version)
+        if [[ -z ${2-} ]]; then
+          echo "Error: --api-version requires a value" >&2
           print_usage
           exit 1
         fi
-        shift
+        FIFTYONE_TEAMS_API_VERSION="$2"
+        shift 2
         ;;
-      -t | --teams-app-version*)
-        shift
-        if test $# -gt 0; then
-          FIFTYONE_TEAMS_APP_VERSION=$1
-        else
+      -t | --teams-app-version)
+        if [[ -z ${2-} ]]; then
+          echo "Error: --teams-app-version requires a value" >&2
           print_usage
           exit 1
         fi
-        shift
+        FIFTYONE_TEAMS_APP_VERSION="$2"
+        shift 2
         ;;
-      -c | --cas-version*)
-        shift
-        if test $# -gt 0; then
-          FIFTYONE_TEAMS_CAS_VERSION=$1
-        else
+      -c | --cas-version)
+        if [[ -z ${2-} ]]; then
+          echo "Error: --cas-version requires a value" >&2
           print_usage
           exit 1
         fi
-        shift
+        FIFTYONE_TEAMS_CAS_VERSION="$2"
+        shift 2
         ;;
       -d | --dry-run)
         DRY_RUN="true"
         shift
         ;;
       *)
-        break
+        echo "Error: Unknown option: $1" >&2
+        print_usage
+        exit 1
         ;;
     esac
   done
@@ -108,7 +108,7 @@ if [[ $DRY_RUN == "true" ]]; then
 fi
 
 for fixture in "${DOCKER_FIXTURES[@]}"; do
-  ./utils/bump-fixtures-docker.sh \
+  "$GIT_ROOT/utils/bump-fixtures-docker.sh" \
     -a "$FIFTYONE_APP_VERSION" \
     -i "$FIFTYONE_TEAMS_API_VERSION" \
     -t "$FIFTYONE_TEAMS_APP_VERSION" \
@@ -117,7 +117,7 @@ for fixture in "${DOCKER_FIXTURES[@]}"; do
 done
 
 for fixture in "${HELM_FIXTURES[@]}"; do
-  ./utils/bump-fixtures-helm.sh \
+  "$GIT_ROOT/utils/bump-fixtures-helm.sh" \
     -a "$FIFTYONE_APP_VERSION" \
     -i "$FIFTYONE_TEAMS_API_VERSION" \
     -t "$FIFTYONE_TEAMS_APP_VERSION" \


### PR DESCRIPTION
# Rationale

Over the last few releases, our fixture files in the fiftyone-teams-app-deploy repo have been behind (as opposed to progressing with the rest of the files).

This PR adds a few supporting scripts to support that. I decided to break it up with three scripts:

1. A script to update docker compose fixtures
2. A script to update helm fixtures
3. A script to run the above (i.e. during CI)

The thinking was that it would be easier for an engineer to run them one-off if needed (not that updating files is all that hard).

## Changes

Three new scripts have been added (see above).

### A script to update docker compose fixtures

This script updates the `.env` files we use for integration test fixtures
Essentially just uses `sed` with the proper flags to update files in place.

###  A script to update helm fixtures
This script updates the `values.yaml` files we use for integration test fixtures
Essentially just uses `yq` with the proper flags to update files in place.

### A script to run the above (i.e. during CI)
Just runs the above two scripts to update the expected files during CI.

<details open>
<summary>Some implementation details</summary>
<br>
<ol>
<li>Uses flags instead of environment variables to make it easier for people to run adhoc and validate args. Each script gets its own set of flags.</li>
<li>Each script gets its own <code>print_usage</code> command. Each is then passed to the common <code>check_empty</code> function and is used if needed.</li>
<li>There is a dry-run flag to test any validations.</li>
<li>There is some special darwin handling as it has different flags than GNU-sed.</li>
</ol>
</details>
Checklist

* [x] This PR maintains parity between Docker Compose and Helm

## Testing

### Example with docker fixtures

```shell
$ ./utils/bump-fixtures.sh -a 2.5.0 -i 2.5.0 -t 2.5.0 -c 2.5.0 -d
# Outputs
.
.
.
VERSION=2.5.0
FIFTYONE_APP_VERSION=2.5.0
FIFTYONE_TEAMS_API_VERSION=2.5.0
FIFTYONE_TEAMS_APP_VERSION=2.5.0
FIFTYONE_TEAMS_CAS_VERSION=2.5.0
```

### Example with helm fixtures

```shell
$ ./utils/bump-fixtures.sh -a 2.5.0 -i 2.5.0 -t 2.5.0 -c 2.5.0 -d
# Outputs
.
.
.
teamsAppSettings:
  dnsName: local.fiftyone.ai
  # env:
  #   # For local development without TLS certs, set `APP_USE_HTTPS=false` to
  #   # prohibit the app from setting Redirect URL protocol to `https`.
  #   # Must be set in both `appSettings.env` and `teamsAppSettings.env`.
  #   # Can be true, when using cert-manager with self-signed certificates
  #   APP_USE_HTTPS: false
  image:
    # See https://console.cloud.google.com/artifacts/docker/computer-vision-team/us-central1/dev-docker?project=computer-vision-team
    repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-teams-app
    # Note: the naming convention for the image `fiftyone-teams-app` differs from
    # the other images (`fiftyone-app`, `fiftyone-app` and `fiftyone-teams-api`).
    # The others are `vW.X.Y.devZ` (note `.devZ` vs `-dev.Z`).
    # This is a byproduct of `npm` versioning versus Python PEP 440.
    pullPolicy: IfNotPresent
    tag: 2.5.0
```

Usage:

```shell
bump-fixtures.sh - Bump versions in docker-compose and helm fixtures.
 
bump-fixtures.sh [options]
 
options:
-h, --help                                          show brief help
-a, --app-version=FIFTYONE_APP_VERSION              Set Fiftyone App Version
-i, --api-version=FIFTYONE_TEAMS_API_VERSION        Set Fiftyone Teams API Version
-t, --teams-app-version=FIFTYONE_TEAMS_APP_VERSION  Set Fiftyone Teams App Version
-c, --cas-version=FIFTYONE_TEAMS_CAS_VERSION        Set Fiftyone CAS Version
-d, --dry-run                                       Perform a dry-run (print to stdout instead of modifying the file)
```

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
