### PR TITLE
Adding required permissions for v2.5+

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -48,7 +48,7 @@ Please refer to the
 [upgrade documentation](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/docker/docs/upgrading.md#fiftyone-teams-v25-delegated-operator-changes)
 for steps on how to upgrade your delegated operators.
 
-To upgrade to FiftyOne Teams v2.5 or later, ensure that the `dbAdmin` permission is set on the `fiftyone` database, as it is required for proper functionality.
+To upgrade to FiftyOne Teams v2.5 or later, ensure that the `dbAdmin` permission is set on the `fiftyone` database in MongoDB, as it is required for proper functionality.
 
 ## Table of Contents
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -48,6 +48,8 @@ Please refer to the
 [upgrade documentation](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/docker/docs/upgrading.md#fiftyone-teams-v25-delegated-operator-changes)
 for steps on how to upgrade your delegated operators.
 
+To upgrade to FiftyOne Teams v2.5 or later, ensure that the `dbAdmin` permission is set on the `fiftyone` database, as it is required for proper functionality.
+
 ## Table of Contents
 
 <!-- toc -->

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -51,6 +51,8 @@ Please refer to the
 [upgrade documentation](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/upgrading.md#fiftyone-teams-v25-delegated-operator-changes)
 for steps on how to upgrade your delegated operators.
 
+To upgrade to FiftyOne Teams v2.5 or later, ensure that the `dbAdmin` permission is set on the `fiftyone` database, as it is required for proper functionality.
+
 ## Table of Contents
 
 <!-- toc -->

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -51,7 +51,7 @@ Please refer to the
 [upgrade documentation](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/upgrading.md#fiftyone-teams-v25-delegated-operator-changes)
 for steps on how to upgrade your delegated operators.
 
-To upgrade to FiftyOne Teams v2.5 or later, ensure that the `dbAdmin` permission is set on the `fiftyone` database, as it is required for proper functionality.
+To upgrade to FiftyOne Teams v2.5 or later, ensure that the `dbAdmin` permission is set on the `fiftyone` database in MongoDB, as it is required for proper functionality.
 
 ## Table of Contents
 


### PR DESCRIPTION
# Rationale

Upgrading to v2.5 without the `dbAdmin@fiftyone` permission breaks all datasets in FiftyOne App.

## Changes

Adds in a warning in the README to set the required permissions in MongoDB.

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
