### PR TITLE
chore: Unit tests require old ASDF

### DIFF
--- a/.github/workflows/test-docker-pulls.yml
+++ b/.github/workflows/test-docker-pulls.yml
@@ -28,6 +28,11 @@ jobs:
         run: sudo apt install -y libsqlite3-dev libbz2-dev
       - name: install asdf & tools
         uses: asdf-vm/actions/install@v3.0.2
+        with:
+          # Issue with some of the tests. So pin to an older version for now. See
+          # https://github.com/voxel51/fiftyone-teams-app-deploy/actions/runs/13078221229/job/36495530561
+          # https://voxel51.atlassian.net/browse/AS-506
+          asdf_branch: v0.14.1
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -27,6 +27,11 @@ jobs:
       - uses: actions/setup-python@v5.3.0
       - name: install asdf & tools
         uses: asdf-vm/actions/install@v3.0.2
+        with:
+          # Issue with some of the tests. So pin to an older version for now. See
+          # https://github.com/voxel51/fiftyone-teams-app-deploy/actions/runs/13078221229/job/36495530561
+          # https://voxel51.atlassian.net/browse/AS-506
+          asdf_branch: v0.14.1
       - name: Run unit tests
         shell: bash
         run: |
@@ -43,6 +48,11 @@ jobs:
         run: sudo apt install -y libsqlite3-dev libbz2-dev
       - name: install asdf & tools
         uses: asdf-vm/actions/install@v3.0.2
+        with:
+          # Issue with some of the tests. So pin to an older version for now. See
+          # https://github.com/voxel51/fiftyone-teams-app-deploy/actions/runs/13078221229/job/36495530561
+          # https://voxel51.atlassian.net/browse/AS-506
+          asdf_branch: v0.14.1
       - name: Authenticate to Google Cloud
         id: auth
         uses: google-github-actions/auth@v2.1.7
@@ -80,6 +90,11 @@ jobs:
       - uses: actions/setup-python@v5.3.0
       - name: install asdf & tools
         uses: asdf-vm/actions/install@v3.0.2
+        with:
+          # Issue with some of the tests. So pin to an older version for now. See
+          # https://github.com/voxel51/fiftyone-teams-app-deploy/actions/runs/13078221229/job/36495530561
+          # https://voxel51.atlassian.net/browse/AS-506
+          asdf_branch: v0.14.1
       - name: Authenticate to Google Cloud
         id: auth
         uses: google-github-actions/auth@v2.1.7

--- a/.github/workflows/test-helm.yml
+++ b/.github/workflows/test-helm.yml
@@ -27,6 +27,11 @@ jobs:
         run: sudo apt install -y libsqlite3-dev libbz2-dev
       - name: install asdf & tools
         uses: asdf-vm/actions/install@v3.0.2
+        with:
+          # Issue with some of the tests. So pin to an older version for now. See
+          # https://github.com/voxel51/fiftyone-teams-app-deploy/actions/runs/13078221229/job/36495530561
+          # https://voxel51.atlassian.net/browse/AS-506
+          asdf_branch: v0.14.1
       - name: Run unit tests
         shell: bash
         run: |

--- a/.github/workflows/test-integration-helm.yml
+++ b/.github/workflows/test-integration-helm.yml
@@ -30,6 +30,11 @@ jobs:
         run: sudo apt install -y libsqlite3-dev libbz2-dev
       - name: install asdf & tools
         uses: asdf-vm/actions/install@v3.0.2
+        with:
+          # Issue with some of the tests. So pin to an older version for now. See
+          # https://github.com/voxel51/fiftyone-teams-app-deploy/actions/runs/13078221229/job/36495530561
+          # https://voxel51.atlassian.net/browse/AS-506
+          asdf_branch: v0.14.1
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:


### PR DESCRIPTION
# Rationale

It appears the ASDF warnings also, somehow, mess with our unit tests. I have seem a few dependabot PRs fail unit tests but, for no apparent reason. After testing, it appears that pinning to a pre-golang ASDF solves this issue. I pinned it to 0.14.1 as that is the ASDF version I am using locally.

This may need to be cherry-picked into `release/v2.6.0`.

## Changes

Pins the ASDF version to the bash implementations of ASDF. Newer versions are written in golang which appear to cause issues when ASDF binaries are invoked.

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
