### PR TITLE
Kevin/fix indents and replace tips with notes

### DIFF
--- a/docker/docs/upgrading.md
+++ b/docker/docs/upgrading.md
@@ -60,8 +60,8 @@ and, as such, might take longer to pull and start.
 To utilize the prior image, update your `common-services.yaml` similar to the below:
 
 ```yaml
-  teams-do-common:
-    image: voxel51/fiftyone-app:v2.5.0
+teams-do-common:
+  image: voxel51/fiftyone-app:v2.5.0
 ```
 
 #### FiftyOne Teams v2.2+ Delegated Operator Changes

--- a/helm/README.md
+++ b/helm/README.md
@@ -73,7 +73,7 @@ in this directory.
         helm upgrade fiftyone-teams-app voxel51/fiftyone-teams-app -f ./values.yaml
         ```
 
-        > **NOTE**  Prior to running helm upgrade you may
+        > **NOTE** Prior to running helm upgrade you may
         > view the changes Helm would apply by using
         > [helm diff](https://github.com/databus23/helm-diff)
         > helm plugin.
@@ -111,7 +111,7 @@ These instructions assume you have
   - If you have not received this information, please contact your
     Voxel51 Support Team via your agreed-upon mechanism (Slack, email, etc.)
 
-> [!TIP]
+> **NOTE**
 > Anytime a license file is updated, you may need to restart the `teams-cas`
 > and `teams-api` services. You can do this by deleting the pods, or by running
 > the following command: </br>

--- a/helm/docs/upgrading.md
+++ b/helm/docs/upgrading.md
@@ -50,7 +50,7 @@ A minimal example `values.yaml` may be found
           -f ./values.yaml
         ```
 
-    > **NOTE**  To view the changes Helm would apply during installations
+    > **NOTE** To view the changes Helm would apply during installations
     > and upgrades, consider using
     > [helm diff](https://github.com/databus23/helm-diff).
     > Voxel51 is not affiliated with the author of this plugin.

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -118,11 +118,11 @@ kubectl --namespace your-namespace-here create secret generic fiftyone-license \
 --from-file=license=./your-license-file
 ```
 
- > [!TIP]
- > To ensure that the new license values take effect
- > immediately, you may need to restart the `teams-cas` and `teams-api` services.
- > You can do this by deleting the pods, or by running the following command:
- > `kubectl rollout restart deploy -n your-namespace teams-cas teams-api`
+> **NOTE**
+> To ensure that the new license values take effect
+> immediately, you may need to restart the `teams-cas` and `teams-api` services.
+> You can do this by deleting the pods, or by running the following command:
+> `kubectl rollout restart deploy -n your-namespace teams-cas teams-api`
 
 We publish the following FiftyOne Teams private images to Docker Hub:
 

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -118,11 +118,11 @@ kubectl --namespace your-namespace-here create secret generic fiftyone-license \
 --from-file=license=./your-license-file
 ```
 
- > [!TIP]
- > To ensure that the new license values take effect
- > immediately, you may need to restart the `teams-cas` and `teams-api` services.
- > You can do this by deleting the pods, or by running the following command:
- > `kubectl rollout restart deploy -n your-namespace teams-cas teams-api`
+> **NOTE**
+> To ensure that the new license values take effect
+> immediately, you may need to restart the `teams-cas` and `teams-api` services.
+> You can do this by deleting the pods, or by running the following command:
+> `kubectl rollout restart deploy -n your-namespace teams-cas teams-api`
 
 We publish the following FiftyOne Teams private images to Docker Hub:
 


### PR DESCRIPTION
# Rationale

helm.fiftyone.ai won't translate the GitHub pages admonition `[!TIP]` and will instead show that in clear text.  For better UX, let's just use the `**NOTE**` that we already have in the docs.

## Changes

* Remove extra whitespace
* replace tips with notes

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
