### PR TITLE
chore: Dont print in non-dry-run mode

### DIFF
--- a/utils/bump-fixtures-docker.sh
+++ b/utils/bump-fixtures-docker.sh
@@ -132,15 +132,13 @@ sed "${sed_flags}" "s/^FIFTYONE_TEAMS_API_VERSION=.*/FIFTYONE_TEAMS_API_VERSION=
 sed "${sed_flags}" "s/^FIFTYONE_TEAMS_APP_VERSION=.*/FIFTYONE_TEAMS_APP_VERSION=${FIFTYONE_TEAMS_APP_VERSION}/" "${file}"
 sed "${sed_flags}" "s/^FIFTYONE_TEAMS_CAS_VERSION=.*/FIFTYONE_TEAMS_CAS_VERSION=${FIFTYONE_TEAMS_CAS_VERSION}/" "${file}"
 
-# Output the file contents (dry-run will print the content)
-cat "${file}"
-
 # Clean up backup file if on macOS
-if [[ $delete_backups == "true" ]]; then
+if [[ ${delete_backups} == "true" ]]; then
   rm "${file}b"
 fi
 
 # Remove temporary file if dry-run
 if [[ $DRY_RUN == "true" ]]; then
-  rm "${tempfile}"
+  cat "${file}"
+  rm "${file}"
 fi

--- a/utils/bump-fixtures-helm.sh
+++ b/utils/bump-fixtures-helm.sh
@@ -135,10 +135,8 @@ if yq -e ".delegatedOperatorExecutorSettings" "${file}" >/dev/null; then
   yq "$yq_flags" ".delegatedOperatorExecutorSettings.image.tag = \"${FIFTYONE_APP_VERSION}\"" "${file}"
 fi
 
-# Output the file contents (dry-run will print the content)
-cat "${file}"
-
 # Remove temporary file if dry-run
 if [[ $DRY_RUN == "true" ]]; then
-  rm "${tempfile}"
+  cat "${file}"
+  rm "${file}"
 fi


### PR DESCRIPTION
# Rationale

Don't `cat` the file unless you're in dry-run mode.

## Changes

Don't `cat` the file unless you're in dry-run mode.

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
