### PR TITLE
docs(banners): clean up docker and helm docs for banner texts.

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -323,14 +323,14 @@ Fiftyone Teams v2.6 introduces the ability to add a static banner to the
 application.
 
 Banner text is configured with
-`teams-cas.env.FIFTYONE_APP_BANNER_TEXT` and
-`teams-app.env.FIFTYONE_APP_BANNER_TEXT`.
+`services.teams-cas.environment.FIFTYONE_APP_BANNER_TEXT` and
+`services.teams-app.environment.FIFTYONE_APP_BANNER_TEXT`.
 Banner background color is configured with
-`teams-cas.env.FIFTYONE_APP_BANNER_COLOR` and
-`teams-app.env.FIFTYONE_APP_BANNER_COLOR`.
+`services.teams-cas.environment.FIFTYONE_APP_BANNER_COLOR` and
+`services.teams-app.environment.FIFTYONE_APP_BANNER_COLOR`.
 Banner text color is configured with
-`teams-cas.env.FIFTYONE_APP_BANNER_TEXT_COLOR` and
-`teams-app.env.FIFTYONE_APP_BANNER_TEXT_COLOR`.
+`services.teams-cas.environment.FIFTYONE_APP_BANNER_TEXT_COLOR` and
+`services.teams-app.environment.FIFTYONE_APP_BANNER_TEXT_COLOR`.
 
 Configure the Static Banner by setting the following environment variables in
 your `compose.override.yaml` like

--- a/docker/README.md
+++ b/docker/README.md
@@ -131,7 +131,7 @@ To deploy FiftyOne Teams:
 
             ```yaml
             services:
-              fiftyone-app-common:
+              fiftyone-app:
                 environment:
                   FIFTYONE_DATABASE_ADMIN: true
             ```
@@ -151,7 +151,7 @@ To deploy FiftyOne Teams:
 
         ```yaml
         services:
-          fiftyone-app-common:
+          fiftyone-app:
             environment:
               # FIFTYONE_DATABASE_ADMIN: true
         ```
@@ -163,7 +163,7 @@ To deploy FiftyOne Teams:
 
         ```yaml
         services:
-          fiftyone-app-common:
+          fiftyone-app:
             environment:
               FIFTYONE_DATABASE_ADMIN: false
         ```
@@ -322,30 +322,30 @@ for configuring snapshot archival.
 Fiftyone Teams v2.6 introduces the ability to add a static banner to the
 application.
 
+Banner text is configured with
+`teams-cas.env.FIFTYONE_APP_BANNER_TEXT` and
+`teams-app.env.FIFTYONE_APP_BANNER_TEXT`.
+Banner background color is configured with
+`teams-cas.env.FIFTYONE_APP_BANNER_COLOR` and
+`teams-app.env.FIFTYONE_APP_BANNER_COLOR`.
+Banner text color is configured with
+`teams-cas.env.FIFTYONE_APP_BANNER_TEXT_COLOR` and
+`teams-app.env.FIFTYONE_APP_BANNER_TEXT_COLOR`.
+
 Configure the Static Banner by setting the following environment variables in
-your `compose.override.yaml`.
-
-Banner text is configured with `FIFTYONE_APP_BANNER_TEXT`.
-
-Banner background color is configured with `FIFTYONE_APP_BANNER_COLOR`.
-
-Banner text color is configured with:
-`casSettings.env.FIFTYONE_APP_BANNER_TEXT_COLOR` and
-`teamsAppSettings.env.FIFTYONE_APP_BANNER_TEXT_COLOR`
-
-Examples:
+your `compose.override.yaml` like
 
 ```yaml
 services:
-  teams-app-common:
+  teams-app:
     environment:
-      FIFTYONE_APP_BANNER_COLOR: `green | rgb(34,139,34") | '#f1f1f1'`
-      FIFTYONE_APP_BANNER_TEXT_COLOR: `green | rgb(34,139,34") | '#f1f1f1'`
+      FIFTYONE_APP_BANNER_COLOR: "green" # or "rgb(34,139,34)" or "#f1f1f1"
+      FIFTYONE_APP_BANNER_TEXT_COLOR: "white" # or "rgb(255,255,255)" or "#FFFFFF"
       FIFTYONE_APP_BANNER_TEXT: "Internal Deployment"
-  teams-cas-common:
+  teams-cas:
     environment:
-      FIFTYONE_APP_BANNER_COLOR: `green | rgb(34,139,34") | '#f1f1f1'`
-      FIFTYONE_APP_BANNER_TEXT_COLOR: `green | rgb(34,139,34") | '#f1f1f1'`
+      FIFTYONE_APP_BANNER_COLOR: "green" # or "rgb(34,139,34)" or "#f1f1f1"
+      FIFTYONE_APP_BANNER_TEXT_COLOR: "white" # or "rgb(255,255,255)" or "#FFFFFF"
       FIFTYONE_APP_BANNER_TEXT: "Internal Deployment"
 ```
 

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -337,31 +337,29 @@ configuration path.
 Fiftyone Teams v2.6 introduces the ability to add a static banner to the
 application.
 
-Configure the Static Banner by setting the following environment variables in
-your `values.yaml`.
-
-Banner text is configured with:
+Banner text is configured with
 `casSettings.env.FIFTYONE_APP_BANNER_TEXT` and
-`teamsAppSettings.env.FIFTYONE_APP_BANNER_TEXT`
-
-Banner background color is configured with:
+`teamsAppSettings.env.FIFTYONE_APP_BANNER_TEXT`.
+Banner background color is configured with
 `casSettings.env.FIFTYONE_APP_BANNER_COLOR` and
-`teamsAppSettings.env.FIFTYONE_APP_BANNER_COLOR`
-
-Banner text color is configured with:
+`teamsAppSettings.env.FIFTYONE_APP_BANNER_COLOR`.
+Banner text color is configured with
 `casSettings.env.FIFTYONE_APP_BANNER_TEXT_COLOR` and
-`teamsAppSettings.env.FIFTYONE_APP_BANNER_TEXT_COLOR`
+`teamsAppSettings.env.FIFTYONE_APP_BANNER_TEXT_COLOR`.
+
+Configure the Static Banner by setting the following environment variables in
+your `values.yaml` like
 
 ```yaml
 casSettings:
   env:
-    FIFTYONE_APP_BANNER_COLOR: "green" # or "rgb(34,139,34)" or ""#f1f1f1"
-    FIFTYONE_APP_BANNER_TEXT_COLOR: "green" # or "rgb(34,139,34)" or ""#f1f1f1"
+    FIFTYONE_APP_BANNER_COLOR: "green" # or "rgb(34,139,34)" or "#f1f1f1"
+    FIFTYONE_APP_BANNER_TEXT_COLOR: "green" # or "rgb(34,139,34)" or "#f1f1f1"
     FIFTYONE_APP_BANNER_TEXT: "Internal Deployment"
 teamsAppSettings:
   env:
-    FIFTYONE_APP_BANNER_COLOR: "green" # or "rgb(34,139,34)" or ""#f1f1f1"
-    FIFTYONE_APP_BANNER_TEXT_COLOR: "green" # or "rgb(34,139,34)" or ""#f1f1f1"
+    FIFTYONE_APP_BANNER_COLOR: "green" # or "rgb(34,139,34)" or "#f1f1f1"
+    FIFTYONE_APP_BANNER_TEXT_COLOR: "green" # or "rgb(34,139,34)" or "#f1f1f1"
     FIFTYONE_APP_BANNER_TEXT: "Internal Deployment"
 ```
 

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -338,33 +338,29 @@ configuration path.
 Fiftyone Teams v2.6 introduces the ability to add a static banner to the
 application.
 
-Configure the Static Banner by setting the following environment variables in
-your `values.yaml`.
-
-Banner text is configured with:
+Banner text is configured with
 `casSettings.env.FIFTYONE_APP_BANNER_TEXT` and
-`teamsAppSettings.env.FIFTYONE_APP_BANNER_TEXT`
-
-
-Banner background color is configured with:
+`teamsAppSettings.env.FIFTYONE_APP_BANNER_TEXT`.
+Banner background color is configured with
 `casSettings.env.FIFTYONE_APP_BANNER_COLOR` and
-`teamsAppSettings.env.FIFTYONE_APP_BANNER_COLOR`
-
-Banner text color is configured with:
+`teamsAppSettings.env.FIFTYONE_APP_BANNER_COLOR`.
+Banner text color is configured with
 `casSettings.env.FIFTYONE_APP_BANNER_TEXT_COLOR` and
-`teamsAppSettings.env.FIFTYONE_APP_BANNER_TEXT_COLOR`
+`teamsAppSettings.env.FIFTYONE_APP_BANNER_TEXT_COLOR`.
 
+Configure the Static Banner by setting the following environment variables in
+your `values.yaml` like
 
 ```yaml
 casSettings:
   env:
-    FIFTYONE_APP_BANNER_COLOR: "green" # or "rgb(34,139,34)" or ""#f1f1f1"
-    FIFTYONE_APP_BANNER_TEXT_COLOR: "green" # or "rgb(34,139,34)" or ""#f1f1f1"
+    FIFTYONE_APP_BANNER_COLOR: "green" # or "rgb(34,139,34)" or "#f1f1f1"
+    FIFTYONE_APP_BANNER_TEXT_COLOR: "green" # or "rgb(34,139,34)" or "#f1f1f1"
     FIFTYONE_APP_BANNER_TEXT: "Internal Deployment"
 teamsAppSettings:
   env:
-    FIFTYONE_APP_BANNER_COLOR: "green" # or "rgb(34,139,34)" or ""#f1f1f1"
-    FIFTYONE_APP_BANNER_TEXT_COLOR: "green" # or "rgb(34,139,34)" or ""#f1f1f1"
+    FIFTYONE_APP_BANNER_COLOR: "green" # or "rgb(34,139,34)" or "#f1f1f1"
+    FIFTYONE_APP_BANNER_TEXT_COLOR: "green" # or "rgb(34,139,34)" or "#f1f1f1"
     FIFTYONE_APP_BANNER_TEXT: "Internal Deployment"
 ```
 


### PR DESCRIPTION
# Rationale

While looking at #318 noticed some opportunities for improvement (and clarity).  

## Changes

* Make consistent across Docker and Helm docs
* Fix formatting errors (backticks replaced by double quotes, remove double double quotes)
* Fix docker service names (users should reference the "real" service names, not the intermediate ones defined in common)

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

## Testing

Looks good locally in previews

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
