### PR TITLE
chore(docs): AS-550 Adding Validation Docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,10 @@ repos:
     hooks:
       - id: codespell
         exclude: helm/local-self-signed-example/cert-manger-crds|tests/go.sum
+        args:
+          - -L
+          # fiftyone.management as fom
+          - fom
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.35.1
     hooks:

--- a/docker/README.md
+++ b/docker/README.md
@@ -499,9 +499,8 @@ For more information, see the docs for
 ## Validating
 
 After deploying FiftyOne Enterprise and configuring authentication, please
-refer to
-[validating your deployment](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/docs/validating-deployment.md)
-for validation information.
+follow
+[validating your deployment](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/docs/validating-deployment.md).
 
 ## FiftyOne Teams Environment Variables
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -67,6 +67,7 @@ for steps on how to upgrade your delegated operators.
   - [Proxies](#proxies)
   - [Terms of Service, Privacy, and Imprint URLs](#terms-of-service-privacy-and-imprint-urls)
   - [Text Similarity](#text-similarity)
+- [Validating](#validating)
 - [FiftyOne Teams Environment Variables](#fiftyone-teams-environment-variables)
 
 <!-- tocstop -->
@@ -494,6 +495,13 @@ For more information, see the docs for
 [Docker Compose Extend](https://docs.docker.com/compose/extends/).
 
 ---
+
+## Validating
+
+After deploying FiftyOne Enterprise and configuring authentication, please
+refer to
+[validating your deployment](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/docs/validating-deployment.md)
+for validation information.
 
 ## FiftyOne Teams Environment Variables
 

--- a/docs/validating-deployment.md
+++ b/docs/validating-deployment.md
@@ -1,0 +1,1 @@
+# Validating Your Deployment

--- a/docs/validating-deployment.md
+++ b/docs/validating-deployment.md
@@ -24,34 +24,34 @@ attempt to validate the connection between your SDK and your deployment.
 
 ## Pre-requisites
 
-The following validation method assumes:
+The following validation method assumes you:
 
-1. You have deployed FiftyOne enterprise in either kubernetes or
-   docker-compose.
-1. You have configured a DNS record(s) for your application.
-1. You have configured TLS termination for your application.
-1. You have configured
-   [your authentication provider](https://docs.voxel51.com/teams/pluggable_auth.html).
-1. You have installed the FiftyOne Enterprise SDK.
-1. You have generated an API Key via the Enterprise UI.
+1. Deployed FiftyOne enterprise in either kubernetes or
+   docker-compose
+1. Configured a DNS record(s) for your application
+1. Configured TLS termination for your application
+1. Configured
+   [your authentication provider](https://docs.voxel51.com/teams/pluggable_auth.html)
+1. Installed the FiftyOne Enterprise SDK
+1. Generated an API Key via the Enterprise UI
 
 ## Running Checks
 
-To run the checks, ensure your `FIFTYONE_API_KEY` and `FIFTYONE_API_URL`
-are set in your environment:
+To run the checks, set the `FIFTYONE_API_KEY` and `FIFTYONE_API_URL`
+environment variables:
 
 ```shell
 export FIFTYONE_API_URL=https://your-api-url
 export FIFTYONE_API_KEY=you4ap1k3y
 ```
 
-Then run `fiftyone.management.test_api_connection()`:
+Test the API connection:
 
 ```shell
 python -c 'import fiftyone.management as fom; fom.test_api_connection()'
 ```
 
-If all goes well, you will see the following log:
+When successful, the it will return:
 
 ```shell
 $ python -c 'import fiftyone.management as fom; fom.test_api_connection()'

--- a/docs/validating-deployment.md
+++ b/docs/validating-deployment.md
@@ -28,11 +28,12 @@ The following validation method assumes:
 
 1. You have deployed FiftyOne enterprise in either kubernetes or
    docker-compose.
-1. You have configured a DNS record(s) for your application
-1. You have configured TLS termination for your application
+1. You have configured a DNS record(s) for your application.
+1. You have configured TLS termination for your application.
 1. You have configured
    [your authentication provider](https://docs.voxel51.com/teams/pluggable_auth.html).
-1. You have installed the FiftyOne Enterprise SDK
+1. You have installed the FiftyOne Enterprise SDK.
+1. You have generated an API Key via the Enterprise UI.
 
 ## Running Checks
 

--- a/docs/validating-deployment.md
+++ b/docs/validating-deployment.md
@@ -1,7 +1,26 @@
+<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-disable-next-line first-line-heading -->
+<div align="center">
+<p align="center">
+
+<img src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
+
+</p>
+</div>
+<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
+
 # Validating Your Deployment
 
 FiftyOne enterprise comes with a `test_api_connection()` method which will
 attempt to validate the connection between your SDK and your deployment.
+
+<!-- toc -->
+
+- [Pre-requisites](#pre-requisites)
+- [Running Checks](#running-checks)
+
+<!-- tocstop -->
 
 ## Pre-requisites
 
@@ -34,7 +53,7 @@ python -c 'import fiftyone.management as fom; fom.test_api_connection()'
 If all goes well, you will see the following log:
 
 ```shell
-% python -c 'import fiftyone.management as fom; fom.test_api_connection()'
+$ python -c 'import fiftyone.management as fom; fom.test_api_connection()'
 
 API connection succeeded
 ```

--- a/docs/validating-deployment.md
+++ b/docs/validating-deployment.md
@@ -1,1 +1,42 @@
 # Validating Your Deployment
+
+FiftyOne enterprise comes with a `test_api_connection()` method which will
+attempt to validate the connection between your SDK and your deployment.
+
+## Pre-requisites
+
+The following validation method assumes:
+
+1. You have deployed FiftyOne enterprise in either kubernetes or
+   docker-compose.
+1. You have configured a DNS record(s) for your application
+1. You have configured TLS termination for your application
+1. You have configured
+   [your authentication provider](https://docs.voxel51.com/teams/pluggable_auth.html).
+1. You have installed the FiftyOne Enterprise SDK
+
+## Running Checks
+
+To run the checks, ensure your `FIFTYONE_API_KEY` and `FIFTYONE_API_URL`
+are set in your environment:
+
+```shell
+export FIFTYONE_API_URL=https://your-api-url
+export FIFTYONE_API_KEY=you4ap1k3y
+```
+
+Then run `fiftyone.management.test_api_connection()`:
+
+```shell
+python -c 'import fiftyone.management as fom; fom.test_api_connection()'
+```
+
+If all goes well, you will see the following log:
+
+```shell
+% python -c 'import fiftyone.management as fom; fom.test_api_connection()'
+
+API connection succeeded
+```
+
+If you have issues during setup, please contact your customer success representative.

--- a/docs/validating-deployment.md
+++ b/docs/validating-deployment.md
@@ -51,7 +51,7 @@ Test the API connection:
 python -c 'import fiftyone.management as fom; fom.test_api_connection()'
 ```
 
-When successful, the it will return:
+When successful, it will return:
 
 ```shell
 $ python -c 'import fiftyone.management as fom; fom.test_api_connection()'

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -431,9 +431,8 @@ appSettings:
 ## Validating
 
 After deploying FiftyOne Enterprise and configuring authentication, please
-refer to
-[validating your deployment](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/docs/validating-deployment.md)
-for validation information.
+follow
+[validating your deployment](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/docs/validating-deployment.md).
 
 ## Values
 

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -79,6 +79,7 @@ for steps on how to upgrade your delegated operators.
   - [Static Banner Configuration](#static-banner-configuration)
   - [Terms of Service, Privacy, and Imprint URLs](#terms-of-service-privacy-and-imprint-urls)
   - [Text Similarity](#text-similarity)
+- [Validating](#validating)
 - [Values](#values)
   - [Deploying On GKE](#deploying-on-gke)
 
@@ -426,6 +427,13 @@ appSettings:
   image:
     repository: voxel51/fiftyone-app-torch
 ```
+
+## Validating
+
+After deploying FiftyOne Enterprise and configuring authentication, please
+refer to
+[validating your deployment](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/docs/validating-deployment.md)
+for validation information.
 
 ## Values
 

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -432,9 +432,8 @@ appSettings:
 ## Validating
 
 After deploying FiftyOne Enterprise and configuring authentication, please
-refer to
-[validating your deployment](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/docs/validating-deployment.md)
-for validation information.
+follow
+[validating your deployment](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/docs/validating-deployment.md).
 
 {{ template "chart.homepageLine" . }}
 

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -79,6 +79,7 @@ for steps on how to upgrade your delegated operators.
   - [Static Banner Configuration](#static-banner-configuration)
   - [Terms of Service, Privacy, and Imprint URLs](#terms-of-service-privacy-and-imprint-urls)
   - [Text Similarity](#text-similarity)
+- [Validating](#validating)
 - [Values](#values)
   - [Deploying On GKE](#deploying-on-gke)
 
@@ -427,6 +428,13 @@ appSettings:
   image:
     repository: voxel51/fiftyone-app-torch
 ```
+
+## Validating
+
+After deploying FiftyOne Enterprise and configuring authentication, please
+refer to
+[validating your deployment](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/docs/validating-deployment.md)
+for validation information.
 
 {{ template "chart.homepageLine" . }}
 


### PR DESCRIPTION
# Rationale

We have some utilities to validate if a deployment is ready or not. We should being writing those down and having a `validation` page where users can say "is my deployment ready?". This PR adds that page and then updates the docker/helm pages to reference it.

## Changes

Adds a new `validating-deployment` page. As of now, this page mainly refers to `fom.test_api_connection()`, however, it could be extended to more detailed URI/Websocket/etc. checks should the need arise.

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
