### PR TITLE
fix: as-324 fix pre release

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,7 +3,7 @@ name: Pull Request
 on:
   pull_request:
     types: [opened, synchronize]
-    branches:
+    branches: # Target Branches
       - main
       - release/*
       - release-next

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -62,27 +62,33 @@ jobs:
     secrets:
       REPO_GOOGLE_WORKLOAD_IDP: ${{ secrets.REPO_GOOGLE_WORKLOAD_IDP }}
 
-
   helm-unit:
     needs: modified-files
     if: ${{ needs.modified-files.outputs.helm-unit-required == 'true' }}
     uses: ./.github/workflows/test-helm.yml
 
+  validate-chart-version:
+    # Always run check, even if no helm changes.
+    uses: ./.github/workflows/validate-chart-version.yml
+
   all-tests:
     runs-on: ubuntu-latest
-    needs: [docker-unit, helm-unit, helm-integration]
+    needs: [docker-unit, helm-unit, helm-integration, validate-chart-version]
     if: always()
     steps:
       - run: sh -c ${{
           (needs.docker-unit.result == 'success' || needs.docker-unit.result == 'skipped') &&
           (needs.helm-integration.result == 'success' || needs.helm-integration.result == 'skipped') &&
-          (needs.helm-unit.result == 'success' || needs.helm-unit.result == 'skipped') }}
+          (needs.helm-unit.result == 'success' || needs.helm-unit.result == 'skipped') &&
+          (needs.validate-chart-version.result == 'success') }}
 
   helm-pre-release:
-    needs: [all-tests, helm-unit, helm-integration]
+    needs: [all-tests, helm-unit, helm-integration, validate-chart-version]
     if: |
       always() &&
-      (needs.helm-unit.result == 'success' || needs.helm-integration.result == 'success')
+      (needs.helm-unit.result == 'success' &&
+       needs.helm-integration.result == 'success' &&
+       needs.validate-chart-version.result == 'success')
     uses: ./.github/workflows/pre-release-internal-env.yml
     secrets:
       REPO_GOOGLE_WORKLOAD_IDP: ${{ secrets.REPO_GOOGLE_WORKLOAD_IDP }}

--- a/.github/workflows/pre-release-internal-env.yml
+++ b/.github/workflows/pre-release-internal-env.yml
@@ -40,7 +40,9 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
-          ref: "${{ github.ref }}"
+          # If a pull request, checkout the source branch
+          # If a push, checkout the actual branch
+          ref: "${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}"
 
       - name: Configure Git
         run: |
@@ -51,18 +53,19 @@ jobs:
         id: find-versions
         run: |
           version=$(yq ".version" helm/fiftyone-teams-app/Chart.yaml)
+          sha="$(git rev-parse --short HEAD)"
 
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             # If this was triggered via a pull_request and then workflow_call.
             # The workflow is triggered by pull_request, not workflow_call,
             # which is why the above conditional uses the event name pull_request.
-            # In this case, use the head_ref from the pull requests (i.e. the
-            # source branch that triggered the PR).
-            version="${version}-sha-${GITHUB_SHA::7}"
+            # In this case, it is a development branch, so mark it as a
+            # sha build.
+            version="${version}-sha-${sha}"
           elif [[ "${{ github.event_name }}" == "push" ]]; then
             # After the PR is merged, a push event is triggered to
-            # the branch. So, just use the ref_name of the push action.
-            version="${version}-rc-${GITHUB_SHA::7}"
+            # the branch. So mark it as an rc build.
+            version="${version}-rc-${sha}"
           else
             # This isn't really needed but, in my opinion, adds clarity
             # to the above two conditionals.

--- a/.github/workflows/pre-release-internal-env.yml
+++ b/.github/workflows/pre-release-internal-env.yml
@@ -18,6 +18,11 @@ on:
       CROSS_REPOSITORY_WORKFLOW:
         required: true
 
+  push:
+    branches:
+      - release/*
+      - release-next
+
 jobs:
   pre-release:
     permissions:
@@ -30,10 +35,6 @@ jobs:
       GCP_SERVICE_ACCOUNT: github@computer-vision-team.iam.gserviceaccount.com
       HELM_CHART_NAME: fiftyone-teams-app
     runs-on: ubuntu-latest
-
-    outputs:
-      fiftyone-teams-app-deploy-version: ${{ steps.find-versions.outputs.FIFTYONE_TEAMS_APP_DEPLOY_VERSION }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
@@ -50,15 +51,28 @@ jobs:
         id: find-versions
         run: |
           version=$(yq ".version" helm/fiftyone-teams-app/Chart.yaml)
-          if [[ "${GITHUB_REF_NAME}" == "release/"* ]]; then
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            # If this was triggered via a pull_request and then workflow_call.
+            # The workflow is triggered by pull_request, not workflow_call,
+            # which is why the above conditional uses the event name pull_request.
+            # In this case, use the head_ref from the pull requests (i.e. the
+            # source branch that triggered the PR).
+            version="${version}-sha-${GITHUB_SHA::7}"
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            # After the PR is merged, a push event is triggered to
+            # the branch. So, just use the ref_name of the push action.
             version="${version}-rc-${GITHUB_SHA::7}"
           else
-            version="${version}-sha-${GITHUB_SHA::7}"
+            # This isn't really needed but, in my opinion, adds clarity
+            # to the above two conditionals.
+            echo "This was triggered by ${{ github.event.name }}. Exiting..."
+            exit 1
           fi
 
-          echo "FIFTYONE_TEAMS_APP_DEPLOY_VERSION=${version}" >> "${GITHUB_ENV}"
-          echo "FIFTYONE_TEAMS_APP_DEPLOY_VERSION=${version}" >> "${GITHUB_OUTPUT}"
+          echo "Triggered via ${{ github.event_name }}. Setting version to ${version}"
 
+          echo "FIFTYONE_TEAMS_APP_DEPLOY_VERSION=${version}" >> "${GITHUB_ENV}"
 
       - name: Install Helm
         uses: azure/setup-helm@v4
@@ -105,6 +119,6 @@ jobs:
               workflow_id: "${{ secrets.CROSS_REPOSITORY_WORKFLOW }}",
               ref: "main",
               inputs: {
-                "fiftyone-teams-app-deploy-version": "${{ steps.find-versions.outputs.FIFTYONE_TEAMS_APP_DEPLOY_VERSION }}"
+                "fiftyone-teams-app-deploy-version": "${{ env.FIFTYONE_TEAMS_APP_DEPLOY_VERSION }}"
               }
             })

--- a/.github/workflows/validate-chart-version.yml
+++ b/.github/workflows/validate-chart-version.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
           ref: "${{ github.ref }}"
 
-      - name: Set Helm Chart Version
+      - name: Validate Helm Chart Version
         run: |
           version=$(yq ".version" helm/fiftyone-teams-app/Chart.yaml)
 

--- a/.github/workflows/validate-chart-version.yml
+++ b/.github/workflows/validate-chart-version.yml
@@ -21,9 +21,9 @@ jobs:
       - name: Validate Helm Chart Version
         run: |
           actual=$(yq ".version" helm/fiftyone-teams-app/Chart.yaml)
-          expected="${ref#release\/v}"
 
           ref="${{ github.event.pull_request.base.ref }}"
+          expected="${ref#release\/v}"
 
           if [[ "${ref}" == "release/"* ]] && [[ "${actual}" != "${expected}" ]]; then
             echo "[ERROR] Version from Chart.yaml (${actual}) should match"

--- a/.github/workflows/validate-chart-version.yml
+++ b/.github/workflows/validate-chart-version.yml
@@ -20,12 +20,13 @@ jobs:
 
       - name: Validate Helm Chart Version
         run: |
-          version=$(yq ".version" helm/fiftyone-teams-app/Chart.yaml)
+          actual=$(yq ".version" helm/fiftyone-teams-app/Chart.yaml)
+          expected="${ref#release\/v}"
 
           ref="${{ github.event.pull_request.base.ref }}"
 
-          if [[ "${ref}" == "release/"* ]] && [[ "${version}" != "${ref#release\/v}" ]]; then
-            echo "[ERROR] Version from Chart.yaml (${version}) should match"
-            echo "        version derived from branch name (${ref#release\/v})"
+          if [[ "${ref}" == "release/"* ]] && [[ "${actual}" != "${expected}" ]]; then
+            echo "[ERROR] Version from Chart.yaml (${actual}) should match"
+            echo "        version derived from branch name (${expected})"
             exit 1
           fi

--- a/.github/workflows/validate-chart-version.yml
+++ b/.github/workflows/validate-chart-version.yml
@@ -1,0 +1,31 @@
+---
+# Validates that, for release branches, the Chart.yaml has been appropriately
+# updated. This is important because we publish pre-release charts based on
+# the Chart.yaml and want to publish accurately versioned charts.
+name: Validate Chart Version
+
+on:
+  workflow_call:
+
+jobs:
+  validate-chart-version:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          ref: "${{ github.ref }}"
+
+      - name: Set Helm Chart Version
+        run: |
+          version=$(yq ".version" helm/fiftyone-teams-app/Chart.yaml)
+
+          ref="${{ github.event.pull_request.base.ref }}"
+
+          if [[ "${ref}" == "release/"* ]] && [[ "${version}" != "${ref#release\/v}" ]]; then
+            echo "[ERROR] Version from Chart.yaml (${version}) should match"
+            echo "        version derived from branch name (${ref#release\/v})"
+            exit 1
+          fi


### PR DESCRIPTION
# Rationale

A few situations have been getting us into weird situations via automation:

1. The chart versions aren't updated on a release branch. This causes a release branch to push pre-release artifacts as the previous version
2. We haven't been pushing artifacts on pushes to the release-branches, only on the PRs. We should push `-rc` versions after the merge happens and `-sha` versions while the PR is in progress (after tests run successfully)

This PR aims to add a new validation workflow to ensure that, on release branches, the chart.yaml gets updated. It also adds push events to the pre-release-internal-env workflow so that, after merges, `-rc` artifacts get pushed.

## Changes

1. Add `validate-chart-version` workflow that checks the release branch's name against the `Chart.yaml` version. If they don't match, throw an error so the submitter has to update their `Chart.yaml`. This could also check other files, but this will hopefully set alerts off so an aloha can check.
2. Add the following events to the pre-release-internal-env workflow. This allows post-merge `rc` to be built.
    ```yaml
      push:
        branches:
          - release/*
          - release-next
      ```
3. Update and comment how the versions get set within the workflow

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

Test actions are listed below and were run in private repo:

<details><summary>pr.yaml</summary>

```yaml
name: Pull Request

on:
  pull_request:
    types: [opened, synchronize]
    # Target Branches
    branches:
      - main
      - release/*
      - release-next

concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true

jobs:
  helm-pre-release:
    uses: ./.github/workflows/pre-release-internal-env.yml
  chart-val:
    uses: ./.github/workflows/validate-chart.yml
```
</details>


<details><summary>pre-release-internal-env.yaml</summary>

```yaml
name: Release Pre-release charts

on:
  workflow_call:

  push:
    branches:
      - release/*
      - release-next

jobs:
  pre-release:
    runs-on: ubuntu-latest

    steps:
      - name: Checkout
        uses: actions/checkout@v4.2.2
        with:
          fetch-depth: 0
          ref: "${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}"

      - name: Set Helm Chart Version
        id: find-versions
        run: |
          ref=""
          sha="$(git rev-parse --short HEAD)"

          echo "${{ github.event_name }}"

          if [[ "${{ github.event_name }}" == "workflow_call" ]] || [[ "${{ github.event_name }}" == "pull_request" ]]; then
            version="sha-${sha}"            
          elif [[ "${{ github.event_name }}" == "push" ]]; then
            version="rc-${sha}"
          else
            # This isn't really needed but, in my opinion, adds clarity
            # to the above two conditionals.
            echo "This was triggered by ${{ github.event.name }}. Exiting..."
            exit 1
          fi

          echo "Using ${version} to determine the build type. sha = ${sha}"

```
</details>

<details><summary>validate-chart.yaml</summary>

```yaml
name: Test version

on:
  workflow_call:

jobs:
  pre-release:
    runs-on: ubuntu-latest

    steps:
      - name: Checkout
        uses: actions/checkout@v4.2.2
        with:
          fetch-depth: 0
          ref: "${{ github.ref }}"

      - name: Test Helm Chart Version
        run: |
          version=$(yq ".version" Chart.yaml)

          ref="${{ github.event.pull_request.base.ref }}"

          if [[ "${ref}" == "release/"* ]] && [[ "${version}" != "${ref#release\/v}" ]]; then
            echo "Version ${version} should match ${ref#release\/v}"
            exit 1
          fi

```
</details>

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
