### PR TITLE
chore(deps): Update chart-releaser action to 1.7.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         env:
           CR_TOKEN: "${{ secrets.CR_TOKEN }}"
           CR_SKIP_EXISTING: true
-        uses: helm/chart-releaser-action@v1.6.0
+        uses: helm/chart-releaser-action@v1.7.0
         with:
           charts_dir: helm
 


### PR DESCRIPTION
# Rationale

[This PR](https://github.com/voxel51/fiftyone-teams-app-deploy/pull/289) was merged into a branch that was subsequently deleted. Just reopening it / pointing it to a new branch.

## Changes

Bump chart releaser action to 1.7.0.


Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
