### PR TITLE
chore: AS-159 Adding an http to https redirect

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -97,6 +97,8 @@ deploy:
               nginx.ingress.kubernetes.io/proxy-buffer-size: 256k
               # Configure nginx-ingress controller proxy buffers for the app
               nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
+              # Force http to https redirect
+              nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
             # For using the nginx-ingress controller
             className: nginx
             paths:


### PR DESCRIPTION
# Rationale

In many of our deployments, we recommend http to https redirect. We should enforce that our skaffold system also follows these. It's not as realistic as deploying a `FrontendConfig` to `minikube` but, I'm not sure that's possible. However, please let me know if I'm wrong!

## Changes

Adds `nginx.ingress.kubernetes.io/force-ssl-redirect: "true"` annotation to `skaffold.yaml`.

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

## Testing

Manual testing. Navigate to `http://local.fiftyone.ai` and ensure that we are automatically redirected to the https endpoint. Also tested via curl:

```shell
$ curl http://local.fiftyone.ai/
<html>
<head><title>308 Permanent Redirect</title></head>
<body>
<center><h1>308 Permanent Redirect</h1></center>
<hr><center>nginx</center>
</body>
</html>
```

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
