### PR TITLE
fix: AS-536 multiple do selector labels

### DIFF
--- a/helm/fiftyone-teams-app/templates/delegated-operator-instance-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/delegated-operator-instance-deployment.yaml
@@ -19,13 +19,11 @@ metadata:
   namespace: {{ $.Values.namespace.name }}
   labels:
     {{- include "delegated-operator-deployments.labels" $labelContext | nindent 4 }}
-    app.teams.operator/instance: {{ $name }}
 spec:
   replicas: {{ $v.replicaCount | default $baseTpl.replicaCount }}
   selector:
     matchLabels:
       {{- include "delegated-operator-deployments.selectorLabels" $labelContext | nindent 6 }}
-      app.teams.operator/instance: {{ $name }}
   template:
     metadata:
       {{- with (merge (dict) ($v.podAnnotations|default dict) ($baseTpl.podAnnotations)) }}
@@ -37,7 +35,6 @@ spec:
         {{- with (merge (dict) ($v.labels | default dict) ($baseTpl.labels)) }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        app.teams.operator/instance: {{ $name }}
     spec:
       {{- with $.Values.imagePullSecrets }}
       imagePullSecrets:

--- a/tests/unit/helm/delegated-operator-instance-deployment_test.go
+++ b/tests/unit/helm/delegated-operator-instance-deployment_test.go
@@ -83,7 +83,6 @@ func (s *deploymentDelegatedOperatorInstanceTemplateTest) TestMetadataLabels() {
 					"app.kubernetes.io/managed-by": "Helm",
 					"app.kubernetes.io/name":       "teams-do",
 					"app.kubernetes.io/instance":   "fiftyone-test",
-					"app.teams.operator/instance":  "teams-do",
 				},
 			},
 		},
@@ -100,7 +99,6 @@ func (s *deploymentDelegatedOperatorInstanceTemplateTest) TestMetadataLabels() {
 					"app.kubernetes.io/managed-by": "Helm",
 					"app.kubernetes.io/name":       "teams-do",
 					"app.kubernetes.io/instance":   "fiftyone-test",
-					"app.teams.operator/instance":  "teams-do",
 				},
 				map[string]string{
 					"helm.sh/chart":                fmt.Sprintf("fiftyone-teams-app-%s", chartVersion),
@@ -108,7 +106,6 @@ func (s *deploymentDelegatedOperatorInstanceTemplateTest) TestMetadataLabels() {
 					"app.kubernetes.io/managed-by": "Helm",
 					"app.kubernetes.io/name":       "teams-do-two",
 					"app.kubernetes.io/instance":   "fiftyone-test",
-					"app.teams.operator/instance":  "teams-do-two",
 				},
 			},
 		},
@@ -124,7 +121,6 @@ func (s *deploymentDelegatedOperatorInstanceTemplateTest) TestMetadataLabels() {
 					"app.kubernetes.io/managed-by": "Helm",
 					"app.kubernetes.io/name":       "teams-do-new-name",
 					"app.kubernetes.io/instance":   "fiftyone-test",
-					"app.teams.operator/instance":  "teams-do-new-name",
 				},
 			},
 		},
@@ -2979,14 +2975,12 @@ func (s *deploymentDelegatedOperatorInstanceTemplateTest) TestTemplateLabels() {
 			[]deploymentDelegatedOperatorInstanceTemplateLabelsExpected{
 				deploymentDelegatedOperatorInstanceTemplateLabelsExpected{
 					selectorMatch: map[string]string{
-						"app.kubernetes.io/name":      "teams-do",
-						"app.kubernetes.io/instance":  "fiftyone-test",
-						"app.teams.operator/instance": "teams-do",
+						"app.kubernetes.io/name":     "teams-do",
+						"app.kubernetes.io/instance": "fiftyone-test",
 					},
 					templateMetadata: map[string]string{
-						"app.kubernetes.io/name":      "teams-do",
-						"app.kubernetes.io/instance":  "fiftyone-test",
-						"app.teams.operator/instance": "teams-do",
+						"app.kubernetes.io/name":     "teams-do",
+						"app.kubernetes.io/instance": "fiftyone-test",
 					},
 				},
 			},
@@ -3000,26 +2994,22 @@ func (s *deploymentDelegatedOperatorInstanceTemplateTest) TestTemplateLabels() {
 			[]deploymentDelegatedOperatorInstanceTemplateLabelsExpected{
 				deploymentDelegatedOperatorInstanceTemplateLabelsExpected{
 					selectorMatch: map[string]string{
-						"app.kubernetes.io/name":      "teams-do",
-						"app.kubernetes.io/instance":  "fiftyone-test",
-						"app.teams.operator/instance": "teams-do",
+						"app.kubernetes.io/name":     "teams-do",
+						"app.kubernetes.io/instance": "fiftyone-test",
 					},
 					templateMetadata: map[string]string{
-						"app.kubernetes.io/name":      "teams-do",
-						"app.kubernetes.io/instance":  "fiftyone-test",
-						"app.teams.operator/instance": "teams-do",
+						"app.kubernetes.io/name":     "teams-do",
+						"app.kubernetes.io/instance": "fiftyone-test",
 					},
 				},
 				deploymentDelegatedOperatorInstanceTemplateLabelsExpected{
 					selectorMatch: map[string]string{
-						"app.kubernetes.io/name":      "teams-do-two",
-						"app.kubernetes.io/instance":  "fiftyone-test",
-						"app.teams.operator/instance": "teams-do-two",
+						"app.kubernetes.io/name":     "teams-do-two",
+						"app.kubernetes.io/instance": "fiftyone-test",
 					},
 					templateMetadata: map[string]string{
-						"app.kubernetes.io/name":      "teams-do-two",
-						"app.kubernetes.io/instance":  "fiftyone-test",
-						"app.teams.operator/instance": "teams-do-two",
+						"app.kubernetes.io/name":     "teams-do-two",
+						"app.kubernetes.io/instance": "fiftyone-test",
 					},
 				},
 			},
@@ -3034,28 +3024,24 @@ func (s *deploymentDelegatedOperatorInstanceTemplateTest) TestTemplateLabels() {
 			[]deploymentDelegatedOperatorInstanceTemplateLabelsExpected{
 				deploymentDelegatedOperatorInstanceTemplateLabelsExpected{
 					selectorMatch: map[string]string{
-						"app.kubernetes.io/name":      "teams-do",
-						"app.kubernetes.io/instance":  "fiftyone-test",
-						"app.teams.operator/instance": "teams-do",
+						"app.kubernetes.io/name":     "teams-do",
+						"app.kubernetes.io/instance": "fiftyone-test",
 					},
 					templateMetadata: map[string]string{
-						"app.kubernetes.io/name":      "teams-do",
-						"app.kubernetes.io/instance":  "fiftyone-test",
-						"app.teams.operator/instance": "teams-do",
-						"myLabel":                     "unruly",
+						"app.kubernetes.io/name":     "teams-do",
+						"app.kubernetes.io/instance": "fiftyone-test",
+						"myLabel":                    "unruly",
 					},
 				},
 				deploymentDelegatedOperatorInstanceTemplateLabelsExpected{
 					selectorMatch: map[string]string{
-						"app.kubernetes.io/name":      "teams-do-two",
-						"app.kubernetes.io/instance":  "fiftyone-test",
-						"app.teams.operator/instance": "teams-do-two",
+						"app.kubernetes.io/name":     "teams-do-two",
+						"app.kubernetes.io/instance": "fiftyone-test",
 					},
 					templateMetadata: map[string]string{
-						"app.kubernetes.io/name":      "teams-do-two",
-						"app.kubernetes.io/instance":  "fiftyone-test",
-						"app.teams.operator/instance": "teams-do-two",
-						"myLabel":                     "unruly",
+						"app.kubernetes.io/name":     "teams-do-two",
+						"app.kubernetes.io/instance": "fiftyone-test",
+						"myLabel":                    "unruly",
 					},
 				},
 			},
@@ -3070,29 +3056,25 @@ func (s *deploymentDelegatedOperatorInstanceTemplateTest) TestTemplateLabels() {
 			[]deploymentDelegatedOperatorInstanceTemplateLabelsExpected{
 				deploymentDelegatedOperatorInstanceTemplateLabelsExpected{
 					selectorMatch: map[string]string{
-						"app.kubernetes.io/name":      "teams-do",
-						"app.kubernetes.io/instance":  "fiftyone-test",
-						"app.teams.operator/instance": "teams-do",
+						"app.kubernetes.io/name":     "teams-do",
+						"app.kubernetes.io/instance": "fiftyone-test",
 					},
 					templateMetadata: map[string]string{
-						"app.kubernetes.io/name":      "teams-do",
-						"app.kubernetes.io/instance":  "fiftyone-test",
-						"app.teams.operator/instance": "teams-do",
-						"teams-do-label":              "teams-do-label-value",
+						"app.kubernetes.io/name":     "teams-do",
+						"app.kubernetes.io/instance": "fiftyone-test",
+						"teams-do-label":             "teams-do-label-value",
 					},
 				},
 				deploymentDelegatedOperatorInstanceTemplateLabelsExpected{
 					selectorMatch: map[string]string{
-						"app.kubernetes.io/name":      "teams-do-two",
-						"app.kubernetes.io/instance":  "fiftyone-test",
-						"app.teams.operator/instance": "teams-do-two",
+						"app.kubernetes.io/name":     "teams-do-two",
+						"app.kubernetes.io/instance": "fiftyone-test",
 					},
 					templateMetadata: map[string]string{
-						"app.kubernetes.io/name":      "teams-do-two",
-						"app.kubernetes.io/instance":  "fiftyone-test",
-						"app.teams.operator/instance": "teams-do-two",
-						"teams-do-two-label":          "teams-do-two-label-value",
-						"myLabel":                     "very-ruly",
+						"app.kubernetes.io/name":     "teams-do-two",
+						"app.kubernetes.io/instance": "fiftyone-test",
+						"teams-do-two-label":         "teams-do-two-label-value",
+						"myLabel":                    "very-ruly",
 					},
 				},
 			},
@@ -3108,30 +3090,26 @@ func (s *deploymentDelegatedOperatorInstanceTemplateTest) TestTemplateLabels() {
 			[]deploymentDelegatedOperatorInstanceTemplateLabelsExpected{
 				deploymentDelegatedOperatorInstanceTemplateLabelsExpected{
 					selectorMatch: map[string]string{
-						"app.kubernetes.io/name":      "teams-do",
-						"app.kubernetes.io/instance":  "fiftyone-test",
-						"app.teams.operator/instance": "teams-do",
+						"app.kubernetes.io/name":     "teams-do",
+						"app.kubernetes.io/instance": "fiftyone-test",
 					},
 					templateMetadata: map[string]string{
-						"app.kubernetes.io/name":      "teams-do",
-						"app.kubernetes.io/instance":  "fiftyone-test",
-						"app.teams.operator/instance": "teams-do",
-						"teams-do-label":              "teams-do-label-value",
-						"myLabel":                     "unruly",
+						"app.kubernetes.io/name":     "teams-do",
+						"app.kubernetes.io/instance": "fiftyone-test",
+						"teams-do-label":             "teams-do-label-value",
+						"myLabel":                    "unruly",
 					},
 				},
 				deploymentDelegatedOperatorInstanceTemplateLabelsExpected{
 					selectorMatch: map[string]string{
-						"app.kubernetes.io/name":      "teams-do-two",
-						"app.kubernetes.io/instance":  "fiftyone-test",
-						"app.teams.operator/instance": "teams-do-two",
+						"app.kubernetes.io/name":     "teams-do-two",
+						"app.kubernetes.io/instance": "fiftyone-test",
 					},
 					templateMetadata: map[string]string{
-						"app.kubernetes.io/name":      "teams-do-two",
-						"app.kubernetes.io/instance":  "fiftyone-test",
-						"app.teams.operator/instance": "teams-do-two",
-						"teams-do-two-label":          "teams-do-two-label-value",
-						"myLabel":                     "very-ruly",
+						"app.kubernetes.io/name":     "teams-do-two",
+						"app.kubernetes.io/instance": "fiftyone-test",
+						"teams-do-two-label":         "teams-do-two-label-value",
+						"myLabel":                    "very-ruly",
 					},
 				},
 			},


### PR DESCRIPTION
# Rationale

While testing a rolling upgrade of this, it appeared that selector labels are immutable. I am removing the `app.teams.operator/instance: {{ $name }}` fields from the labels. The `"app.kubernetes.io/name` already correctly reflects the name of the DO and, therefore, this is redundant.


## Changes

remove `app.teams.operator/instance: {{ $name }}` labels as they are redundant.

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
