### PR TITLE
chore: bring banner doc updates forward from the future

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -316,6 +316,30 @@ Please refer to the
 [snapshot archival configuration documentation](./docs/configuring-snapshot-archival.md)
 for configuring snapshot archival.
 
+### Static Banner Configuration
+
+Fiftyone Teams v2.6 introduces the ability to add a static banner to the
+application.
+
+Configure the Static Banner by setting the following environment variables in
+your `compose.override.yaml`.
+
+Banner text is configured with `FIFTYONE_APP_BANNER_TEXT`.
+
+Banner background color is configured with `FIFTYONE_APP_BANNER_COLOR`.
+
+Banner text color is configured with:
+`casSettings.env.FIFTYONE_APP_BANNER_TEXT_COLOR` and
+`teamsAppSettings.env.FIFTYONE_APP_BANNER_TEXT_COLOR`
+
+Examples:
+
+- (casSettings | teamsAppSettings).env.
+  `FIFTYONE_APP_BANNER_COLOR`: `green | rgb(34,139,34) | #f1f1f1`
+- (casSettings | teamsAppSettings).env.
+  `FIFTYONE_APP_BANNER_TEXT_COLOR`: `green | rgb(34,139,34") | #f1f1f1`
+- (casSettings | teamsAppSettings).env.`FIFTYONE_APP_BANNER_TEXT`="Internal Deployment"
+
 ### FiftyOne Teams Authenticated API
 
 FiftyOne Teams v1.3 introduces the capability to connect FiftyOne Teams SDK

--- a/docker/README.md
+++ b/docker/README.md
@@ -60,6 +60,7 @@ for steps on how to upgrade your delegated operators.
   - [Builtin Delegated Operator Orchestrator](#builtin-delegated-operator-orchestrator)
   - [Central Authentication Service](#central-authentication-service)
   - [Snapshot Archival](#snapshot-archival)
+  - [Static Banner Configuration](#static-banner-configuration)
   - [FiftyOne Teams Authenticated API](#fiftyone-teams-authenticated-api)
   - [FiftyOne Teams Plugins](#fiftyone-teams-plugins)
   - [Storage Credentials and `FIFTYONE_ENCRYPTION_KEY`](#storage-credentials-and-fiftyone_encryption_key)
@@ -334,11 +335,19 @@ Banner text color is configured with:
 
 Examples:
 
-- (casSettings | teamsAppSettings).env.
-  `FIFTYONE_APP_BANNER_COLOR`: `green | rgb(34,139,34) | #f1f1f1`
-- (casSettings | teamsAppSettings).env.
-  `FIFTYONE_APP_BANNER_TEXT_COLOR`: `green | rgb(34,139,34") | #f1f1f1`
-- (casSettings | teamsAppSettings).env.`FIFTYONE_APP_BANNER_TEXT`="Internal Deployment"
+```yaml
+services:
+  teams-app-common:
+    environment:
+      FIFTYONE_APP_BANNER_COLOR: `green | rgb(34,139,34") | '#f1f1f1'`
+      FIFTYONE_APP_BANNER_TEXT_COLOR: `green | rgb(34,139,34") | '#f1f1f1'`
+      FIFTYONE_APP_BANNER_TEXT: "Internal Deployment"
+  teams-cas-common:
+    environment:
+      FIFTYONE_APP_BANNER_COLOR: `green | rgb(34,139,34") | '#f1f1f1'`
+      FIFTYONE_APP_BANNER_TEXT_COLOR: `green | rgb(34,139,34") | '#f1f1f1'`
+      FIFTYONE_APP_BANNER_TEXT: "Internal Deployment"
+```
 
 ### FiftyOne Teams Authenticated API
 

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -68,6 +68,7 @@ for steps on how to upgrade your delegated operators.
   - [Proxies](#proxies)
   - [Snapshot Archival](#snapshot-archival)
   - [Storage Credentials and `FIFTYONE_ENCRYPTION_KEY`](#storage-credentials-and-fiftyone_encryption_key)
+  - [Static Banner Configuration](#static-banner-configuration)
   - [Text Similarity](#text-similarity)
 - [Values](#values)
   - [Deploying On GKE](#deploying-on-gke)

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -331,6 +331,39 @@ FiftyOne Teams continues to support the use of environment variables to set
 storage credentials in the application context and is providing an alternate
 configuration path.
 
+### Static Banner Configuration
+
+Fiftyone Teams v2.6 introduces the ability to add a static banner to the
+application.
+
+Configure the Static Banner by setting the following environment variables in
+your `values.yaml`.
+
+Banner text is configured with:
+`casSettings.env.FIFTYONE_APP_BANNER_TEXT` and
+`teamsAppSettings.env.FIFTYONE_APP_BANNER_TEXT`
+
+Banner background color is configured with:
+`casSettings.env.FIFTYONE_APP_BANNER_COLOR` and
+`teamsAppSettings.env.FIFTYONE_APP_BANNER_COLOR`
+
+Banner text color is configured with:
+`casSettings.env.FIFTYONE_APP_BANNER_TEXT_COLOR` and
+`teamsAppSettings.env.FIFTYONE_APP_BANNER_TEXT_COLOR`
+
+```yaml
+casSettings:
+  env:
+    FIFTYONE_APP_BANNER_COLOR: "green" # or "rgb(34,139,34)" or ""#f1f1f1"
+    FIFTYONE_APP_BANNER_TEXT_COLOR: "green" # or "rgb(34,139,34)" or ""#f1f1f1"
+    FIFTYONE_APP_BANNER_TEXT: "Internal Deployment"
+teamsAppSettings:
+  env:
+    FIFTYONE_APP_BANNER_COLOR: "green" # or "rgb(34,139,34)" or ""#f1f1f1"
+    FIFTYONE_APP_BANNER_TEXT_COLOR: "green" # or "rgb(34,139,34)" or ""#f1f1f1"
+    FIFTYONE_APP_BANNER_TEXT: "Internal Deployment"
+```
+
 ### Text Similarity
 
 Since version v1.2, FiftyOne Teams supports using text similarity

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -68,6 +68,7 @@ for steps on how to upgrade your delegated operators.
   - [Proxies](#proxies)
   - [Snapshot Archival](#snapshot-archival)
   - [Storage Credentials and `FIFTYONE_ENCRYPTION_KEY`](#storage-credentials-and-fiftyone_encryption_key)
+  - [Static Banner Configuration](#static-banner-configuration)
   - [Text Similarity](#text-similarity)
 - [Values](#values)
   - [Deploying On GKE](#deploying-on-gke)

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -332,6 +332,41 @@ FiftyOne Teams continues to support the use of environment variables to set
 storage credentials in the application context and is providing an alternate
 configuration path.
 
+### Static Banner Configuration
+
+Fiftyone Teams v2.6 introduces the ability to add a static banner to the
+application.
+
+Configure the Static Banner by setting the following environment variables in
+your `values.yaml`.
+
+Banner text is configured with:
+`casSettings.env.FIFTYONE_APP_BANNER_TEXT` and
+`teamsAppSettings.env.FIFTYONE_APP_BANNER_TEXT`
+
+
+Banner background color is configured with:
+`casSettings.env.FIFTYONE_APP_BANNER_COLOR` and
+`teamsAppSettings.env.FIFTYONE_APP_BANNER_COLOR`
+
+Banner text color is configured with:
+`casSettings.env.FIFTYONE_APP_BANNER_TEXT_COLOR` and
+`teamsAppSettings.env.FIFTYONE_APP_BANNER_TEXT_COLOR`
+
+
+```yaml
+casSettings:
+  env:
+    FIFTYONE_APP_BANNER_COLOR: "green" # or "rgb(34,139,34)" or ""#f1f1f1"
+    FIFTYONE_APP_BANNER_TEXT_COLOR: "green" # or "rgb(34,139,34)" or ""#f1f1f1"
+    FIFTYONE_APP_BANNER_TEXT: "Internal Deployment"
+teamsAppSettings:
+  env:
+    FIFTYONE_APP_BANNER_COLOR: "green" # or "rgb(34,139,34)" or ""#f1f1f1"
+    FIFTYONE_APP_BANNER_TEXT_COLOR: "green" # or "rgb(34,139,34)" or ""#f1f1f1"
+    FIFTYONE_APP_BANNER_TEXT: "Internal Deployment"
+```
+
 ### Text Similarity
 
 Since version v1.2, FiftyOne Teams supports using text similarity

--- a/tests/integration/compose/docker-compose-internal-auth_test.go
+++ b/tests/integration/compose/docker-compose-internal-auth_test.go
@@ -108,7 +108,7 @@ func (s *commonServicesInternalAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "http://127.0.0.1:3000/api/hello",
 					responsePayload:  `{"name":"John Doe"}`,
 					httpResponseCode: 200,
-					log:              "Listening on port 3000",
+					log:              " ✓ Ready in",
 				},
 				{
 					name:             "teams-cas",
@@ -145,7 +145,7 @@ func (s *commonServicesInternalAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "http://127.0.0.1:3000/api/hello",
 					responsePayload:  `{"name":"John Doe"}`,
 					httpResponseCode: 200,
-					log:              "Listening on port 3000",
+					log:              " ✓ Ready in",
 				},
 				{
 					name:             "teams-cas",
@@ -182,7 +182,7 @@ func (s *commonServicesInternalAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "http://127.0.0.1:3000/api/hello",
 					responsePayload:  `{"name":"John Doe"}`,
 					httpResponseCode: 200,
-					log:              "Listening on port 3000",
+					log:              " ✓ Ready in",
 				},
 				{
 					name:             "teams-cas",
@@ -226,7 +226,7 @@ func (s *commonServicesInternalAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "http://127.0.0.1:3000/api/hello",
 					responsePayload:  `{"name":"John Doe"}`,
 					httpResponseCode: 200,
-					log:              "Listening on port 3000",
+					log:              " ✓ Ready in",
 				},
 				{
 					name:             "teams-cas",

--- a/tests/integration/compose/docker-compose-legacy-auth_test.go
+++ b/tests/integration/compose/docker-compose-legacy-auth_test.go
@@ -108,7 +108,7 @@ func (s *commonServicesLegacyAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "http://127.0.0.1:3000/api/hello",
 					responsePayload:  `{"name":"John Doe"}`,
 					httpResponseCode: 200,
-					log:              "Listening on port 3000",
+					log:              " ✓ Ready in",
 				},
 				{
 					name:             "teams-cas",
@@ -145,7 +145,7 @@ func (s *commonServicesLegacyAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "http://127.0.0.1:3000/api/hello",
 					responsePayload:  `{"name":"John Doe"}`,
 					httpResponseCode: 200,
-					log:              "Listening on port 3000",
+					log:              " ✓ Ready in",
 				},
 				{
 					name:             "teams-cas",
@@ -182,7 +182,7 @@ func (s *commonServicesLegacyAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "http://127.0.0.1:3000/api/hello",
 					responsePayload:  `{"name":"John Doe"}`,
 					httpResponseCode: 200,
-					log:              "Listening on port 3000",
+					log:              " ✓ Ready in",
 				},
 				{
 					name:             "teams-cas",
@@ -226,7 +226,7 @@ func (s *commonServicesLegacyAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "http://127.0.0.1:3000/api/hello",
 					responsePayload:  `{"name":"John Doe"}`,
 					httpResponseCode: 200,
-					log:              "Listening on port 3000",
+					log:              " ✓ Ready in",
 				},
 				{
 					name:             "teams-cas",

--- a/tests/integration/helm/helm-internal-auth_test.go
+++ b/tests/integration/helm/helm-internal-auth_test.go
@@ -93,7 +93,7 @@ func (s *internalAuthHelmTest) TestHelmInstall() {
 					url:              ternary(s.context == "minikube", "https://local.fiftyone.ai/api/hello", ""),
 					responsePayload:  `{"name":"John Doe"}`,
 					httpResponseCode: 200,
-					log:              "Listening on port 3000",
+					log:              " ✓ Ready in",
 				},
 				// ordering this last to avoid test flakes where testing for log before the container is running
 				{
@@ -171,7 +171,7 @@ func (s *internalAuthHelmTest) TestHelmInstall() {
 					url:              ternary(s.context == "minikube", "https://local.fiftyone.ai/api/hello", ""),
 					responsePayload:  `{"name":"John Doe"}`,
 					httpResponseCode: 200,
-					log:              "Listening on port 3000",
+					log:              " ✓ Ready in",
 				},
 				{
 					name:             "teams-do",
@@ -250,7 +250,7 @@ func (s *internalAuthHelmTest) TestHelmInstall() {
 					url:              ternary(s.context == "minikube", "https://local.fiftyone.ai/api/hello", ""),
 					responsePayload:  `{"name":"John Doe"}`,
 					httpResponseCode: 200,
-					log:              "Listening on port 3000",
+					log:              " ✓ Ready in",
 				},
 				{
 					name:             "teams-plugins",

--- a/tests/integration/helm/helm-legacy-auth_test.go
+++ b/tests/integration/helm/helm-legacy-auth_test.go
@@ -99,7 +99,7 @@ func (s *legacyAuthHelmTest) TestHelmInstall() {
 					url:              ternary(s.context == "minikube", "https://local.fiftyone.ai/api/hello", ""),
 					responsePayload:  `{"name":"John Doe"}`,
 					httpResponseCode: 200,
-					log:              "Listening on port 3000",
+					log:              " ✓ Ready in",
 				},
 				// ordering this last to avoid test flakes where testing for log before the container is running
 				{
@@ -167,7 +167,7 @@ func (s *legacyAuthHelmTest) TestHelmInstall() {
 					url:              ternary(s.context == "minikube", "https://local.fiftyone.ai/api/hello", ""),
 					responsePayload:  `{"name":"John Doe"}`,
 					httpResponseCode: 200,
-					log:              "Listening on port 3000",
+					log:              " ✓ Ready in",
 				},
 				{
 					name:             "teams-do",
@@ -245,7 +245,7 @@ func (s *legacyAuthHelmTest) TestHelmInstall() {
 					url:              ternary(s.context == "minikube", "https://local.fiftyone.ai/api/hello", ""),
 					responsePayload:  `{"name":"John Doe"}`,
 					httpResponseCode: 200,
-					log:              "Listening on port 3000",
+					log:              " ✓ Ready in",
 				},
 				{
 					name:             "teams-plugins",

--- a/tests/integration/helm/helm-topology-spread-constraint_test.go
+++ b/tests/integration/helm/helm-topology-spread-constraint_test.go
@@ -103,7 +103,7 @@ func (s *topologyAuthHelmTest) TestHelmInstall() {
 					url:              ternary(s.context == "minikube", "https://local.fiftyone.ai/api/hello", ""),
 					responsePayload:  `{"name":"John Doe"}`,
 					httpResponseCode: 200,
-					log:              "Listening on port 3000",
+					log:              " ✓ Ready in",
 				},
 				{
 					name:             "teams-cas",


### PR DESCRIPTION
# Rationale

The banner feature was released in 2.6.0, but the doc updates didn't get pulled into `fiftyone-teams-app-deploy`

This does that.

And (hopefully) pulls forward fixes to helm integration tests.


