### PR TITLE
ci(artifacts): AS-414 Validate Default Docker Pulls

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -21,9 +21,6 @@ jobs:
         run: sudo apt install -y libsqlite3-dev libbz2-dev
       - name: install asdf & tools
         uses: asdf-vm/actions/install@v3.0.2
-      - name: DEBUG
-        run: |
-          which shfmt
-          shfmt --version
-          shfmt -d -w -s utils/bump-fixtures-common.sh utils/bump-fixtures-helm.sh utils/get-image-versions.sh utils/bump-fixtures-docker.sh
+        with:
+          asdf_branch: v0.14.1
       - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -21,4 +21,9 @@ jobs:
         run: sudo apt install -y libsqlite3-dev libbz2-dev
       - name: install asdf & tools
         uses: asdf-vm/actions/install@v3.0.2
+      - name: DEBUG
+        run: |
+          which shfmt
+          shfmt --version
+          shfmt -d -w -s utils/bump-fixtures-common.sh utils/bump-fixtures-helm.sh utils/get-image-versions.sh utils/bump-fixtures-docker.sh
       - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -24,5 +24,6 @@ jobs:
         with:
           # Issue with some of the pre-commit hooks. So pin to an older version for now. See
           # https://github.com/voxel51/fiftyone-teams-app-deploy/actions/runs/13078221229/job/36495530561
+          # See https://voxel51.atlassian.net/browse/AS-506
           asdf_branch: v0.14.1
       - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -22,5 +22,7 @@ jobs:
       - name: install asdf & tools
         uses: asdf-vm/actions/install@v3.0.2
         with:
+          # Issue with some of the pre-commit hooks. So pin to an older version for now. See
+          # https://github.com/voxel51/fiftyone-teams-app-deploy/actions/runs/13078221229/job/36495530561
           asdf_branch: v0.14.1
       - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/test-docker-pulls.yml
+++ b/.github/workflows/test-docker-pulls.yml
@@ -1,0 +1,41 @@
+---
+# Ensures that all of the default images in our
+# helm values.yaml file are pullable to authenticated
+# users.
+# Triggered on the first PR opening to the main branch.
+# Re-runs will need to be manually kicked off.
+# Add 'synchronize' to `on.pull_request.types`
+# if that's a hassle.
+
+name: Tests - Artifact Pulls
+
+on:
+  pull_request:
+    types:
+      - opened
+    branches:
+      - main # test only on first opening to a main branch
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit-helm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+      - uses: actions/setup-python@v5.3.0
+      - name: Temporary SQLite/LZMA - Install missing libraries
+        run: sudo apt install -y libsqlite3-dev libbz2-dev
+      - name: install asdf & tools
+        uses: asdf-vm/actions/install@v3.0.2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Test all docker pulls
+        shell: bash
+        run: |
+          ./utils/validate-docker-pulls.sh

--- a/.github/workflows/test-docker-pulls.yml
+++ b/.github/workflows/test-docker-pulls.yml
@@ -2,10 +2,7 @@
 # Ensures that all of the default images in our
 # helm values.yaml file are pullable to authenticated
 # users.
-# Triggered on the first PR opening to the main branch.
-# Re-runs will need to be manually kicked off.
-# Add 'synchronize' to `on.pull_request.types`
-# if that's a hassle.
+# Triggered on the PRs to the main branch.
 
 name: Tests - Artifact Pulls
 
@@ -13,8 +10,9 @@ on:
   pull_request:
     types:
       - opened
+      - synchronize
     branches:
-      - main # test only on first opening to a main branch
+      - main # test only PRs to main branch
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test-docker-pulls.yml
+++ b/.github/workflows/test-docker-pulls.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.ORG_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.ORG_DOCKERHUB_TOKEN }}
       - name: Test all docker pulls
         shell: bash
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,6 +92,7 @@ repos:
       - id: shellcheck
       - id: shfmt
         args:
+          - -d
           - -w
           - -s
   - repo: https://github.com/compilerla/conventional-pre-commit

--- a/.tool-versions
+++ b/.tool-versions
@@ -6,7 +6,6 @@ jq 1.7.1
 kubectl 1.32.0
 minikube 1.34.0
 pre-commit 4.0.1
-python 3.10.14
 shellcheck 0.10.0
 shfmt 3.10.0
 skaffold 2.13.2

--- a/utils/common.sh
+++ b/utils/common.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
 
-RED="\e[31m"
-GREEN="\e[32m"
-NO_COLOR="\e[0m"
+RED="\033[0;31m"
+GREEN="\033[0;32m"
+NO_COLOR="\033[0m"
 
 # shellcheck disable=SC2034
 GIT_ROOT=$(git rev-parse --show-toplevel)
 
 log_info() {
   local msg="${1}"
-  printf "%sINFO: %s%s$\n" "${GREEN}" "${msg}" "${NO_COLOR}"
+  echo -e "${GREEN}INFO: ${msg}${NO_COLOR}"
 }
 
 log_error() {
   local msg="${1}"
-  printf "%sERROR: %s%s\n" "${RED}" "${msg}" "${NO_COLOR}" >&2
+  echo -e "${RED}ERROR: ${msg}${NO_COLOR}" >&2
 }

--- a/utils/common.sh
+++ b/utils/common.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+RED="\e[31m"
+GREEN="\e[32m"
+NO_COLOR="\e[0m"
+
+# shellcheck disable=SC2034
+GIT_ROOT=$(git rev-parse --show-toplevel)
+
+log_info() {
+  local msg="${1}"
+  printf "%sINFO: %s%s$\n" "${GREEN}" "${msg}" "${NO_COLOR}"
+}
+
+log_error() {
+  local msg="${1}"
+  printf "%sERROR: %s%s\n" "${RED}" "${msg}" "${NO_COLOR}" >&2
+}

--- a/utils/validate-docker-pulls.sh
+++ b/utils/validate-docker-pulls.sh
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
 
+# Validates the pulling of docker images.
+# It maintains a static list of what we expect to be pullable
+# during a helm/docker deployment. It then runs a helm template,
+# utilizing our default values files, to get a list of files that
+# would be deployed. It first compares that list to our
+# EXPECTED_IMAGES array - helping stop typos or unexpected images
+# from leaking into our system. Finally, it pulls each expected image
+# to make sure they are pullable.
+# See ./utils/validate-docker-pulls.sh -h for help.
+
 set -euo pipefail
 
 # These are images we expect to be pullable in an
@@ -29,6 +39,10 @@ print_usage() {
   echo "options:"
   echo "-h, --help               Show brief help"
   echo "-f, --values VALUES_YAML values.yaml to use in templating. Defaults to ${VALUES_YAML}"
+  echo " "
+  echo "examples:"
+  echo "./utils/validate-docker-pulls.sh"
+  echo "./utils/validate-docker-pulls.sh -f ./path/to/values.yaml"
 }
 
 parse_arguments() {

--- a/utils/validate-docker-pulls.sh
+++ b/utils/validate-docker-pulls.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+VALUES_YAML=""
+
+. "$(dirname "$0")/common.sh"
+
+print_usage() {
+  local package
+  package=$(basename "$0")
+  echo "$package - Validate docker pulls for all default images."
+  echo " "
+  echo "$package [options]"
+  echo " "
+  echo "options:"
+  echo "-h, --help               Show brief help"
+  echo "-f, --values VALUES_YAML values.yaml to use in templating"
+}
+
+parse_arguments() {
+  while test $# -gt 0; do
+    case "$1" in
+      -h | --help)
+        print_usage
+        exit 0
+        ;;
+      -f | --values)
+        if [[ -z ${2-} ]]; then
+          log_error "--values requires a value"
+          print_usage
+          exit 1
+        fi
+        if [[ ! -f ${2} ]]; then
+          log_error "Provided values file does not exist or does not have permissions to be read"
+          print_usage
+          exit 1
+        fi
+        VALUES_YAML="${2}"
+        shift 2
+        ;;
+      *)
+        log_error "Unknown option: $1"
+        print_usage
+        exit 1
+        ;;
+    esac
+  done
+}
+
+check_requirements() {
+  required_cmds=("helm" "yq")
+
+  for cmd in "${required_cmds[@]}"; do
+    if ! command -v "$cmd" &>/dev/null; then
+      log_error "'$cmd' doesn't exist or is not executable. Please install '$cmd'"
+      exit 1
+    fi
+  done
+}
+
+docker_pull() {
+  local image="$1"
+
+  if ! docker pull "${image}"; then
+    return 1
+  fi
+
+  return 0
+}
+
+parse_arguments "$@"
+check_requirements
+
+cd "${GIT_ROOT}/helm/fiftyone-teams-app"
+
+images=$(
+  helm template . -f "${VALUES_YAML}" |
+    yq eval -o yaml '.. | select(.image? != null) | .image' |
+    sort |
+    uniq |
+    grep -v -- '---' |
+    xargs
+)
+
+read -r -a images_array <<<"$images"
+
+pids=()
+rcs=()
+exit_code=0
+
+for img in "${images_array[@]}"; do
+  docker_pull "${img}" &
+  pids+=($!)
+done
+
+set +e # disable -e for 'wait'
+for pid in "${pids[@]}"; do
+  wait "${pid}"
+  rcs+=($?)
+done
+set -e
+
+for idx in "${!rcs[@]}"; do
+  if [[ ${rcs[$idx]} -ne 0 ]]; then
+    log_error "Could not pull ${images_array[$idx]}!"
+    exit_code=1
+  else
+    log_info "Pulled ${images_array[$idx]} successfully."
+  fi
+done
+
+exit $exit_code

--- a/utils/validate-docker-pulls.sh
+++ b/utils/validate-docker-pulls.sh
@@ -72,10 +72,8 @@ docker_pull() {
 parse_arguments "$@"
 check_requirements
 
-cd "${GIT_ROOT}/helm/fiftyone-teams-app"
-
 images=$(
-  helm template . -f "${VALUES_YAML}" |
+  helm template "${GIT_ROOT}/helm/fiftyone-teams-app" -f "${VALUES_YAML}" |
     yq eval -o yaml '.. | select(.image? != null) | .image' |
     sort |
     uniq |


### PR DESCRIPTION
# Rationale

We require a way to make sure that all of our docker images are pullable before releasing artifacts to the public. We spoke internally about a script that performs this validation - essentially doing a `docker pull` on every image in the output of a `helm template`.

This PR takes a first pass at that - creating a bash script to:

1. Template a helm chart with values file
2. Perform a docker pull on every image it finds
3. Exit 0 or 1, depending on the success of these pulls

## Changes

* A new script to perform the above
* A new github action to run this script when a PR to main is first opened
  * intentionally left out `synchronize`
* A new set of common scripts like logging / common variables that every script uses

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

## Testing

<details open>
<summary>Testing...</summary>
<br>

Successful!
```
./utils/validate-docker-pulls.sh 
v2.5.0: Pulling from voxel51/fiftyone-teams-cas
v2.5.0: Pulling from voxel51/fiftyone-teams-api
v2.5.0: Pulling from voxel51/fiftyone-teams-app
stable-glibc: Pulling from library/busybox
Digest: sha256:a65e1b3739ab18fbb6c6df7b8adbbb25e863a0e4dd52117ed70b51a2d3e8468c
Status: Image is up to date for voxel51/fiftyone-teams-api:v2.5.0
Digest: sha256:65260dc7d92a4d989026c92255eec9d1a4fc0dceb677d4dcd9ce67e9aed882a9
Status: Image is up to date for voxel51/fiftyone-teams-cas:v2.5.0
docker.io/voxel51/fiftyone-teams-api:v2.5.0
docker.io/voxel51/fiftyone-teams-cas:v2.5.0
Digest: sha256:53f3fff4a69d5a9a09091efe5fa01f5eef9643ef9c18d189030b8fd32597fa50
Status: Image is up to date for voxel51/fiftyone-teams-app:v2.5.0
docker.io/voxel51/fiftyone-teams-app:v2.5.0
Digest: sha256:870b2cfd9e8f465247c14a96680388426e2f28a8494b798e7aa1714683163eb0
Status: Image is up to date for busybox:stable-glibc
docker.io/library/busybox:stable-glibc
v2.5.0: Pulling from voxel51/fiftyone-app
Digest: sha256:87b4e7c165522d32c614f8fb2f689e46ca493c2d3bae376a14fde23e29e66005
Status: Image is up to date for voxel51/fiftyone-app:v2.5.0
docker.io/voxel51/fiftyone-app:v2.5.0

What's next:

What's next:

What's next:

What's next:
    View a summary of image vulnerabilities and recommendations → docker scout quickview voxel51/fiftyone-app:v2.5.0
    View a summary of image vulnerabilities and recommendations → docker scout quickview voxel51/fiftyone-teams-api:v2.5.0
    View a summary of image vulnerabilities and recommendations → docker scout quickview voxel51/fiftyone-teams-cas:v2.5.0

What's next:
    View a summary of image vulnerabilities and recommendations → docker scout quickview voxel51/fiftyone-teams-app:v2.5.0
    View a summary of image vulnerabilities and recommendations → docker scout quickview docker.io/busybox:stable-glibc
INFO: Pulled docker.io/busybox:stable-glibc successfully.
INFO: Pulled voxel51/fiftyone-app:v2.5.0 successfully.
INFO: Pulled voxel51/fiftyone-teams-api:v2.5.0 successfully.
INFO: Pulled voxel51/fiftyone-teams-app:v2.5.0 successfully.
INFO: Pulled voxel51/fiftyone-teams-cas:v2.5.0 successfully.
```

Non-successful
```
./utils/validate-docker-pulls.sh
.
.
.
ERROR: Could not pull FIFTYONE_AUTH_MODE!
ERROR: Could not pull FIFTYONE_AUTH_SECRET!
ERROR: Could not pull FIFTYONE_DATABASE_ADMIN!
ERROR: Could not pull FIFTYONE_DATABASE_NAME!
ERROR: Could not pull FIFTYONE_DATABASE_URI!
ERROR: Could not pull FIFTYONE_ENCRYPTION_KEY!
ERROR: Could not pull FIFTYONE_ENV!
ERROR: Could not pull FIFTYONE_INTERNAL_SERVICE!
ERROR: Could not pull FIFTYONE_MEDIA_CACHE_APP_IMAGES!
ERROR: Could not pull FIFTYONE_MEDIA_CACHE_SIZE_BYTES!
ERROR: Could not pull FIFTYONE_SERVER_ADDRESS!
ERROR: Could not pull FIFTYONE_SERVER_PATH_PREFIX!
ERROR: Could not pull FIFTYONE_SIGNED_URL_EXPIRATION!
ERROR: Could not pull FIFTYONE_TEAMS_PLUGIN_URL!
ERROR: Could not pull FIFTYONE_TEAMS_PROXY_URL!
ERROR: Could not pull GRAPHQL_DEFAULT_LIMIT!
ERROR: Could not pull LICENSE_KEY_FILE_PATHS!
ERROR: Could not pull LOGGING_LEVEL!
ERROR: Could not pull MONGO_DEFAULT_DB!
ERROR: Could not pull NEXTAUTH_URL!
ERROR: Could not pull RECOIL_DUPLICATE_ATOM_KEY_CHECKING_ENABLED!
ERROR: Could not pull TEAMS_API_DATABASE_NAME!
ERROR: Could not pull TEAMS_API_MONGODB_URI!
ERROR: Could not pull fiftyone-app!
ERROR: Could not pull fiftyone-license!
ERROR: Could not pull fiftyone-teams!
ERROR: Could not pull fiftyone-teams-secrets!
ERROR: Could not pull http!
ERROR: Could not pull init-cas!
ERROR: Could not pull release-name-fiftyone-teams-app!
ERROR: Could not pull teams-api!
ERROR: Could not pull teams-app!
ERROR: Could not pull teams-cas!
```
</details>
<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
