### PR TITLE
ToS, Privacy, and Imprint environment values documentation for docker…

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -65,6 +65,7 @@ for steps on how to upgrade your delegated operators.
   - [FiftyOne Teams Plugins](#fiftyone-teams-plugins)
   - [Storage Credentials and `FIFTYONE_ENCRYPTION_KEY`](#storage-credentials-and-fiftyone_encryption_key)
   - [Proxies](#proxies)
+  - [Terms of Service, Privacy, and Imprint URLs](#terms-of-service-privacy-and-imprint-urls)
   - [Text Similarity](#text-similarity)
 - [FiftyOne Teams Environment Variables](#fiftyone-teams-environment-variables)
 
@@ -435,6 +436,27 @@ Please refer to the
 [proxy configuration documentation](./docs/configuring-proxies.md)
 for information on how to configure proxies.
 
+### Terms of Service, Privacy, and Imprint URLs
+
+Fiftyone Teams v2.6 introduces the ability to override
+the Terms of Service, Privacy, and Imprint (optional) links
+if required in the App.
+
+Configure the URLs by setting the following environment variables in
+your `compose.override.yaml`.
+
+Terms of Service URL is configured with `FIFTYONE_APP_TERMS_URL`.
+
+Privacy URL is configured with `FIFTYONE_APP_PRIVACY_URL`.
+
+Imprint/Impressum URL is configured with `FIFTYONE_APP_IMPRINT_URL`
+
+Examples:
+
+- teamsAppSettings.env.`FIFTYONE_APP_TERMS_URL`: `https://abc.com/tos`
+- teamsAppSettings.env.`FIFTYONE_APP_PRIVACY_URL`: `https://abc.com/privacy`
+- teamsAppSettings.env.`FIFTYONE_APP_IMPRINT_URL`: `https://abc.com/imprint`
+
 ### Text Similarity
 
 FiftyOne Teams version 1.2 and higher supports using text similarity searches
@@ -486,6 +508,9 @@ For more information, see the docs for
 | `FIFTYONE_APP_BANNER_COLOR`                 | Global banner background color in App                                                                                                                                                                                                                                          | No                        |
 | `FIFTYONE_APP_BANNER_TEXT_COLOR`            | Global banner text color in App                                                                                                                                                                                                                                                | No                        |
 | `FIFTYONE_APP_BANNER_TEXT`                  | Global banner text in App                                                                                                                                                                                                                                                      | No                        |
+| `FIFTYONE_APP_TERMS_URL`                  | Terms of Service URL used in App                                                                                                                                                                                                                                                      | No                        |
+| `FIFTYONE_APP_PRIVACY_URL`                  | Privacy URL used in App                                                                                                                                                                                                                                                      | No                        |
+| `FIFTYONE_APP_IMPRINT_URL`                  | Imprint URL used in App                                                                                                                                                                                                                                                      | No                        |
 | `FIFTYONE_APP_TEAMS_SDK_RECOMMENDED_VERSION` | The recommended fiftyone SDK version. This will be displayed in install modal (i.e. `pip install ... fiftyone==0.11.0`)                                                                                                                                                       | No                        |
 | `FIFTYONE_APP_THEME`                        | The default theme configuration for your FiftyOne Teams application as described [here](https://docs.voxel51.com/user_guide/config.html#configuring-the-app)                                                                                                                   | No                        |
 | `FIFTYONE_APP_DEFAULT_QUERY_PERFORMANCE`    | Controls whether Query Performance mode is enabled by default for every dataset for the teams application. Set to false to set default mode to off.                                                                                                                            | No                        |

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -69,6 +69,7 @@ for steps on how to upgrade your delegated operators.
   - [Snapshot Archival](#snapshot-archival)
   - [Storage Credentials and `FIFTYONE_ENCRYPTION_KEY`](#storage-credentials-and-fiftyone_encryption_key)
   - [Static Banner Configuration](#static-banner-configuration)
+  - [Terms of Service, Privacy, and Imprint URLs](#terms-of-service-privacy-and-imprint-urls)
   - [Text Similarity](#text-similarity)
 - [Values](#values)
   - [Deploying On GKE](#deploying-on-gke)
@@ -363,6 +364,31 @@ teamsAppSettings:
     FIFTYONE_APP_BANNER_COLOR: "green" # or "rgb(34,139,34)" or ""#f1f1f1"
     FIFTYONE_APP_BANNER_TEXT_COLOR: "green" # or "rgb(34,139,34)" or ""#f1f1f1"
     FIFTYONE_APP_BANNER_TEXT: "Internal Deployment"
+```
+
+### Terms of Service, Privacy, and Imprint URLs
+
+Fiftyone Teams v2.6 introduces the ability to override the Terms of Service, Privacy,
+and Imprint (optional) links if required in the App.
+
+Configure the URLs by setting the following environment variables in
+your `values.yaml`.
+
+Terms of Service URL is configured with
+`teamsAppSettings.env.FIFTYONE_APP_TERMS_URL`.
+
+Privacy URL is configured with
+`teamsAppSettings.env.FIFTYONE_APP_PRIVACY_URL`.
+
+Imprint/Impressum URL is configured with
+`teamsAppSettings.env.FIFTYONE_APP_IMPRINT_URL`
+
+```yaml
+teamsAppSettings:
+  env:
+    FIFTYONE_APP_TERMS_URL: "https://abc.com/tos"
+    FIFTYONE_APP_PRIVACY_URL: "https://abc.com/privacy"
+    FIFTYONE_APP_IMPRINT_URL: "https://abc.com/imprint"
 ```
 
 ### Text Similarity

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -69,6 +69,7 @@ for steps on how to upgrade your delegated operators.
   - [Snapshot Archival](#snapshot-archival)
   - [Storage Credentials and `FIFTYONE_ENCRYPTION_KEY`](#storage-credentials-and-fiftyone_encryption_key)
   - [Static Banner Configuration](#static-banner-configuration)
+  - [Terms of Service, Privacy, and Imprint URLs](#terms-of-service-privacy-and-imprint-urls)
   - [Text Similarity](#text-similarity)
 - [Values](#values)
   - [Deploying On GKE](#deploying-on-gke)
@@ -366,6 +367,31 @@ teamsAppSettings:
     FIFTYONE_APP_BANNER_COLOR: "green" # or "rgb(34,139,34)" or ""#f1f1f1"
     FIFTYONE_APP_BANNER_TEXT_COLOR: "green" # or "rgb(34,139,34)" or ""#f1f1f1"
     FIFTYONE_APP_BANNER_TEXT: "Internal Deployment"
+```
+
+### Terms of Service, Privacy, and Imprint URLs
+
+Fiftyone Teams v2.6 introduces the ability to override the Terms of Service, Privacy,
+and Imprint (optional) links if required in the App.
+
+Configure the URLs by setting the following environment variables in
+your `values.yaml`.
+
+Terms of Service URL is configured with
+`teamsAppSettings.env.FIFTYONE_APP_TERMS_URL`.
+
+Privacy URL is configured with
+`teamsAppSettings.env.FIFTYONE_APP_PRIVACY_URL`.
+
+Imprint/Impressum URL is configured with
+`teamsAppSettings.env.FIFTYONE_APP_IMPRINT_URL`
+
+```yaml
+teamsAppSettings:
+  env:
+    FIFTYONE_APP_TERMS_URL: "https://abc.com/tos"
+    FIFTYONE_APP_PRIVACY_URL: "https://abc.com/privacy"
+    FIFTYONE_APP_IMPRINT_URL: "https://abc.com/imprint"
 ```
 
 ### Text Similarity


### PR DESCRIPTION
# Rationale

https://voxel51.atlassian.net/browse/FOEPD-87

App PR that consumes these variables https://github.com/voxel51/fiftyone-teams/pull/1208

Pretty sure should go out asap - I'll double check with team if 2.6 is correct

- Note: only set in Teams-App container. not needed in CAS

## Changes

<!-- Describe the changes. -->

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
