### PR TITLE
refactor(pre-commit): change shfmt arguments from short form to long …

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,9 +92,9 @@ repos:
       - id: shellcheck
       - id: shfmt
         args:
-          - -d
-          - -w
-          - -s
+          - --diff
+          - --write
+          - --simplify
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v4.0.0
     hooks:


### PR DESCRIPTION
…form for easier readability.

# Rationale

While reviewing an already merged PR, noticed that we updated the `.pre-commit-config.yaml` `shfmt` hook adding `-d`.  What's `-d`?  ¯\_(ツ)_/¯. Oh.  `diff`. Let's use the long form instead. : D

## Changes

* pre-commit

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

n/a ^

## Testing

<!-- Describe the way the changes were tested. -->

## Notes

<details>
<summary>`shfmt --help`</summary>

```
$ shfmt --help
usage: shfmt [flags] [path ...]

shfmt formats shell programs. If the only argument is a dash ('-') or no
arguments are given, standard input will be used. If a given path is a
directory, all shell scripts found under that directory will be used.

  --version  show version and exit

  -l,  --list      list files whose formatting differs from shfmt's
  -w,  --write     write result to file instead of stdout
  -d,  --diff      error with a diff when the formatting differs
  -s,  --simplify  simplify the code
  -mn, --minify    minify the code to reduce its size (implies -s)
  --apply-ignore   always apply EditorConfig ignore rules
  --filename str   provide a name for the standard input file

Parser options:

  -ln, --language-dialect str  bash/posix/mksh/bats, default "auto"
  -p,  --posix                 shorthand for -ln=posix

Printer options:

  -i,  --indent uint       0 for tabs (default), >0 for number of spaces
  -bn, --binary-next-line  binary ops like && and | may start a line
  -ci, --case-indent       switch cases will be indented
  -sr, --space-redirects   redirect operators will be followed by a space
  -kp, --keep-padding      keep column alignment paddings
  -fn, --func-next-line    function opening braces are placed on a separate line

Utilities:

  -f, --find   recursively find all shell files and print the paths
  --to-json    print syntax tree to stdout as a typed JSON
  --from-json  read syntax tree from stdin as a typed JSON

Formatting options can also be read from EditorConfig files; see 'man shfmt'
for a detailed description of the tool's behavior.
For more information and to report bugs, see https://github.com/mvdan/sh.
```

</details>

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections

-->
