### PR TITLE
chore(docs): add `fiftyone-teams-cv-full` to image list

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -110,6 +110,7 @@ We publish the following FiftyOne Teams private images to Docker Hub:
 - `voxel51/fiftyone-teams-api`
 - `voxel51/fiftyone-teams-app`
 - `voxel51/fiftyone-teams-cas`
+- `voxel51/fiftyone-teams-cv-full`
 
 For Docker Hub credentials, please contact your Voxel51 support team.
 

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -133,6 +133,7 @@ We publish the following FiftyOne Teams private images to Docker Hub:
 - `voxel51/fiftyone-teams-api`
 - `voxel51/fiftyone-teams-app`
 - `voxel51/fiftyone-teams-cas`
+- `voxel51/fiftyone-teams-cv-full`
 
 For Docker Hub credentials, please contact your Voxel51 support team.
 

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -133,6 +133,7 @@ We publish the following FiftyOne Teams private images to Docker Hub:
 - `voxel51/fiftyone-teams-api`
 - `voxel51/fiftyone-teams-app`
 - `voxel51/fiftyone-teams-cas`
+- `voxel51/fiftyone-teams-cv-full`
 
 For Docker Hub credentials, please contact your Voxel51 support team.
 


### PR DESCRIPTION
# Rationale

we should add the image here (I've been adding it manually to the published helm doc)

## Changes

adds `fiftyone-teams-cv-full` image to the image list

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
