### PR TITLE
fix: AS-324 implementing path filter

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
       - release/*
+      - release-next
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,78 @@
+name: Pull Request
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - main
+      - release/*
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  modified-files:
+    runs-on: ubuntu-latest
+    outputs:
+      docker-unit-required: ${{ steps.filter.outputs.docker-unit }}
+      helm-integration-required: ${{ steps.filter.outputs.helm-integration }}
+      helm-unit-required: ${{ steps.filter.outputs.helm-unit }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            docker-unit:
+              - '.github/workflows/test-docker.yml'
+              - 'docker/common-services.yaml'
+              - 'docker/internal-auth/**'
+              - 'docker/legacy-auth/**'
+              - 'tests/fixtures/docker/**'
+              - 'tests/integration/compose/**'
+              - 'tests/unit/compose/**'
+            helm-integration:
+              - '.github/workflows/test-integration-helm.yml'
+              - 'helm/fiftyone-teams-app/**'
+              - 'tests/fixtures/helm/**'
+              - 'tests/integration/helm/**'
+              - 'tests/unit/helm/**'
+            helm-unit:
+              - '.github/workflows/test-helm.yml'
+              - 'helm/fiftyone-teams-app/**'
+              - 'tests/fixtures/helm/**'
+              - 'tests/integration/helm/**'
+              - 'tests/unit/helm/**'
+
+  docker-unit:
+    needs: modified-files
+    if: ${{ needs.modified-files.outputs.docker-unit-required == 'true' }}
+    uses: ./.github/workflows/test-docker.yml
+
+  helm-integration:
+    needs: modified-files
+    if: ${{ needs.modified-files.outputs.helm-integration-required == 'true' }}
+    uses: ./.github/workflows/test-integration-helm.yml
+
+  helm-unit:
+    needs: modified-files
+    if: ${{ needs.modified-files.outputs.helm-unit-required == 'true' }}
+    uses: ./.github/workflows/test-helm.yml
+
+  all-tests:
+    runs-on: ubuntu-latest
+    needs: [docker-unit, helm-unit, helm-integration]
+    if: always()
+    steps:
+      - run: sh -c ${{
+          (needs.docker-unit.result == 'success' || needs.docker-unit.result == 'skipped') &&
+          (needs.helm-integration.result == 'success' || needs.helm-integration.result == 'skipped') &&
+          (needs.helm-unit.result == 'success' || needs.helm-unit.result == 'skipped') }}
+
+  helm-pre-release:
+    needs: [all-tests, helm-unit, helm-integration]
+    if: |
+      always() &&
+      (needs.helm-unit.result == 'success' || needs.helm-integration.result == 'success')
+    uses: ./.github/workflows/pre-release-internal-env.yml

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -50,11 +50,18 @@ jobs:
     needs: modified-files
     if: ${{ needs.modified-files.outputs.docker-unit-required == 'true' }}
     uses: ./.github/workflows/test-docker.yml
+    secrets:
+      REPO_GOOGLE_WORKLOAD_IDP: ${{ secrets.REPO_GOOGLE_WORKLOAD_IDP }}
+      FO_INTERNAL_LICENSE: ${{ secrets.FO_INTERNAL_LICENSE }}
+      FO_LEGACY_LICENSE: ${{ secrets.FO_LEGACY_LICENSE }}
 
   helm-integration:
     needs: modified-files
     if: ${{ needs.modified-files.outputs.helm-integration-required == 'true' }}
     uses: ./.github/workflows/test-integration-helm.yml
+    secrets:
+      REPO_GOOGLE_WORKLOAD_IDP: ${{ secrets.REPO_GOOGLE_WORKLOAD_IDP }}
+
 
   helm-unit:
     needs: modified-files
@@ -77,3 +84,8 @@ jobs:
       always() &&
       (needs.helm-unit.result == 'success' || needs.helm-integration.result == 'success')
     uses: ./.github/workflows/pre-release-internal-env.yml
+    secrets:
+      REPO_GOOGLE_WORKLOAD_IDP: ${{ secrets.REPO_GOOGLE_WORKLOAD_IDP }}
+      WD_HCI_FG_PAT: ${{ secrets.WD_HCI_FG_PAT }}
+      CROSS_REPOSITORY_REPOSITORY: ${{ secrets.CROSS_REPOSITORY_REPOSITORY }}
+      CROSS_REPOSITORY_WORKFLOW: ${{ secrets.CROSS_REPOSITORY_WORKFLOW }}

--- a/.github/workflows/pre-release-internal-env.yml
+++ b/.github/workflows/pre-release-internal-env.yml
@@ -10,7 +10,17 @@
 name: Release Pre-release charts
 
 on:
-  workflow_call: {}
+  workflow_call:
+    secrets:
+      REPO_GOOGLE_WORKLOAD_IDP:
+        required: true
+      WD_HCI_FG_PAT:
+        required: true
+      CROSS_REPOSITORY_REPOSITORY:
+        required: true
+      CROSS_REPOSITORY_WORKFLOW:
+        required: true
+
 
   push:
     branches-ignore:

--- a/.github/workflows/pre-release-internal-env.yml
+++ b/.github/workflows/pre-release-internal-env.yml
@@ -1,12 +1,9 @@
 ---
 # Releases a pre-release chart and the charts
-# that depend on it. It is triggered by:
-# 1) pushes to a feature/fix/non-release branch.
-#    This allows us to test changes in live envs before submitting
-#    a PR.
-# 2) The PR workflow. The PR workflow will first run any and all tests
-#    that it has to. If the tests are successful,create a new RC-stamped
-#    chart to use for internal environments.
+# that depend on it. It is triggered by
+# The PR workflow. The PR workflow will first run any and all tests
+# that it has to. If the tests are successful,create a new RC-stamped
+# chart to use for internal environments.
 name: Release Pre-release charts
 
 on:
@@ -20,15 +17,6 @@ on:
         required: true
       CROSS_REPOSITORY_WORKFLOW:
         required: true
-
-
-  push:
-    branches-ignore:
-      - main
-      - release/*
-    paths:
-      - 'helm/fiftyone-teams-app/**'
-      - '.github/workflows/pre-release-internal-env.yml'
 
 jobs:
   pre-release:

--- a/.github/workflows/pre-release-internal-env.yml
+++ b/.github/workflows/pre-release-internal-env.yml
@@ -1,10 +1,21 @@
 ---
+# Releases a pre-release chart and the charts
+# that depend on it. It is triggered by:
+# 1) pushes to a feature/fix/non-release branch.
+#    This allows us to test changes in live envs before submitting
+#    a PR.
+# 2) The PR workflow. The PR workflow will first run any and all tests
+#    that it has to. If the tests are successful,create a new RC-stamped
+#    chart to use for internal environments.
 name: Release Pre-release charts
 
 on:
+  workflow_call: {}
+
   push:
     branches-ignore:
       - main
+      - release/*
     paths:
       - 'helm/fiftyone-teams-app/**'
       - '.github/workflows/pre-release-internal-env.yml'

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -3,10 +3,6 @@ name: Tests - Docker Compose
 
 on: workflow_call
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   unit-compose:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -1,19 +1,7 @@
 ---
 name: Tests - Docker Compose
 
-on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-    paths:
-      - .github/workflows/test-docker.yml
-      - docker/common-services.yaml
-      - docker/internal-auth/**
-      - docker/legacy-auth/**
-      - tests/fixtures/docker/**
-      - tests/integration/compose/**
-      - tests/unit/compose/**
+on: workflow_call
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -1,7 +1,15 @@
 ---
 name: Tests - Docker Compose
 
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      REPO_GOOGLE_WORKLOAD_IDP:
+        required: true
+      FO_INTERNAL_LICENSE:
+        required: true
+      FO_LEGACY_LICENSE:
+        required: true
 
 jobs:
   unit-compose:

--- a/.github/workflows/test-helm.yml
+++ b/.github/workflows/test-helm.yml
@@ -3,10 +3,6 @@ name: Tests - Helm
 
 on: workflow_call
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   unit-helm:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-helm.yml
+++ b/.github/workflows/test-helm.yml
@@ -1,17 +1,7 @@
 ---
 name: Tests - Helm
 
-on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-    paths:
-      - .github/workflows/test-helm.yml
-      - helm/fiftyone-teams-app/**
-      - tests/fixtures/helm/**
-      - tests/integration/helm/**
-      - tests/unit/helm/**
+on: workflow_call
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test-integration-helm.yml
+++ b/.github/workflows/test-integration-helm.yml
@@ -1,7 +1,11 @@
 ---
 name: Tests - Integration Helm
 
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      REPO_GOOGLE_WORKLOAD_IDP:
+        required: true
 
 jobs:
   integration-helm:

--- a/.github/workflows/test-integration-helm.yml
+++ b/.github/workflows/test-integration-helm.yml
@@ -3,10 +3,6 @@ name: Tests - Integration Helm
 
 on: workflow_call
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   integration-helm:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-integration-helm.yml
+++ b/.github/workflows/test-integration-helm.yml
@@ -1,17 +1,7 @@
 ---
 name: Tests - Integration Helm
 
-on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-    paths:
-      - .github/workflows/test-integration-helm.yml
-      - helm/fiftyone-teams-app/**
-      - tests/fixtures/helm/**
-      - tests/integration/helm/**
-      - tests/unit/helm/**
+on: workflow_call
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
# Rationale

Currently, we publish pre-release artifacts on every push. That means that we're pushing some artifacts which just won't work. We should re-arrange that workflow so that artifact pushes happen only after tests have successfully run.

That also means that we shouldn't push on every branch and PRs have to be submitted before building pre-release artifacts. That seems OK to me!

## Changes

Restructure workflows to use `workflow_call` instead of `pull_request` events. A new wrapper, similar to fiftyone OSS, will pull those steps together. Affected workflows are:

- test-docker
- test-helm
- test-integration-helm
- pre-release-internal-env

As a final step, the workflow will trigger a pre-release build.

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
