### PR TITLE
Revert "Adds global banner text and color env variables to README"

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -53,7 +53,6 @@ for steps on how to upgrade your delegated operators.
   - [Builtin Delegated Operator Orchestrator](#builtin-delegated-operator-orchestrator)
   - [Central Authentication Service](#central-authentication-service)
   - [Snapshot Archival](#snapshot-archival)
-  - [Static Banner Configuration](#static-banner-configuration)
   - [FiftyOne Teams Authenticated API](#fiftyone-teams-authenticated-api)
   - [FiftyOne Teams Plugins](#fiftyone-teams-plugins)
   - [Storage Credentials and `FIFTYONE_ENCRYPTION_KEY`](#storage-credentials-and-fiftyone_encryption_key)
@@ -310,33 +309,6 @@ Please refer to the
 [snapshot archival configuration documentation](./docs/configuring-snapshot-archival.md)
 for configuring snapshot archival.
 
-### Static Banner Configuration
-
-Fiftyone Teams v2.5 introduces the ability to add a static banner to the
-application.
-
-Configure the Static Banner by setting the following environment variables in
-your `compose.override.yaml`.
-
-Banner text is configured with `FIFTYONE_APP_BANNER_TEXT`.
-
-Banner background color is configured with `FIFTYONE_APP_BANNER_COLOR`.
-
-Examples:
-
-```yaml
-# compose.override.yaml
-services:
-  teams-cas:
-    environment:
-      FIFTYONE_APP_BANNER_COLOR: "green" # or "rgb(34,139,34)" or "#f1f1f1"
-      FIFTYONE_APP_BANNER_TEXT: "Internal Deployment"
-  teams-app:
-    environment:
-      FIFTYONE_APP_BANNER_COLOR: "green" # or "rgb(34,139,34)" or "#f1f1f1"
-      FIFTYONE_APP_BANNER_TEXT: "Internal Deployment"
-```
-
 ### FiftyOne Teams Authenticated API
 
 FiftyOne Teams v1.3 introduces the capability to connect FiftyOne Teams SDK
@@ -479,8 +451,6 @@ For more information, see the docs for
 | `CAS_MONGODB_URI`                           | The MongoDB Connection STring for CAS; this will default to `FIFTYONE_DATABASE_URI`                                                                                                                                                                                            | No                        |
 | `FIFTYONE_APP_ALLOW_MEDIA_EXPORT`           | Set this to `"false"` if you want to disable media export options                                                                                                                                                                                                              | No                        |
 | `FIFTYONE_APP_ANONYMOUS_ANALYTICS_ENABLED`           | Controls whether anonymous analytics are captured for the teams application. Set to false to opt-out of anonymous analytics.                                                                                                                                                                                                              | No                        |
-| `FIFTYONE_APP_BANNER_COLOR`           | Global banner background color in App                                                                                                     | No                        |
-| `FIFTYONE_APP_BANNER_TEXT`           | Global banner text in App                                                                                                    | No                        |
 | `FIFTYONE_APP_TEAMS_SDK_RECOMMENDED_VERSION` | The recommended fiftyone SDK version. This will be displayed in install modal (i.e. `pip install ... fiftyone==0.11.0`)                                                                                                                                                        | No                        |
 | `FIFTYONE_APP_THEME`                        | The default theme configuration for your FiftyOne Teams application as described [here](https://docs.voxel51.com/user_guide/config.html#configuring-the-app)                                                                                                                   | No                        |
 | `FIFTYONE_APP_DEFAULT_QUERY_PERFORMANCE`    | Controls whether Query Performance mode is enabled by default for every dataset for the teams application. Set to false to set default mode to off.                                                                                                                            | No                        |

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -61,7 +61,6 @@ for steps on how to upgrade your delegated operators.
   - [Proxies](#proxies)
   - [Snapshot Archival](#snapshot-archival)
   - [Storage Credentials and `FIFTYONE_ENCRYPTION_KEY`](#storage-credentials-and-fiftyone_encryption_key)
-  - [Static Banner Configuration](#static-banner-configuration)
   - [Text Similarity](#text-similarity)
 - [Values](#values)
   - [Deploying On GKE](#deploying-on-gke)
@@ -324,33 +323,6 @@ mounted into pods or provided via environment variables.
 FiftyOne Teams continues to support the use of environment variables to set
 storage credentials in the application context and is providing an alternate
 configuration path.
-
-### Static Banner Configuration
-
-Fiftyone Teams v2.5 introduces the ability to add a static banner to the
-application.
-
-Configure the Static Banner by setting the following environment variables in
-your `values.yaml`.
-
-Banner text is configured with:
-`casSettings.env.FIFTYONE_APP_BANNER_TEXT` and
-`teamsAppSettings.env.FIFTYONE_APP_BANNER_TEXT`
-
-Banner background color is configured with:
-`casSettings.env.FIFTYONE_APP_BANNER_COLOR` and
-`teamsAppSettings.env.FIFTYONE_APP_BANNER_COLOR`
-
-```yaml
-casSettings:
-  env:
-    FIFTYONE_APP_BANNER_COLOR: "green" # or "rgb(34,139,34)" or ""#f1f1f1"
-    FIFTYONE_APP_BANNER_TEXT: "Internal Deployment"
-teamsAppSettings:
-  env:
-    FIFTYONE_APP_BANNER_COLOR: "green" # or "rgb(34,139,34)" or ""#f1f1f1"
-    FIFTYONE_APP_BANNER_TEXT: "Internal Deployment"
-```
 
 ### Text Similarity
 

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -61,7 +61,6 @@ for steps on how to upgrade your delegated operators.
   - [Proxies](#proxies)
   - [Snapshot Archival](#snapshot-archival)
   - [Storage Credentials and `FIFTYONE_ENCRYPTION_KEY`](#storage-credentials-and-fiftyone_encryption_key)
-  - [Static Banner Configuration](#static-banner-configuration)
   - [Text Similarity](#text-similarity)
 - [Values](#values)
   - [Deploying On GKE](#deploying-on-gke)
@@ -325,34 +324,6 @@ mounted into pods or provided via environment variables.
 FiftyOne Teams continues to support the use of environment variables to set
 storage credentials in the application context and is providing an alternate
 configuration path.
-
-### Static Banner Configuration
-
-Fiftyone Teams v2.5 introduces the ability to add a static banner to the
-application.
-
-Configure the Static Banner by setting the following environment variables in
-your `values.yaml`.
-
-Banner text is configured with:
-`casSettings.env.FIFTYONE_APP_BANNER_TEXT` and
-`teamsAppSettings.env.FIFTYONE_APP_BANNER_TEXT`
-
-
-Banner background color is configured with:
-`casSettings.env.FIFTYONE_APP_BANNER_COLOR` and
-`teamsAppSettings.env.FIFTYONE_APP_BANNER_COLOR`
-
-```yaml
-casSettings:
-  env:
-    FIFTYONE_APP_BANNER_COLOR: "green" # or "rgb(34,139,34)" or ""#f1f1f1"
-    FIFTYONE_APP_BANNER_TEXT: "Internal Deployment"
-teamsAppSettings:
-  env:
-    FIFTYONE_APP_BANNER_COLOR: "green" # or "rgb(34,139,34)" or ""#f1f1f1"
-    FIFTYONE_APP_BANNER_TEXT: "Internal Deployment"
-```
 
 ### Text Similarity
 


### PR DESCRIPTION
Reverts voxel51/fiftyone-teams-app-deploy#277

This should be included as part of version v2.6.0, not v2.5.0.

See [thread here](https://voxel51.slack.com/archives/C05L68A72FM/p1737143630269069)