### PR TITLE
chore: tests and documentation for HA API

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,5 @@
 cmctl 2.1.1
+gcloud 509.0.0
 golang 1.22.3
 helm 3.16.4
 helm-docs 1.14.2
@@ -6,6 +7,7 @@ jq 1.7.1
 kubectl 1.32.0
 minikube 1.34.0
 pre-commit 4.0.1
+python 3.11.11
 shellcheck 0.10.0
 shfmt 3.10.0
 skaffold 2.13.2

--- a/helm/docs/configure-ha-teams-api.md
+++ b/helm/docs/configure-ha-teams-api.md
@@ -1,0 +1,154 @@
+<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-disable-next-line first-line-heading -->
+<div align="center">
+<p align="center">
+
+<img src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
+
+</p>
+</div>
+<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
+
+---
+
+# Configuring Highly Available FiftyOne `teams-api` Deployments
+
+FiftyOne Teams v2.7 introduces support for running multiple `teams-api` pods for
+high availability [HA].
+
+Running multiple `teams-api` pods requires a read-write volume available to all
+of the pods in the `teams-api` deployment to synchronize the API cache.
+
+In this example we will use a read-write-many [RWX] persistent volume [PV]
+mounted from an NFS server. Alternate storage solutions vary based on cloud
+providers and infrastructure services.  PVs may also be configured using a
+number of provider-specific services, such as:
+
+* Google Cloud
+  [Filestore](https://cloud.google.com/filestore/docs)
+* Amazon
+  [EFS](https://aws.amazon.com/efs/)
+* Azure
+  [Files](https://learn.microsoft.com/en-us/azure/storage/files/).
+
+## Provision an NFS Share
+
+Configure an NFS export on an NFS server accessible by the kubernetes cluster.
+An example configuration would be to share an `/exports/fiftyone_teams_app`
+directory:
+
+```shell
+$ cat /etc/exports
+/exports 10.202.15.0/24(rw,insecure,fsid=0,root_squash,all_squash,no_subtree_check)
+/exports/fiftyone_teams_app
+```
+
+> [!TIP]
+> The NFS share used for HA FiftyOne Teams API pods can be the same NFS share
+> used for plugins.  Voxel51 uses the parent directory as the shared root, and
+> a subdirectory for read-only plugin PVCs.
+
+## PV and PVC Creation
+
+The following yaml configuration will create a PV and PVC designed to access the
+NFS share provisioned above:
+
+```yaml
+# nfs-shared-pv-pvc.yaml
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: teams-shared-pv
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteMany
+  claimRef:
+    name: teams-shared-pvc
+    namespace: fiftyone-teams
+  nfs:
+    server: nfs-server
+    path: "/fiftyone_teams_app"
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: teams-shared-pvc
+  namespace: fiftyone-teams
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""
+  resources:
+    requests:
+      storage: 10Gi
+```
+
+Apply the configuration to create the PV and PVC for shared storage:
+
+```shell
+kubectl apply -f nfs-shared-pv-pvc.yaml
+```
+
+## `values.yaml` Changes
+
+### Add PVs and PVCs
+
+To run multiple `teams-api` pods, provide `ReadWrite` access to the `teams-api`
+deployment by adding `volumes` and `volumeMounts` configuration to the
+`apiSettings` section of your `values.yaml`:
+
+```yaml
+# values.yaml
+apiSettings:
+  [...existing config...]
+  volumes:
+    - name: nfs-shared-vol
+   persistentVolumeClaim:
+     claimName: teams-shared-pvc
+  volumeMounts:
+    - name: nfs-shared-vol
+   mountPath: /opt/shared
+  [...existing config...]
+```
+
+### Set the `FIFTYONE_SHARED_ROOT_DIR` environment variable
+
+To run multiple `teams-api` pods, set the `FIFTYONE_SHARED_ROOT_DIR` environment
+variable in `apiSettings.env` section of your `values.yaml`:
+
+```yaml
+# values.yaml
+apiSettings:
+  [...existing config...]
+  env:
+    [...existing env config...]
+ FIFTYONE_SHARED_ROOT_DIR: /opt/shared
+ [...existing env config...]
+  [...existing config...]
+```
+
+### Set the number of `teams-api` replicas to run
+
+To run multiple `teams-api` pods, set the `apiSettings.replicaCount` value in
+your `values.yaml`:
+
+```yaml
+# values.yaml
+apiSettings:
+  [...existing config...]
+  replicaCount: 2
+  [...existing config...]
+```
+
+## Apply the Changes to the Existing `fiftyone-teams-app` Deployment
+
+Apply the changes to the existing `fiftyone-teams-app` Helm deployment:
+
+```shell
+helm upgrade fiftyone-teams-app voxel51/fiftyone-teams-app -f values.yaml
+```

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -64,6 +64,7 @@ for steps on how to upgrade your delegated operators.
   - [Builtin Delegated Operator Orchestrator](#builtin-delegated-operator-orchestrator)
   - [Central Authentication Service](#central-authentication-service)
   - [FiftyOne Teams Authenticated API](#fiftyone-teams-authenticated-api)
+  - [Highly Available FiftyOne `teams-api` Deployments](#highly-available-fiftyone-teams-api-deployments)
   - [Plugins](#plugins)
   - [Proxies](#proxies)
   - [Snapshot Archival](#snapshot-archival)
@@ -247,6 +248,17 @@ To enable the FiftyOne Teams Authenticated API,
 [expose the FiftyOne Teams API endpoint](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/expose-teams-api.md)
 and
 [configure your SDK](https://docs.voxel51.com/teams/api_connection.html).
+
+### Highly Available FiftyOne `teams-api` Deployments
+
+FiftyOne Teams v2.7 introduced support for running multiple `teams-api` pods for
+high availability [HA].
+
+Running multiple `teams-api` pods requires a read-write volume available to all
+of the pods in the `teams-api` deployment to synchronize the API cache.
+
+For configuring HA FiftyOne `teams-api` deployments see
+[Configuring Highly Available FiftyOne `teams-api` Deployments](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/configure-ha-teams-api.md)
 
 ### Plugins
 

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -64,6 +64,7 @@ for steps on how to upgrade your delegated operators.
   - [Builtin Delegated Operator Orchestrator](#builtin-delegated-operator-orchestrator)
   - [Central Authentication Service](#central-authentication-service)
   - [FiftyOne Teams Authenticated API](#fiftyone-teams-authenticated-api)
+  - [Highly Available FiftyOne `teams-api` Deployments](#highly-available-fiftyone-teams-api-deployments)
   - [Plugins](#plugins)
   - [Proxies](#proxies)
   - [Snapshot Archival](#snapshot-archival)
@@ -248,6 +249,17 @@ To enable the FiftyOne Teams Authenticated API,
 [expose the FiftyOne Teams API endpoint](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/expose-teams-api.md)
 and
 [configure your SDK](https://docs.voxel51.com/teams/api_connection.html).
+
+### Highly Available FiftyOne `teams-api` Deployments
+
+FiftyOne Teams v2.7 introduced support for running multiple `teams-api` pods for
+high availability [HA].
+
+Running multiple `teams-api` pods requires a read-write volume available to all
+of the pods in the `teams-api` deployment to synchronize the API cache.
+
+For configuring HA FiftyOne `teams-api` deployments see
+[Configuring Highly Available FiftyOne `teams-api` Deployments](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/configure-ha-teams-api.md)
 
 ### Plugins
 

--- a/tests/unit/helm/api-deployment_test.go
+++ b/tests/unit/helm/api-deployment_test.go
@@ -197,6 +197,21 @@ func (s *deploymentApiTemplateTest) TestReplicas() {
 			nil,
 			1,
 		},
+		{
+			"overrideReplicaCountWithoutCacheDefined",
+			map[string]string{
+				"apiSettings.replicaCount": "3",
+			},
+			1,
+		},
+		{
+			"overrideReplicaCountWithCacheDefined",
+			map[string]string{
+				"apiSettings.replicaCount":                 "2",
+				"apiSettings.env.FIFTYONE_SHARED_ROOT_DIR": "/opt/shared",
+			},
+			2,
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
# Rationale

We added support for multiple replicas in `teams-api` in our Helm charts, and deployed it to dev.fifityone.ai

This is a followup PR to document how to replicate that process, and to add documentation.

I am not adding documentation for docker-compose environments as we do not typically treat those environments as highly-available

## Changes

- tests
- docs
