### PR TITLE
chore: AS-118 Unit tests and bug fix

### DIFF
--- a/helm/fiftyone-teams-app/templates/_helpers.tpl
+++ b/helm/fiftyone-teams-app/templates/_helpers.tpl
@@ -290,7 +290,7 @@ Create a merged list of environment variables for delegated-operator-executor
 {{- define "delegated-operator-executor.env-vars-list" -}}
 {{- $secretName := .Values.secret.name }}
 - name: API_URL
-  value: {{ printf "http://%s:%.0f" .Values.apiSettings.service.name .Values.apiSettings.service.port | quote }}
+  value: {{ printf "http://%s:%.0f" .Values.apiSettings.service.name (float64 .Values.apiSettings.service.port) | quote }}
 - name: FIFTYONE_DATABASE_ADMIN
   value: "false"
 - name: FIFTYONE_DATABASE_NAME
@@ -327,7 +327,7 @@ Create a merged list of environment variables for fiftyone-teams-api
 {{- define "fiftyone-teams-api.env-vars-list" -}}
 {{- $secretName := .Values.secret.name }}
 - name: CAS_BASE_URL
-  value: {{ printf "http://%s:%.0f/cas/api" .Values.casSettings.service.name .Values.casSettings.service.port | quote }}
+  value: {{ printf "http://%s:%.0f/cas/api" .Values.casSettings.service.name (float64 .Values.casSettings.service.port) | quote }}
 - name: FIFTYONE_AUTH_SECRET
   valueFrom:
     secretKeyRef:
@@ -372,7 +372,7 @@ Create a merged list of environment variables for fiftyone-app
 {{- define "fiftyone-app.env-vars-list" -}}
 {{- $secretName := .Values.secret.name }}
 - name: API_URL
-  value: {{ printf "http://%s:%.0f" .Values.apiSettings.service.name .Values.apiSettings.service.port | quote }}
+  value: {{ printf "http://%s:%.0f" .Values.apiSettings.service.name (float64 .Values.apiSettings.service.port) | quote }}
 - name: FIFTYONE_AUTH_SECRET
   valueFrom:
     secretKeyRef:
@@ -476,7 +476,7 @@ Create a merged list of environment variables for fiftyone-teams-plugins
 {{- define "teams-plugins.env-vars-list" -}}
 {{- $secretName := .Values.secret.name }}
 - name: API_URL
-  value: {{ printf "http://%s:%.0f" .Values.apiSettings.service.name .Values.apiSettings.service.port | quote }}
+  value: {{ printf "http://%s:%.0f" .Values.apiSettings.service.name (float64 .Values.apiSettings.service.port) | quote }}
 - name: FIFTYONE_AUTH_SECRET
   valueFrom:
     secretKeyRef:
@@ -519,7 +519,7 @@ Create a merged list of environment variables for fiftyone-teams-app
 {{- define "fiftyone-teams-app.env-vars-list" -}}
 {{- $secretName := .Values.secret.name }}
 - name: API_URL
-  value: {{ printf "http://%s:%.0f" .Values.apiSettings.service.name .Values.apiSettings.service.port | quote }}
+  value: {{ printf "http://%s:%.0f" .Values.apiSettings.service.name (float64 .Values.apiSettings.service.port) | quote }}
 - name: FIFTYONE_API_URI
 {{- if .Values.teamsAppSettings.fiftyoneApiOverride }}
   value: {{ .Values.teamsAppSettings.fiftyoneApiOverride }}
@@ -538,12 +538,12 @@ Create a merged list of environment variables for fiftyone-teams-app
 - name: FIFTYONE_SERVER_PATH_PREFIX
   value: "/api/proxy/fiftyone-teams"
 - name: FIFTYONE_TEAMS_PROXY_URL
-  value: {{ printf "http://%s:%.0f" .Values.appSettings.service.name .Values.appSettings.service.port | quote }}
+  value: {{ printf "http://%s:%.0f" .Values.appSettings.service.name (float64 .Values.appSettings.service.port) | quote }}
 - name: FIFTYONE_TEAMS_PLUGIN_URL
 {{- if .Values.pluginsSettings.enabled }}
-  value: {{ printf "http://%s:%.0f" .Values.pluginsSettings.service.name .Values.pluginsSettings.service.port | quote }}
+  value: {{ printf "http://%s:%.0f" .Values.pluginsSettings.service.name (float64 .Values.pluginsSettings.service.port) | quote }}
 {{- else }}
-  value: {{ printf "http://%s:%.0f" .Values.appSettings.service.name .Values.appSettings.service.port | quote }}
+  value: {{ printf "http://%s:%.0f" .Values.appSettings.service.name (float64 .Values.appSettings.service.port) | quote }}
 {{- end }}
 {{- range $key, $val := .Values.teamsAppSettings.env }}
 - name: {{ $key }}

--- a/tests/unit/helm/api-deployment_test.go
+++ b/tests/unit/helm/api-deployment_test.go
@@ -679,6 +679,165 @@ func (s *deploymentApiTemplateTest) TestContainerEnv() {
 				s.Equal(expectedEnvVars, envVars, "Envs should be equal")
 			},
 		},
+		{
+			"overrideSecretName",
+			map[string]string{
+				"secret.name": "override-secret-name",
+			},
+			func(envVars []corev1.EnvVar) {
+				expectedEnvVarJSON := `[
+          {
+            "name": "CAS_BASE_URL",
+            "value": "http://teams-cas:80/cas/api"
+          },
+          {
+            "name": "FIFTYONE_AUTH_SECRET",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "override-secret-name",
+                "key": "fiftyoneAuthSecret"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_DATABASE_NAME",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "override-secret-name",
+                "key": "fiftyoneDatabaseName"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_DATABASE_URI",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "override-secret-name",
+                "key": "mongodbConnectionString"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_ENCRYPTION_KEY",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "override-secret-name",
+                "key": "encryptionKey"
+              }
+            }
+          },
+          {
+            "name": "MONGO_DEFAULT_DB",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "override-secret-name",
+                "key": "fiftyoneDatabaseName"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_ENV",
+            "value": "production"
+          },
+          {
+            "name": "FIFTYONE_INTERNAL_SERVICE",
+            "value": "true"
+          },
+          {
+            "name": "GRAPHQL_DEFAULT_LIMIT",
+            "value": "10"
+          },
+          {
+            "name": "LOGGING_LEVEL",
+            "value": "INFO"
+          }
+        ]`
+				var expectedEnvVars []corev1.EnvVar
+				err := json.Unmarshal([]byte(expectedEnvVarJSON), &expectedEnvVars)
+				s.NoError(err)
+				s.Equal(expectedEnvVars, envVars, "Envs should be equal")
+			},
+		},
+		{
+			"overrideCasServiceNameAndPort",
+			map[string]string{
+				"casSettings.service.name": "teams-cas-override",
+				"casSettings.service.port": "8000",
+			},
+			func(envVars []corev1.EnvVar) {
+				expectedEnvVarJSON := `[
+          {
+            "name": "CAS_BASE_URL",
+            "value": "http://teams-cas-override:8000/cas/api"
+          },
+          {
+            "name": "FIFTYONE_AUTH_SECRET",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "fiftyone-teams-secrets",
+                "key": "fiftyoneAuthSecret"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_DATABASE_NAME",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "fiftyone-teams-secrets",
+                "key": "fiftyoneDatabaseName"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_DATABASE_URI",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "fiftyone-teams-secrets",
+                "key": "mongodbConnectionString"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_ENCRYPTION_KEY",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "fiftyone-teams-secrets",
+                "key": "encryptionKey"
+              }
+            }
+          },
+          {
+            "name": "MONGO_DEFAULT_DB",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "fiftyone-teams-secrets",
+                "key": "fiftyoneDatabaseName"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_ENV",
+            "value": "production"
+          },
+          {
+            "name": "FIFTYONE_INTERNAL_SERVICE",
+            "value": "true"
+          },
+          {
+            "name": "GRAPHQL_DEFAULT_LIMIT",
+            "value": "10"
+          },
+          {
+            "name": "LOGGING_LEVEL",
+            "value": "INFO"
+          }
+        ]`
+				var expectedEnvVars []corev1.EnvVar
+				err := json.Unmarshal([]byte(expectedEnvVarJSON), &expectedEnvVars)
+				s.NoError(err)
+				s.Equal(expectedEnvVars, envVars, "Envs should be equal")
+			},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/tests/unit/helm/app-deployment_test.go
+++ b/tests/unit/helm/app-deployment_test.go
@@ -669,6 +669,155 @@ func (s *deploymentAppTemplateTest) TestContainerEnv() {
 				s.Equal(expectedEnvVars, envVars, "Envs should be equal")
 			},
 		},
+		{
+			"overrideSecretName",
+			map[string]string{
+				"secret.name": "override-secret-name",
+			},
+			func(envVars []corev1.EnvVar) {
+				expectedEnvVarJSON := `[
+          {
+            "name": "API_URL",
+            "value": "http://teams-api:80"
+          },
+          {
+            "name": "FIFTYONE_AUTH_SECRET",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "override-secret-name",
+                "key": "fiftyoneAuthSecret"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_DATABASE_NAME",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "override-secret-name",
+                "key": "fiftyoneDatabaseName"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_DATABASE_URI",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "override-secret-name",
+                "key": "mongodbConnectionString"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_ENCRYPTION_KEY",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "override-secret-name",
+                "key": "encryptionKey"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_DATABASE_ADMIN",
+            "value": "false"
+          },
+          {
+            "name": "FIFTYONE_INTERNAL_SERVICE",
+            "value": "true"
+          },
+          {
+            "name": "FIFTYONE_MEDIA_CACHE_APP_IMAGES",
+            "value": "false"
+          },
+          {
+            "name": "FIFTYONE_MEDIA_CACHE_SIZE_BYTES",
+            "value": "-1"
+          },
+          {
+            "name": "FIFTYONE_SIGNED_URL_EXPIRATION",
+            "value": "24"
+          }
+        ]`
+				var expectedEnvVars []corev1.EnvVar
+				err := json.Unmarshal([]byte(expectedEnvVarJSON), &expectedEnvVars)
+				s.NoError(err)
+				s.Equal(expectedEnvVars, envVars, "Envs should be equal")
+			},
+		},
+		{
+			"overrideApiServiceNameAndPort",
+			map[string]string{
+				"apiSettings.service.name": "teams-api-override",
+				"apiSettings.service.port": "8000",
+			},
+			func(envVars []corev1.EnvVar) {
+				expectedEnvVarJSON := `[
+          {
+            "name": "API_URL",
+            "value": "http://teams-api-override:8000"
+          },
+          {
+            "name": "FIFTYONE_AUTH_SECRET",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "fiftyone-teams-secrets",
+                "key": "fiftyoneAuthSecret"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_DATABASE_NAME",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "fiftyone-teams-secrets",
+                "key": "fiftyoneDatabaseName"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_DATABASE_URI",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "fiftyone-teams-secrets",
+                "key": "mongodbConnectionString"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_ENCRYPTION_KEY",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "fiftyone-teams-secrets",
+                "key": "encryptionKey"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_DATABASE_ADMIN",
+            "value": "false"
+          },
+          {
+            "name": "FIFTYONE_INTERNAL_SERVICE",
+            "value": "true"
+          },
+          {
+            "name": "FIFTYONE_MEDIA_CACHE_APP_IMAGES",
+            "value": "false"
+          },
+          {
+            "name": "FIFTYONE_MEDIA_CACHE_SIZE_BYTES",
+            "value": "-1"
+          },
+          {
+            "name": "FIFTYONE_SIGNED_URL_EXPIRATION",
+            "value": "24"
+          }
+        ]`
+				var expectedEnvVars []corev1.EnvVar
+				err := json.Unmarshal([]byte(expectedEnvVarJSON), &expectedEnvVars)
+				s.NoError(err)
+				s.Equal(expectedEnvVars, envVars, "Envs should be equal")
+			},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/tests/unit/helm/cas-deployment_test.go
+++ b/tests/unit/helm/cas-deployment_test.go
@@ -812,6 +812,188 @@ func (s *deploymentCasTemplateTest) TestContainerEnv() {
 				s.Equal(expectedEnvVars, envVars, "Envs should be equal")
 			},
 		},
+		{
+			"overrideAppDNsName",
+			map[string]string{
+				"teamsAppSettings.dnsName": "the-app:9999",
+			},
+			func(envVars []corev1.EnvVar) {
+				expectedEnvVarJSON := `[
+          {
+            "name": "CAS_MONGODB_URI",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "fiftyone-teams-secrets",
+                "key": "mongodbConnectionString"
+              }
+            }
+          },
+          {
+            "name": "CAS_URL",
+            "value": "https://the-app:9999"
+          },
+          {
+            "name": "FIFTYONE_AUTH_SECRET",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "fiftyone-teams-secrets",
+                "key": "fiftyoneAuthSecret"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_ENCRYPTION_KEY",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "fiftyone-teams-secrets",
+                "key": "encryptionKey"
+              }
+            }
+          },
+          {
+            "name": "LICENSE_KEY_FILE_PATHS",
+            "value": "/opt/fiftyone/licenses/fiftyone-license"
+          },
+          {
+            "name": "NEXTAUTH_URL",
+            "value": "https://the-app:9999/cas/api/auth"
+          },
+          {
+            "name": "TEAMS_API_DATABASE_NAME",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "fiftyone-teams-secrets",
+                "key": "fiftyoneDatabaseName"
+              }
+            }
+          },
+          {
+            "name": "TEAMS_API_MONGODB_URI",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "fiftyone-teams-secrets",
+                "key": "mongodbConnectionString"
+              }
+            }
+          },
+          {
+            "name": "CAS_DATABASE_NAME",
+            "value": "cas"
+          },
+          {
+            "name": "CAS_DEFAULT_USER_ROLE",
+            "value": "GUEST"
+          },
+          {
+            "name": "CAS_MONGODB_URI_KEY",
+            "value": "mongodbConnectionString"
+          },
+          {
+            "name": "DEBUG",
+            "value": "cas:*,-cas:*:debug"
+          },
+          {
+            "name": "FIFTYONE_AUTH_MODE",
+            "value": "legacy"
+          }
+        ]`
+				var expectedEnvVars []corev1.EnvVar
+				err := json.Unmarshal([]byte(expectedEnvVarJSON), &expectedEnvVars)
+				s.NoError(err)
+				s.Equal(expectedEnvVars, envVars, "Envs should be equal")
+			},
+		},
+		{
+			"overrideSecretName",
+			map[string]string{
+				"secret.name": "override-secret-name",
+			},
+			func(envVars []corev1.EnvVar) {
+				expectedEnvVarJSON := `[
+          {
+            "name": "CAS_MONGODB_URI",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "override-secret-name",
+                "key": "mongodbConnectionString"
+              }
+            }
+          },
+          {
+            "name": "CAS_URL",
+            "value": "https://"
+          },
+          {
+            "name": "FIFTYONE_AUTH_SECRET",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "override-secret-name",
+                "key": "fiftyoneAuthSecret"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_ENCRYPTION_KEY",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "override-secret-name",
+                "key": "encryptionKey"
+              }
+            }
+          },
+          {
+            "name": "LICENSE_KEY_FILE_PATHS",
+            "value": "/opt/fiftyone/licenses/fiftyone-license"
+          },
+          {
+            "name": "NEXTAUTH_URL",
+            "value": "https:///cas/api/auth"
+          },
+          {
+            "name": "TEAMS_API_DATABASE_NAME",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "override-secret-name",
+                "key": "fiftyoneDatabaseName"
+              }
+            }
+          },
+          {
+            "name": "TEAMS_API_MONGODB_URI",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "override-secret-name",
+                "key": "mongodbConnectionString"
+              }
+            }
+          },
+          {
+            "name": "CAS_DATABASE_NAME",
+            "value": "cas"
+          },
+          {
+            "name": "CAS_DEFAULT_USER_ROLE",
+            "value": "GUEST"
+          },
+          {
+            "name": "CAS_MONGODB_URI_KEY",
+            "value": "mongodbConnectionString"
+          },
+          {
+            "name": "DEBUG",
+            "value": "cas:*,-cas:*:debug"
+          },
+          {
+            "name": "FIFTYONE_AUTH_MODE",
+            "value": "legacy"
+          }
+        ]`
+				var expectedEnvVars []corev1.EnvVar
+				err := json.Unmarshal([]byte(expectedEnvVarJSON), &expectedEnvVars)
+				s.NoError(err)
+				s.Equal(expectedEnvVars, envVars, "Envs should be equal")
+			},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/tests/unit/helm/delegated-operator-executor-deployment_test.go
+++ b/tests/unit/helm/delegated-operator-executor-deployment_test.go
@@ -496,6 +496,131 @@ func (s *deploymentDelegatedOperatorExecutorTemplateTest) TestContainerEnv() {
 				s.Equal(expectedEnvVars, envVars, "Envs should be equal")
 			},
 		},
+		{
+			"overrideSecretName",
+			map[string]string{
+				"delegatedOperatorExecutorSettings.enabled": "true",
+				"secret.name": "override-secret-name",
+			},
+			func(envVars []corev1.EnvVar) {
+				expectedEnvVarJSON := `[
+          {
+            "name": "API_URL",
+            "value": "http://teams-api:80"
+          },
+          {
+            "name": "FIFTYONE_DATABASE_ADMIN",
+            "value": "false"
+          },
+          {
+            "name": "FIFTYONE_DATABASE_NAME",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "override-secret-name",
+                "key": "fiftyoneDatabaseName"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_DATABASE_URI",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "override-secret-name",
+                "key": "mongodbConnectionString"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_ENCRYPTION_KEY",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "override-secret-name",
+                "key": "encryptionKey"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_DELEGATED_OPERATION_RUN_LINK_PATH",
+            "value": ""
+          },
+          {
+            "name": "FIFTYONE_INTERNAL_SERVICE",
+            "value": "true"
+          },
+          {
+            "name": "FIFTYONE_MEDIA_CACHE_SIZE_BYTES",
+            "value": "-1"
+          }
+        ]`
+				var expectedEnvVars []corev1.EnvVar
+				err := json.Unmarshal([]byte(expectedEnvVarJSON), &expectedEnvVars)
+				s.NoError(err)
+				s.Equal(expectedEnvVars, envVars, "Envs should be equal")
+			},
+		},
+		{
+			"overrideApiServiceNameAndPort",
+			map[string]string{
+				"delegatedOperatorExecutorSettings.enabled": "true",
+				"apiSettings.service.name":                  "teams-api-override",
+				"apiSettings.service.port":                  "8000",
+			},
+			func(envVars []corev1.EnvVar) {
+				expectedEnvVarJSON := `[
+          {
+            "name": "API_URL",
+            "value": "http://teams-api-override:8000"
+          },
+          {
+            "name": "FIFTYONE_DATABASE_ADMIN",
+            "value": "false"
+          },
+          {
+            "name": "FIFTYONE_DATABASE_NAME",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "fiftyone-teams-secrets",
+                "key": "fiftyoneDatabaseName"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_DATABASE_URI",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "fiftyone-teams-secrets",
+                "key": "mongodbConnectionString"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_ENCRYPTION_KEY",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "fiftyone-teams-secrets",
+                "key": "encryptionKey"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_DELEGATED_OPERATION_RUN_LINK_PATH",
+            "value": ""
+          },
+          {
+            "name": "FIFTYONE_INTERNAL_SERVICE",
+            "value": "true"
+          },
+          {
+            "name": "FIFTYONE_MEDIA_CACHE_SIZE_BYTES",
+            "value": "-1"
+          }
+        ]`
+				var expectedEnvVars []corev1.EnvVar
+				err := json.Unmarshal([]byte(expectedEnvVarJSON), &expectedEnvVars)
+				s.NoError(err)
+				s.Equal(expectedEnvVars, envVars, "Envs should be equal")
+			},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/tests/unit/helm/plugins-deployment_test.go
+++ b/tests/unit/helm/plugins-deployment_test.go
@@ -772,6 +772,149 @@ func (s *deploymentPluginsTemplateTest) TestContainerEnv() {
 				s.Equal(expectedEnvVars, envVars, "Envs should be equal")
 			},
 		},
+		{
+			"overrideSecretName",
+			map[string]string{
+				"pluginsSettings.enabled": "true",
+				"secret.name":             "override-secret-name",
+			},
+			func(envVars []corev1.EnvVar) {
+				expectedEnvVarJSON := `[
+          {
+            "name": "API_URL",
+            "value": "http://teams-api:80"
+          },
+          {
+            "name": "FIFTYONE_AUTH_SECRET",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "override-secret-name",
+                "key": "fiftyoneAuthSecret"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_DATABASE_ADMIN",
+            "value": "false"
+          },
+          {
+            "name": "FIFTYONE_DATABASE_NAME",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "override-secret-name",
+                "key": "fiftyoneDatabaseName"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_DATABASE_URI",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "override-secret-name",
+                "key": "mongodbConnectionString"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_ENCRYPTION_KEY",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "override-secret-name",
+                "key": "encryptionKey"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_INTERNAL_SERVICE",
+            "value": "true"
+          },
+          {
+            "name": "FIFTYONE_MEDIA_CACHE_APP_IMAGES",
+            "value": "false"
+          },
+          {
+            "name": "FIFTYONE_MEDIA_CACHE_SIZE_BYTES",
+            "value": "-1"
+          }
+        ]`
+				var expectedEnvVars []corev1.EnvVar
+				err := json.Unmarshal([]byte(expectedEnvVarJSON), &expectedEnvVars)
+				s.NoError(err)
+				s.Equal(expectedEnvVars, envVars, "Envs should be equal")
+			},
+		},
+		{
+			"overrideApiServiceNameAndPort",
+			map[string]string{
+				"pluginsSettings.enabled":  "true",
+				"apiSettings.service.name": "teams-api-override",
+				"apiSettings.service.port": "8000",
+			},
+			func(envVars []corev1.EnvVar) {
+				expectedEnvVarJSON := `[
+          {
+            "name": "API_URL",
+            "value": "http://teams-api-override:8000"
+          },
+          {
+            "name": "FIFTYONE_AUTH_SECRET",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "fiftyone-teams-secrets",
+                "key": "fiftyoneAuthSecret"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_DATABASE_ADMIN",
+            "value": "false"
+          },
+          {
+            "name": "FIFTYONE_DATABASE_NAME",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "fiftyone-teams-secrets",
+                "key": "fiftyoneDatabaseName"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_DATABASE_URI",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "fiftyone-teams-secrets",
+                "key": "mongodbConnectionString"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_ENCRYPTION_KEY",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "fiftyone-teams-secrets",
+                "key": "encryptionKey"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_INTERNAL_SERVICE",
+            "value": "true"
+          },
+          {
+            "name": "FIFTYONE_MEDIA_CACHE_APP_IMAGES",
+            "value": "false"
+          },
+          {
+            "name": "FIFTYONE_MEDIA_CACHE_SIZE_BYTES",
+            "value": "-1"
+          }
+        ]`
+				var expectedEnvVars []corev1.EnvVar
+				err := json.Unmarshal([]byte(expectedEnvVarJSON), &expectedEnvVars)
+				s.NoError(err)
+				s.Equal(expectedEnvVars, envVars, "Envs should be equal")
+			},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/tests/unit/helm/teams-app-deployment_test.go
+++ b/tests/unit/helm/teams-app-deployment_test.go
@@ -604,6 +604,404 @@ func (s *deploymentTeamsAppTemplateTest) TestContainerEnv() {
 				s.Equal(expectedEnvVars, envVars, "Envs should be equal")
 			},
 		},
+		{
+			"overrideFiftyoneApiOverrideAndApidDnsNameAndAppDNsName",
+			map[string]string{
+				"teamsAppSettings.fiftyoneApiOverride": "https://some-other-api:9999/api",
+				"apiSettings.dnsName":                  "the-api:9999", // this should be ignored, so testing proper order of operations
+				"teamsAppSettings.dnsName":             "the-app:9999", // this should be ignored, so testing proper order of operations
+			},
+			func(envVars []corev1.EnvVar) {
+				expectedEnvVarJSON := fmt.Sprintf(`[
+          {
+            "name": "API_URL",
+            "value": "http://teams-api:80"
+          },
+          {
+            "name": "FIFTYONE_API_URI",
+            "value": "https://some-other-api:9999/api"
+          },
+          {
+            "name": "FIFTYONE_AUTH_SECRET",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "fiftyone-teams-secrets",
+                "key": "fiftyoneAuthSecret"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_SERVER_ADDRESS",
+            "value": ""
+          },
+          {
+            "name": "FIFTYONE_SERVER_PATH_PREFIX",
+            "value": "/api/proxy/fiftyone-teams"
+          },
+          {
+            "name": "FIFTYONE_TEAMS_PROXY_URL",
+            "value": "http://fiftyone-app:80"
+          },
+          {
+            "name": "FIFTYONE_TEAMS_PLUGIN_URL",
+            "value": "http://fiftyone-app:80"
+          },
+          {
+            "name": "APP_USE_HTTPS",
+            "value": "true"
+          },
+          {
+            "name": "FIFTYONE_APP_ALLOW_MEDIA_EXPORT",
+            "value": "true"
+          },
+          {
+            "name": "FIFTYONE_APP_ANONYMOUS_ANALYTICS_ENABLED",
+            "value": "true"
+          },
+          {
+            "name": "FIFTYONE_APP_DEFAULT_QUERY_PERFORMANCE",
+            "value": "true"
+          },
+          {
+            "name": "FIFTYONE_APP_ENABLE_QUERY_PERFORMANCE",
+            "value": "true"
+          },
+          {
+            "name": "FIFTYONE_APP_TEAMS_SDK_RECOMMENDED_VERSION",
+            "value": "%s"
+          },
+          {
+            "name": "FIFTYONE_APP_THEME",
+            "value": "dark"
+          },
+          {
+            "name": "RECOIL_DUPLICATE_ATOM_KEY_CHECKING_ENABLED",
+            "value": "false"
+          }
+        ]`, chartVersion)
+				var expectedEnvVars []corev1.EnvVar
+				err := json.Unmarshal([]byte(expectedEnvVarJSON), &expectedEnvVars)
+				s.NoError(err)
+				s.Equal(expectedEnvVars, envVars, "Envs should be equal")
+			},
+		},
+		{
+			"overrideApidDnsNameAndAppDNsName",
+			map[string]string{
+				"apiSettings.dnsName":      "the-api:9999",
+				"teamsAppSettings.dnsName": "the-app:9999", // this should be ignored, so testing proper order of operations
+			},
+			func(envVars []corev1.EnvVar) {
+				expectedEnvVarJSON := fmt.Sprintf(`[
+          {
+            "name": "API_URL",
+            "value": "http://teams-api:80"
+          },
+          {
+            "name": "FIFTYONE_API_URI",
+            "value": "https://the-api:9999"
+          },
+          {
+            "name": "FIFTYONE_AUTH_SECRET",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "fiftyone-teams-secrets",
+                "key": "fiftyoneAuthSecret"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_SERVER_ADDRESS",
+            "value": ""
+          },
+          {
+            "name": "FIFTYONE_SERVER_PATH_PREFIX",
+            "value": "/api/proxy/fiftyone-teams"
+          },
+          {
+            "name": "FIFTYONE_TEAMS_PROXY_URL",
+            "value": "http://fiftyone-app:80"
+          },
+          {
+            "name": "FIFTYONE_TEAMS_PLUGIN_URL",
+            "value": "http://fiftyone-app:80"
+          },
+          {
+            "name": "APP_USE_HTTPS",
+            "value": "true"
+          },
+          {
+            "name": "FIFTYONE_APP_ALLOW_MEDIA_EXPORT",
+            "value": "true"
+          },
+          {
+            "name": "FIFTYONE_APP_ANONYMOUS_ANALYTICS_ENABLED",
+            "value": "true"
+          },
+          {
+            "name": "FIFTYONE_APP_DEFAULT_QUERY_PERFORMANCE",
+            "value": "true"
+          },
+          {
+            "name": "FIFTYONE_APP_ENABLE_QUERY_PERFORMANCE",
+            "value": "true"
+          },
+          {
+            "name": "FIFTYONE_APP_TEAMS_SDK_RECOMMENDED_VERSION",
+            "value": "%s"
+          },
+          {
+            "name": "FIFTYONE_APP_THEME",
+            "value": "dark"
+          },
+          {
+            "name": "RECOIL_DUPLICATE_ATOM_KEY_CHECKING_ENABLED",
+            "value": "false"
+          }
+        ]`, chartVersion)
+				var expectedEnvVars []corev1.EnvVar
+				err := json.Unmarshal([]byte(expectedEnvVarJSON), &expectedEnvVars)
+				s.NoError(err)
+				s.Equal(expectedEnvVars, envVars, "Envs should be equal")
+			},
+		},
+		{
+			"overrideAppDNsName",
+			map[string]string{
+				"teamsAppSettings.dnsName": "the-app:9999",
+			},
+			func(envVars []corev1.EnvVar) {
+				expectedEnvVarJSON := fmt.Sprintf(`[
+          {
+            "name": "API_URL",
+            "value": "http://teams-api:80"
+          },
+          {
+            "name": "FIFTYONE_API_URI",
+            "value": "https://the-app:9999"
+          },
+          {
+            "name": "FIFTYONE_AUTH_SECRET",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "fiftyone-teams-secrets",
+                "key": "fiftyoneAuthSecret"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_SERVER_ADDRESS",
+            "value": ""
+          },
+          {
+            "name": "FIFTYONE_SERVER_PATH_PREFIX",
+            "value": "/api/proxy/fiftyone-teams"
+          },
+          {
+            "name": "FIFTYONE_TEAMS_PROXY_URL",
+            "value": "http://fiftyone-app:80"
+          },
+          {
+            "name": "FIFTYONE_TEAMS_PLUGIN_URL",
+            "value": "http://fiftyone-app:80"
+          },
+          {
+            "name": "APP_USE_HTTPS",
+            "value": "true"
+          },
+          {
+            "name": "FIFTYONE_APP_ALLOW_MEDIA_EXPORT",
+            "value": "true"
+          },
+          {
+            "name": "FIFTYONE_APP_ANONYMOUS_ANALYTICS_ENABLED",
+            "value": "true"
+          },
+          {
+            "name": "FIFTYONE_APP_DEFAULT_QUERY_PERFORMANCE",
+            "value": "true"
+          },
+          {
+            "name": "FIFTYONE_APP_ENABLE_QUERY_PERFORMANCE",
+            "value": "true"
+          },
+          {
+            "name": "FIFTYONE_APP_TEAMS_SDK_RECOMMENDED_VERSION",
+            "value": "%s"
+          },
+          {
+            "name": "FIFTYONE_APP_THEME",
+            "value": "dark"
+          },
+          {
+            "name": "RECOIL_DUPLICATE_ATOM_KEY_CHECKING_ENABLED",
+            "value": "false"
+          }
+        ]`, chartVersion)
+				var expectedEnvVars []corev1.EnvVar
+				err := json.Unmarshal([]byte(expectedEnvVarJSON), &expectedEnvVars)
+				s.NoError(err)
+				s.Equal(expectedEnvVars, envVars, "Envs should be equal")
+			},
+		},
+		{
+			"overridePluginsEnabled",
+			map[string]string{
+				"pluginsSettings.enabled": "true",
+			},
+			func(envVars []corev1.EnvVar) {
+				expectedEnvVarJSON := fmt.Sprintf(`[
+          {
+            "name": "API_URL",
+            "value": "http://teams-api:80"
+          },
+          {
+            "name": "FIFTYONE_API_URI",
+            "value": "https://"
+          },
+          {
+            "name": "FIFTYONE_AUTH_SECRET",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "fiftyone-teams-secrets",
+                "key": "fiftyoneAuthSecret"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_SERVER_ADDRESS",
+            "value": ""
+          },
+          {
+            "name": "FIFTYONE_SERVER_PATH_PREFIX",
+            "value": "/api/proxy/fiftyone-teams"
+          },
+          {
+            "name": "FIFTYONE_TEAMS_PROXY_URL",
+            "value": "http://fiftyone-app:80"
+          },
+          {
+            "name": "FIFTYONE_TEAMS_PLUGIN_URL",
+            "value": "http://teams-plugins:80"
+          },
+          {
+            "name": "APP_USE_HTTPS",
+            "value": "true"
+          },
+          {
+            "name": "FIFTYONE_APP_ALLOW_MEDIA_EXPORT",
+            "value": "true"
+          },
+          {
+            "name": "FIFTYONE_APP_ANONYMOUS_ANALYTICS_ENABLED",
+            "value": "true"
+          },
+          {
+            "name": "FIFTYONE_APP_DEFAULT_QUERY_PERFORMANCE",
+            "value": "true"
+          },
+          {
+            "name": "FIFTYONE_APP_ENABLE_QUERY_PERFORMANCE",
+            "value": "true"
+          },
+          {
+            "name": "FIFTYONE_APP_TEAMS_SDK_RECOMMENDED_VERSION",
+            "value": "%s"
+          },
+          {
+            "name": "FIFTYONE_APP_THEME",
+            "value": "dark"
+          },
+          {
+            "name": "RECOIL_DUPLICATE_ATOM_KEY_CHECKING_ENABLED",
+            "value": "false"
+          }
+        ]`, chartVersion)
+				var expectedEnvVars []corev1.EnvVar
+				err := json.Unmarshal([]byte(expectedEnvVarJSON), &expectedEnvVars)
+				s.NoError(err)
+				s.Equal(expectedEnvVars, envVars, "Envs should be equal")
+			},
+		},
+		{
+			"overrideSecretName",
+			map[string]string{
+				"secret.name": "override-secret-name",
+			},
+			func(envVars []corev1.EnvVar) {
+				expectedEnvVarJSON := fmt.Sprintf(`[
+          {
+            "name": "API_URL",
+            "value": "http://teams-api:80"
+          },
+          {
+            "name": "FIFTYONE_API_URI",
+            "value": "https://"
+          },
+          {
+            "name": "FIFTYONE_AUTH_SECRET",
+            "valueFrom": {
+              "secretKeyRef": {
+                "name": "override-secret-name",
+                "key": "fiftyoneAuthSecret"
+              }
+            }
+          },
+          {
+            "name": "FIFTYONE_SERVER_ADDRESS",
+            "value": ""
+          },
+          {
+            "name": "FIFTYONE_SERVER_PATH_PREFIX",
+            "value": "/api/proxy/fiftyone-teams"
+          },
+          {
+            "name": "FIFTYONE_TEAMS_PROXY_URL",
+            "value": "http://fiftyone-app:80"
+          },
+          {
+            "name": "FIFTYONE_TEAMS_PLUGIN_URL",
+            "value": "http://fiftyone-app:80"
+          },
+          {
+            "name": "APP_USE_HTTPS",
+            "value": "true"
+          },
+          {
+            "name": "FIFTYONE_APP_ALLOW_MEDIA_EXPORT",
+            "value": "true"
+          },
+          {
+            "name": "FIFTYONE_APP_ANONYMOUS_ANALYTICS_ENABLED",
+            "value": "true"
+          },
+          {
+            "name": "FIFTYONE_APP_DEFAULT_QUERY_PERFORMANCE",
+            "value": "true"
+          },
+          {
+            "name": "FIFTYONE_APP_ENABLE_QUERY_PERFORMANCE",
+            "value": "true"
+          },
+          {
+            "name": "FIFTYONE_APP_TEAMS_SDK_RECOMMENDED_VERSION",
+            "value": "%s"
+          },
+          {
+            "name": "FIFTYONE_APP_THEME",
+            "value": "dark"
+          },
+          {
+            "name": "RECOIL_DUPLICATE_ATOM_KEY_CHECKING_ENABLED",
+            "value": "false"
+          }
+        ]`, chartVersion)
+				var expectedEnvVars []corev1.EnvVar
+				err := json.Unmarshal([]byte(expectedEnvVarJSON), &expectedEnvVars)
+				s.NoError(err)
+				s.Equal(expectedEnvVars, envVars, "Envs should be equal")
+			},
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
# Rationale

We had some missing unit tests in our test suite.  Essentially, we wanted to test what happened to container env vars under the following values changes:

* .Values.teamsAppSettings.fiftyoneApiOverride
* .Values.apiSettings.dnsName
* .Values.teamsAppSettings.dnsName
* .Values.pluginsSettings.enabled
* .Values.secret.name
* .Values.*.service.name
* .Values.*.service.port

During this, a bug was uncovered. We were using go formatting and go was trying to interpret the numerical values of Values.*.service.port. However, `helm --set` passes this as a string. For example:

```shell
helm template . \
  --set apiSettings.service.port=8000 \
  --set delegatedOperatorExecutorSettings.enabled=true > out
```

Leads to:
```yaml
            - name: API_URL
              value: "http://teams-api:%!f(int64=8000)"
```

Service was fine:

```yaml
# Source: fiftyone-teams-app/templates/api-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: teams-api
  namespace: fiftyone-teams
  labels:
    helm.sh/chart: fiftyone-teams-app-2.4.0
    app.kubernetes.io/version: "v2.4.0"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: teams-api
    app.kubernetes.io/instance: release-name
spec:
  type: ClusterIP
  ports:
    - port: 8000
      targetPort: teams-api
      protocol: TCP
      name: http
  selector:
    app.kubernetes.io/name: teams-api
    app.kubernetes.io/instance: release-name
```

Default values were also fine (as they were already `float64`).

It appears that we needed to add an explicit cast to `float64` to match the format specifier. Output is now:

```yaml
            - name: API_URL
              value: "http://teams-api:8000"
```

## Changes

* Add unit test cases for the aforementioned fields
* Update the `*.env-vars-list` to add an explicit `float64` cast to values that should be numerical

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

## Testing

Manual testing listed above. In addition to manual `helm template`:

```shell
make test-unit-helm
```

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
