### PR TITLE
build(asdf): AS-506 ASDF install action bump

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -20,10 +20,5 @@ jobs:
       - name: Temporary SQLite/LZMA - Install missing libraries
         run: sudo apt install -y libsqlite3-dev libbz2-dev
       - name: install asdf & tools
-        uses: asdf-vm/actions/install@v3.0.2
-        with:
-          # Issue with some of the pre-commit hooks. So pin to an older version for now. See
-          # https://github.com/voxel51/fiftyone-teams-app-deploy/actions/runs/13078221229/job/36495530561
-          # See https://voxel51.atlassian.net/browse/AS-506
-          asdf_branch: v0.14.1
+        uses: asdf-vm/actions/install@1117842ea70e2711a0072e3a71265cbfe2c830be
       - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -18,12 +18,7 @@ jobs:
       - uses: actions/checkout@v4.2.2
       - uses: actions/setup-python@v5.4.0
       - name: install asdf & tools
-        uses: asdf-vm/actions/install@v3.0.2
-        with:
-          # Issue with some of the tests. So pin to an older version for now. See
-          # https://github.com/voxel51/fiftyone-teams-app-deploy/actions/runs/13078221229/job/36495530561
-          # https://voxel51.atlassian.net/browse/AS-506
-          asdf_branch: v0.14.1
+        uses: asdf-vm/actions/install@1117842ea70e2711a0072e3a71265cbfe2c830be
       - name: Run unit tests
         shell: bash
         run: |
@@ -39,12 +34,7 @@ jobs:
       - name: Temporary SQLite/LZMA - Install missing libraries
         run: sudo apt install -y libsqlite3-dev libbz2-dev
       - name: install asdf & tools
-        uses: asdf-vm/actions/install@v3.0.2
-        with:
-          # Issue with some of the tests. So pin to an older version for now. See
-          # https://github.com/voxel51/fiftyone-teams-app-deploy/actions/runs/13078221229/job/36495530561
-          # https://voxel51.atlassian.net/browse/AS-506
-          asdf_branch: v0.14.1
+        uses: asdf-vm/actions/install@1117842ea70e2711a0072e3a71265cbfe2c830be
       - name: Authenticate to Google Cloud
         id: auth
         uses: google-github-actions/auth@v2.1.7
@@ -81,12 +71,7 @@ jobs:
       - uses: actions/checkout@v4.2.2
       - uses: actions/setup-python@v5.4.0
       - name: install asdf & tools
-        uses: asdf-vm/actions/install@v3.0.2
-        with:
-          # Issue with some of the tests. So pin to an older version for now. See
-          # https://github.com/voxel51/fiftyone-teams-app-deploy/actions/runs/13078221229/job/36495530561
-          # https://voxel51.atlassian.net/browse/AS-506
-          asdf_branch: v0.14.1
+        uses: asdf-vm/actions/install@1117842ea70e2711a0072e3a71265cbfe2c830be
       - name: Authenticate to Google Cloud
         id: auth
         uses: google-github-actions/auth@v2.1.7

--- a/.github/workflows/test-helm.yml
+++ b/.github/workflows/test-helm.yml
@@ -12,12 +12,7 @@ jobs:
       - name: Temporary SQLite/LZMA - Install missing libraries
         run: sudo apt install -y libsqlite3-dev libbz2-dev
       - name: install asdf & tools
-        uses: asdf-vm/actions/install@v3.0.2
-        with:
-          # Issue with some of the tests. So pin to an older version for now. See
-          # https://github.com/voxel51/fiftyone-teams-app-deploy/actions/runs/13078221229/job/36495530561
-          # https://voxel51.atlassian.net/browse/AS-506
-          asdf_branch: v0.14.1
+        uses: asdf-vm/actions/install@1117842ea70e2711a0072e3a71265cbfe2c830be
       - name: Run unit tests
         shell: bash
         run: |

--- a/.github/workflows/test-integration-helm.yml
+++ b/.github/workflows/test-integration-helm.yml
@@ -19,12 +19,7 @@ jobs:
       - name: Temporary SQLite/LZMA - Install missing libraries
         run: sudo apt install -y libsqlite3-dev libbz2-dev
       - name: install asdf & tools
-        uses: asdf-vm/actions/install@v3.0.2
-        with:
-          # Issue with some of the tests. So pin to an older version for now. See
-          # https://github.com/voxel51/fiftyone-teams-app-deploy/actions/runs/13078221229/job/36495530561
-          # https://voxel51.atlassian.net/browse/AS-506
-          asdf_branch: v0.14.1
+        uses: asdf-vm/actions/install@1117842ea70e2711a0072e3a71265cbfe2c830be
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:


### PR DESCRIPTION
# Rationale

ASDF actions were failing due to the GoLang rewrite. The old action emitted a huge warning that sometimes made it's way into STDOUT and messed with test results. This was solved via a PR linked in the [Jira Ticket](https://voxel51.atlassian.net/browse/AS-506).

> [!NOTE]
> I'm only bumping the action where versions were specifically pinned via the below. This is because dependabot will bump the other versions when a release is cut. We can go back and switch these back to release versions at that time, but it felt good to do away with the 0.14.1 pin.

```
        uses: asdf-vm/actions/install@v3.0.2
        with:
          # Issue with some of the pre-commit hooks. So pin to an older version for now. See
          # https://github.com/voxel51/fiftyone-teams-app-deploy/actions/runs/13078221229/job/36495530561
          # See https://voxel51.atlassian.net/browse/AS-506
          asdf_branch: v0.14.1
```

## Changes

Uses the GitHub sha of the new/merged/fixed action.

## Testing

Will be tested via actions for pre-commit and all tests.

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
