### PR TITLE
docs(gpus): AS-561 Document gpu workloads

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -59,12 +59,13 @@ for steps on how to upgrade your delegated operators.
 - [Advanced Configuration](#advanced-configuration)
   - [Builtin Delegated Operator Orchestrator](#builtin-delegated-operator-orchestrator)
   - [Central Authentication Service](#central-authentication-service)
+  - [FiftyOne Enterprise Authenticated API](#fiftyone-enterprise-authenticated-api)
+  - [GPU Enabled Workloads](#gpu-enabled-workloads)
+  - [Plugins](#plugins)
+  - [Proxies](#proxies)
   - [Snapshot Archival](#snapshot-archival)
   - [Static Banner Configuration](#static-banner-configuration)
-  - [FiftyOne Enterprise Authenticated API](#fiftyone-enterprise-authenticated-api)
-  - [FiftyOne Enterprise Plugins](#fiftyone-enterprise-plugins)
   - [Storage Credentials and `FIFTYONE_ENCRYPTION_KEY`](#storage-credentials-and-fiftyone_encryption_key)
-  - [Proxies](#proxies)
   - [Terms of Service, Privacy, and Imprint URLs](#terms-of-service-privacy-and-imprint-urls)
   - [Text Similarity](#text-similarity)
 - [Validating](#validating)
@@ -309,46 +310,6 @@ To upgrade from versions prior to FiftyOne Enterprise v1.6
 > **NOTE**: See
 > [Upgrading From Previous Versions](./docs/upgrading.md)
 
-### Snapshot Archival
-
-Since version v1.5, FiftyOne Enterprise supports
-[archiving snapshots](https://docs.voxel51.com/enterprise/dataset_versioning.html#snapshot-archival)
-to cold storage locations to prevent filling up the MongoDB database.
-Supported locations are network mounted filesystems and cloud storage folders.
-
-Please refer to the
-[snapshot archival configuration documentation](./docs/configuring-snapshot-archival.md)
-for configuring snapshot archival.
-
-### Static Banner Configuration
-
-FiftyOne Enterprise v2.6 introduces the ability to add a static banner to the
-application.
-
-Banner text is configured with `FIFTYONE_APP_BANNER_TEXT`.
-
-Banner background color is configured with `FIFTYONE_APP_BANNER_COLOR`.
-
-Banner text color is configured with:
-`casSettings.env.FIFTYONE_APP_BANNER_TEXT_COLOR` and
-`teamsAppSettings.env.FIFTYONE_APP_BANNER_TEXT_COLOR`
-
-Examples:
-
-```yaml
-services:
-  teams-app-common:
-    environment:
-      FIFTYONE_APP_BANNER_COLOR: `green | rgb(34,139,34") | '#f1f1f1'`
-      FIFTYONE_APP_BANNER_TEXT_COLOR: `green | rgb(34,139,34") | '#f1f1f1'`
-      FIFTYONE_APP_BANNER_TEXT: "Internal Deployment"
-  teams-cas-common:
-    environment:
-      FIFTYONE_APP_BANNER_COLOR: `green | rgb(34,139,34") | '#f1f1f1'`
-      FIFTYONE_APP_BANNER_TEXT_COLOR: `green | rgb(34,139,34") | '#f1f1f1'`
-      FIFTYONE_APP_BANNER_TEXT: "Internal Deployment"
-```
-
 ### FiftyOne Enterprise Authenticated API
 
 FiftyOne Enterprise v1.3 introduces the capability to connect FiftyOne
@@ -360,7 +321,15 @@ To enable the FiftyOne Enterprise Authenticated API you will need to
 and
 [configure your SDK](https://docs.voxel51.com/enterprise/api_connection.html).
 
-### FiftyOne Enterprise Plugins
+### GPU Enabled Workloads
+
+FiftyOne services can be scheduled on GPU-enabled hardware for more efficient
+computation.
+
+To schedule pods on GPU-enabled hardware, see the
+[configuring GPU workloads documentation][gpu-workloads].
+
+### Plugins
 
 FiftyOne Enterprise v1.3+ includes significant enhancements for
 [Plugins](https://docs.voxel51.com/plugins/index.html)
@@ -402,6 +371,53 @@ manually must be redeployed using the FiftyOne Enterprise UI.
 For configuring your plugins, see
 [Configuring Plugins](./docs/configuring-plugins.md).
 
+### Proxies
+
+FiftyOne Enterprise supports routing traffic through proxy servers.
+Please refer to the
+[proxy configuration documentation](./docs/configuring-proxies.md)
+for information on how to configure proxies.
+
+### Snapshot Archival
+
+Since version v1.5, FiftyOne Enterprise supports
+[archiving snapshots](https://docs.voxel51.com/enterprise/dataset_versioning.html#snapshot-archival)
+to cold storage locations to prevent filling up the MongoDB database.
+Supported locations are network mounted filesystems and cloud storage folders.
+
+Please refer to the
+[snapshot archival configuration documentation](./docs/configuring-snapshot-archival.md)
+for configuring snapshot archival.
+
+### Static Banner Configuration
+
+FiftyOne Enterprise v2.6 introduces the ability to add a static banner to the
+application.
+
+Banner text is configured with `FIFTYONE_APP_BANNER_TEXT`.
+
+Banner background color is configured with `FIFTYONE_APP_BANNER_COLOR`.
+
+Banner text color is configured with:
+`casSettings.env.FIFTYONE_APP_BANNER_TEXT_COLOR` and
+`teamsAppSettings.env.FIFTYONE_APP_BANNER_TEXT_COLOR`
+
+Examples:
+
+```yaml
+services:
+  teams-app-common:
+    environment:
+      FIFTYONE_APP_BANNER_COLOR: `green | rgb(34,139,34") | '#f1f1f1'`
+      FIFTYONE_APP_BANNER_TEXT_COLOR: `green | rgb(34,139,34") | '#f1f1f1'`
+      FIFTYONE_APP_BANNER_TEXT: "Internal Deployment"
+  teams-cas-common:
+    environment:
+      FIFTYONE_APP_BANNER_COLOR: `green | rgb(34,139,34") | '#f1f1f1'`
+      FIFTYONE_APP_BANNER_TEXT_COLOR: `green | rgb(34,139,34") | '#f1f1f1'`
+      FIFTYONE_APP_BANNER_TEXT: "Internal Deployment"
+```
+
 ### Storage Credentials and `FIFTYONE_ENCRYPTION_KEY`
 
 As of FiftyOne Enterprise 1.1, containers based on the
@@ -435,13 +451,6 @@ to manage storage credentials by navigating to
 FiftyOne Enterprise version 1.3+ continues to support the use of environment
 variables to set storage credentials in the application context and is
 providing an alternate configuration path.
-
-### Proxies
-
-FiftyOne Enterprise supports routing traffic through proxy servers.
-Please refer to the
-[proxy configuration documentation](./docs/configuring-proxies.md)
-for information on how to configure proxies.
 
 ### Terms of Service, Privacy, and Imprint URLs
 
@@ -556,5 +565,6 @@ follow
 | `NO_PROXY_LIST`                              | The list of servers that should bypass the proxy; if a proxy is in use this must include the list of FiftyOne services (`fiftyone-app, teams-api,teams-app,teams-cas` must be included, `teams-plugins` should be included for dedicated plugins configurations)               | No                        |
 
 <!-- Reference Links -->
+[gpu-workloads]: https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/docker/docs/configuring-gpu-workloads.md
 [internal-auth-mode]: https://docs.voxel51.com/teams/pluggable_auth.html#internal-mode
 [legacy-auth-mode]: https://docs.voxel51.com/teams/pluggable_auth.html#legacy-mode

--- a/docker/README.md
+++ b/docker/README.md
@@ -327,7 +327,7 @@ FiftyOne services can be scheduled on GPU-enabled hardware for more efficient
 computation.
 
 To schedule pods on GPU-enabled hardware, see the
-[configuring GPU workloads documentation][gpu-workloads].
+[configuring GPU workloads documentation](./docs/configuring-gpu-workloads.md).
 
 ### Plugins
 
@@ -565,6 +565,5 @@ follow
 | `NO_PROXY_LIST`                              | The list of servers that should bypass the proxy; if a proxy is in use this must include the list of FiftyOne services (`fiftyone-app, teams-api,teams-app,teams-cas` must be included, `teams-plugins` should be included for dedicated plugins configurations)               | No                        |
 
 <!-- Reference Links -->
-[gpu-workloads]: https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/docker/docs/configuring-gpu-workloads.md
 [internal-auth-mode]: https://docs.voxel51.com/teams/pluggable_auth.html#internal-mode
 [legacy-auth-mode]: https://docs.voxel51.com/teams/pluggable_auth.html#legacy-mode

--- a/docker/docs/configuring-gpu-workloads.md
+++ b/docker/docs/configuring-gpu-workloads.md
@@ -26,12 +26,11 @@
 
 ## Overview
 
-In many machine learning applications, it is desirable to utilize available
+Many machine learning applications utilize
 GPU hardware for intensive computations.
-The FiftyOne Enterprise compose files allow users to schedule containers on
-GPU-enabled nodes using the docker compose
-[`deploy.resource.reservation.devices`][compose-deploy-resources]
-settings for individual services.
+The FiftyOne Enterprise docker compose files allow users to schedule containers on
+GPU-enabled nodes using a service's
+[`deploy.resource.reservation.devices`][compose-deploy-resources].
 
 The below will show an example deploying a GPU-enabled container via docker
 compose by following their
@@ -42,20 +41,21 @@ in a FiftyOne Enterprise context.
 
 ### Prerequisites
 
-This example assumes you have a docker compose node with GPU devices available.
-This example also assumes you have followed the
-[GPU prerequisites][compose-gpu-resources]
-outlined by docker.
+This example assumes you have a docker compose node with GPU devices available
+and you have followed Docker's
+[GPU prerequisites][compose-gpu-resources].
 
 ### Deploying GPU-enabled Delegated Operator Containers
 
-In this example, we will leverage GPUs for
-[delegated operators](./configuring-delegated-operators.md).
+We will configure the
+[delegated operators](./configuring-delegated-operators.md)
+with GPUs.
 
-Under `.services.teams-do` in your `compose.delegated-operators.yaml`,
+In your `compose.delegated-operators.yaml`, under `.services.teams-do`,
 add the `deploy.resource.reservation.devices` configuration:
 
 ```yaml
+services:
   teams-do:
     extends:
       file: ../common-services.yaml
@@ -69,7 +69,7 @@ add the `deploy.resource.reservation.devices` configuration:
                 capabilities: [gpu]
 ```
 
-Now redeploy your stack via `docker compose up -d` and wait for the
+Redeploy the stack via `docker compose up -d` and wait for the
 `teams-do` containers to be deployed.
 
 For advanced GPU configuration, including selecting specific GPU devices,
@@ -78,10 +78,10 @@ please refer to the
 
 ### Validating GPU Access
 
-You can validate that the container can correctly access the GPU drivers using
+You may validate that the container can access the GPU drivers using
 PyTorch's
 [cuda.is_available method][pytorch-cuda-is-available]
-from within the container.
+by execing into the container and running
 
 ```shell
 $ docker compose exec teams-do \
@@ -89,7 +89,7 @@ $ docker compose exec teams-do \
 True
 ```
 
-If `True` is printed, then you are ready to run computations on GPU hardware.
+If `True` is printed, then computations may run on GPU hardware.
 
 <!-- Reference Links -->
 

--- a/docker/docs/configuring-gpu-workloads.md
+++ b/docker/docs/configuring-gpu-workloads.md
@@ -1,0 +1,99 @@
+<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-disable-next-line first-line-heading -->
+<div align="center">
+<p align="center">
+
+<img src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
+
+</p>
+</div>
+<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
+
+---
+
+# Leveraging GPU Workloads
+
+<!-- toc -->
+
+- [Overview](#overview)
+- [Utilizing GPUs For Delegated Operations](#utilizing-gpus-for-delegated-operations)
+  - [Prerequisites](#prerequisites)
+  - [Deploying GPU-enabled Delegated Operator Containers](#deploying-gpu-enabled-delegated-operator-containers)
+  - [Validating GPU Access](#validating-gpu-access)
+
+<!-- tocstop -->
+
+## Overview
+
+In many machine learning applications, it is desirable to utilize available
+GPU hardware for intensive computations.
+The FiftyOne Enterprise compose files allow users to schedule containers on
+GPU-enabled nodes using the docker compose
+[`deploy.resource.reservation.devices`][compose-deploy-resources]
+settings for individual services.
+
+The below will show an example deploying a GPU-enabled container via docker
+compose by following their
+[documentation][compose-gpu-how-to]
+in a FiftyOne Enterprise context.
+
+## Utilizing GPUs For Delegated Operations
+
+### Prerequisites
+
+This example assumes you have a docker compose node with GPU devices available.
+This example also assumes you have followed the
+[GPU prerequisites][compose-gpu-resources]
+outlined by docker.
+
+### Deploying GPU-enabled Delegated Operator Containers
+
+In this example, we will leverage GPUs for
+[delegated operators](./configuring-delegated-operators.md).
+
+Under `.services.teams-do` in your `compose.delegated-operators.yaml`,
+add the `deploy.resource.reservation.devices` configuration:
+
+```yaml
+  teams-do:
+    extends:
+      file: ../common-services.yaml
+      service: teams-do-common
+      deploy:
+        resources:
+          reservations:
+            devices:
+              - driver: nvidia
+                count: 1
+                capabilities: [gpu]
+```
+
+Now redeploy your stack via `docker compose up -d` and wait for the
+`teams-do` containers to be deployed.
+
+For advanced GPU configuration, including selecting specific GPU devices,
+please refer to the
+[docker documentation][compose-gpu-how-to].
+
+### Validating GPU Access
+
+You can validate that the container can correctly access the GPU drivers using
+PyTorch's
+[cuda.is_available method][pytorch-cuda-is-available]
+from within the container.
+
+```shell
+$ docker compose exec teams-do \
+    python -c 'import torch; print(torch.cuda.is_available())'
+True
+```
+
+If `True` is printed, then you are ready to run computations on GPU hardware.
+
+<!-- Reference Links -->
+
+[compose-deploy-resources]: https://docs.docker.com/reference/compose-file/deploy/#resources
+[compose-gpu-how-to]: https://docs.docker.com/compose/how-tos/gpu-support/
+[compose-gpu-resources]: https://docs.docker.com/engine/containers/resource_constraints/#gpu
+[pytorch-cuda-is-available]: https://pytorch.org/docs/stable/generated/torch.cuda.is_available.html

--- a/docker/docs/configuring-gpu-workloads.md
+++ b/docker/docs/configuring-gpu-workloads.md
@@ -69,7 +69,7 @@ services:
     deploy:
       replicas: ${FIFTYONE_DELEGATED_OPERATOR_WORKER_REPLICAS:-3}
     command: >
-      /bin/sh -c "fiftyone delegated launch -t remote"
+      /bin/sh -c "fiftyone delegated launch -t remote  -n 'teams-do-with-gpu'"
     environment:
       API_URL: ${API_URL}
       FIFTYONE_DATABASE_ADMIN: false

--- a/helm/docs/configuring-gpu-workloads.md
+++ b/helm/docs/configuring-gpu-workloads.md
@@ -64,22 +64,22 @@ the desired amount of GPUs from the Kubernetes scheduler:
 
 ```yaml
 delegatedOperatorDeployments:
-    deployments:
-        teamsDoWithGpu:
-            nodeSelector:
-                cloud.google.com/gke-accelerator: nvidia-l4  # Modify For Your Needs
-                cloud.google.com/gke-accelerator-count: "1"  # Modify For Your Needs
-            resources:
-                limits:
-                    cpu: 4        # Modify For Your Needs
-                    memory: 12Gi  # Modify For Your Needs
-                requests:
-                    cpu: 4             # Modify For Your Needs
-                    memory: 12Gi       # Modify For Your Needs
-                    nvidia.com/gpu: 1  # Modify For Your Needs
-            env:
-                [...existing environment variables...]
-                LD_LIBRARY_PATH: /usr/local/nvidia/lib64  # Modify For Your Needs
+  deployments:
+    teamsDoWithGpu:
+      nodeSelector:
+        cloud.google.com/gke-accelerator: nvidia-l4  # Modify For Your Needs
+        cloud.google.com/gke-accelerator-count: "1"  # Modify For Your Needs
+      resources:
+        limits:
+          cpu: 4        # Modify For Your Needs
+          memory: 12Gi  # Modify For Your Needs
+        requests:
+          cpu: 4             # Modify For Your Needs
+          memory: 12Gi       # Modify For Your Needs
+          nvidia.com/gpu: 1  # Modify For Your Needs
+      env:
+        [...existing environment variables...]
+        LD_LIBRARY_PATH: /usr/local/nvidia/lib64  # Modify For Your Needs
 ```
 
 Now upgrade your deployment via `helm upgrade` and wait for the

--- a/helm/docs/configuring-gpu-workloads.md
+++ b/helm/docs/configuring-gpu-workloads.md
@@ -62,11 +62,15 @@ The deployment should also set the `LD_LIBRARY_PATH` variable to the
 corresponding
 [google GPU driver][gke-gpu-how-to-cuda].
 Also be sure to modify the deployment's `resources.requests` to request
-the desired amount of GPUs from the Kubernetes scheduler:
+the desired amount of GPUs from the Kubernetes scheduler.
+
+The below will deploy a CPU-based delegated operator (`teamsDo`) as well
+as a GPU-based delegated operator (`teamsDoWithGpu`):
 
 ```yaml
 delegatedOperatorDeployments:
   deployments:
+    teamsDo: {}  # A CPU Based Deployment
     teamsDoWithGpu:
       nodeSelector:
         cloud.google.com/gke-accelerator: nvidia-l4  # Modify For Your Needs

--- a/helm/docs/configuring-gpu-workloads.md
+++ b/helm/docs/configuring-gpu-workloads.md
@@ -26,7 +26,7 @@
 
 ## Overview
 
-In many machine learning applications, it is desirable to utilize available
+Many machine learning applications utilize
 GPU hardware for intensive computations.
 The FiftyOne Enterprise helm chart allows users to schedule pods on
 GPU-enabled nodes using the `nodeSelector` values for individual services.
@@ -49,10 +49,12 @@ for assistance in setting up those clusters.
 
 ### Deploying GPU-enabled Delegated Operator Pods
 
-In this example, we will leverage GKE GPUs for
-[delegated operators](./configuring-delegated-operators.md).
+We will configure the
+[delegated operators](./configuring-delegated-operators.md)
+with GKE GPUs.
 
-Under `.Values.delegatedOperatorDeployments.deployments`, add a new delegated
+In your `values.yaml`,
+under `.Values.delegatedOperatorDeployments.deployments`, add a new delegated
 operator deployment.
 Ensure the delegated operator deployment has `nodeSelector` set to valid
 [GKE accelerator values and counts][gke-gpu-how-to-multi].
@@ -82,15 +84,15 @@ delegatedOperatorDeployments:
         LD_LIBRARY_PATH: /usr/local/nvidia/lib64  # Modify For Your Needs
 ```
 
-Now upgrade your deployment via `helm upgrade` and wait for the
+Upgrade your deployment via `helm upgrade` and wait for the
 `teams-do-with-gpu` pods to be scheduled and deployed.
 
 ### Validating GPU Access
 
-You can validate that the pod can correctly access the GPU drivers using
+You may validate that the pod can access the GPU drivers using
 PyTorch's
 [cuda.is_available method][pytorch-cuda-is-available]
-from within the pod.
+by execing into the pod and running
 
 ```shell
 $ kubectl exec -it -n <YOUR_NAMESPACE> \
@@ -98,7 +100,7 @@ $ kubectl exec -it -n <YOUR_NAMESPACE> \
 True
 ```
 
-If `True` is printed, then you are ready to run computations on GPU hardware.
+If `True` is printed, then computations may run on GPU hardware.
 
 <!-- Reference Links -->
 

--- a/helm/docs/configuring-gpu-workloads.md
+++ b/helm/docs/configuring-gpu-workloads.md
@@ -1,0 +1,101 @@
+<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-disable-next-line first-line-heading -->
+<div align="center">
+<p align="center">
+
+<img src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
+
+</p>
+</div>
+<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
+
+---
+
+# Leveraging GPU Workloads
+
+<!-- toc -->
+
+- [Overview](#overview)
+- [Utilizing GKE GPUs For Delegated Operations](#utilizing-gke-gpus-for-delegated-operations)
+  - [Prerequisites](#prerequisites)
+  - [Deploying GPU-enabled Delegated Operator Pods](#deploying-gpu-enabled-delegated-operator-pods)
+  - [Validating GPU Access](#validating-gpu-access)
+
+<!-- tocstop -->
+
+## Overview
+
+In many machine learning applications, it is desirable to utilize available
+GPU hardware for intensive computations.
+The FiftyOne Enterprise helm chart allows users to schedule pods on
+GPU-enabled nodes using the `nodeSelector` values for individual services.
+
+The below will show an example on Google Kubernetes Engine (GKE)
+following their
+[documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/gpus)
+in a FiftyOne Enterprise context.
+
+## Utilizing GKE GPUs For Delegated Operations
+
+### Prerequisites
+
+This example assumes you have a GKE cluster with GPU-available nodes.
+Please refer to the
+[autopilot documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/autopilot-gpus)
+or the
+[standard node pool documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/gpus)
+for assistance in setting up those clusters.
+
+### Deploying GPU-enabled Delegated Operator Pods
+
+In this example, we will leverage GKE GPUs for
+[delegated operators](./configuring-delegated-operators.md).
+
+Under `.Values.delegatedOperatorDeployments.deployments`, add a new delegated
+operator deployment.
+Ensure the delegated operator deployment has `nodeSelector` set to valid
+[GKE accelerator values and counts](https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#multiple_gpus).
+The deployment should also set the `LD_LIBRARY_PATH` variable to the
+corresponding
+[google GPU driver](https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#cuda).
+Also be sure to modify the deployment's `resources.requests` to request
+the desired amount of GPUs from the Kubernetes scheduler:
+
+```yaml
+delegatedOperatorDeployments:
+    deployments:
+        teamsDoWithGpu:
+            nodeSelector:
+                cloud.google.com/gke-accelerator: nvidia-l4  # Modify For Your Needs
+                cloud.google.com/gke-accelerator-count: "1"  # Modify For Your Needs
+            resources:
+                limits:
+                    cpu: 4        # Modify For Your Needs
+                    memory: 12Gi  # Modify For Your Needs
+                requests:
+                    cpu: 4             # Modify For Your Needs
+                    memory: 12Gi       # Modify For Your Needs
+                    nvidia.com/gpu: 1  # Modify For Your Needs
+            env:
+                [...existing environment variables...]
+                LD_LIBRARY_PATH: /usr/local/nvidia/lib64  # Modify For Your Needs
+```
+
+Now upgrade your deployment via `helm upgrade` and wait for the
+`teams-do-with-gpu` pods to be scheduled and deployed.
+
+### Validating GPU Access
+
+You can validate that the pod can correctly access the GPU drivers using
+PyTorches
+[cuda.is_available method](https://pytorch.org/docs/stable/generated/torch.cuda.is_available.html)
+from within the pod.
+
+```shell
+$ kubectl exec -it -n <YOUR_NAMESPACE> \
+    <YOUR_POD> -- python -c 'import torch; print(torch.cuda.is_available())'
+True
+```
+
+If `True` is printed, then you are ready to run computations on GPU hardware.

--- a/helm/docs/configuring-gpu-workloads.md
+++ b/helm/docs/configuring-gpu-workloads.md
@@ -33,7 +33,7 @@ GPU-enabled nodes using the `nodeSelector` values for individual services.
 
 The below will show an example on Google Kubernetes Engine (GKE)
 following their
-[documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/gpus)
+[documentation][gke-gpu-how-to]
 in a FiftyOne Enterprise context.
 
 ## Utilizing GKE GPUs For Delegated Operations
@@ -42,9 +42,9 @@ in a FiftyOne Enterprise context.
 
 This example assumes you have a GKE cluster with GPU-available nodes.
 Please refer to the
-[autopilot documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/autopilot-gpus)
+[autopilot documentation][gke-autopilot-gke-how-to]
 or the
-[standard node pool documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/gpus)
+[standard node pool documentation][gke-gpu-how-to]
 for assistance in setting up those clusters.
 
 ### Deploying GPU-enabled Delegated Operator Pods
@@ -55,10 +55,10 @@ In this example, we will leverage GKE GPUs for
 Under `.Values.delegatedOperatorDeployments.deployments`, add a new delegated
 operator deployment.
 Ensure the delegated operator deployment has `nodeSelector` set to valid
-[GKE accelerator values and counts](https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#multiple_gpus).
+[GKE accelerator values and counts][gke-gpu-how-to-multi].
 The deployment should also set the `LD_LIBRARY_PATH` variable to the
 corresponding
-[google GPU driver](https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#cuda).
+[google GPU driver][gke-gpu-how-to-cuda].
 Also be sure to modify the deployment's `resources.requests` to request
 the desired amount of GPUs from the Kubernetes scheduler:
 
@@ -88,8 +88,8 @@ Now upgrade your deployment via `helm upgrade` and wait for the
 ### Validating GPU Access
 
 You can validate that the pod can correctly access the GPU drivers using
-PyTorches
-[cuda.is_available method](https://pytorch.org/docs/stable/generated/torch.cuda.is_available.html)
+PyTorch's
+[cuda.is_available method][pytorch-cuda-is-available]
 from within the pod.
 
 ```shell
@@ -99,3 +99,11 @@ True
 ```
 
 If `True` is printed, then you are ready to run computations on GPU hardware.
+
+<!-- Reference Links -->
+
+[gke-autopilot-gke-how-to]: https://cloud.google.com/kubernetes-engine/docs/how-to/autopilot-gpus
+[gke-gpu-how-to]: https://cloud.google.com/kubernetes-engine/docs/how-to/gpus
+[gke-gpu-how-to-cuda]: https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#cuda
+[gke-gpu-how-to-multi]: https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#multiple_gpus
+[pytorch-cuda-is-available]: https://pytorch.org/docs/stable/generated/torch.cuda.is_available.html

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -266,7 +266,7 @@ FiftyOne services can be scheduled on GPU-enabled hardware for more efficient
 computation.
 
 To schedule pods on GPU-enabled hardware, see the
-[configuring GPU workloads documentation][gpu-workloads].
+[configuring GPU workloads documentation](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/configuring-gpu-workloads.md).
 
 ### Highly Available FiftyOne `teams-api` Deployments
 
@@ -756,7 +756,6 @@ serviceAccount:
 [autoscaling]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
 [container-security-context]: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 [deployment]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
-[gpu-workloads]: https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/configuring-gpu-workloads.md
 [howto-wif]: https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
 [image-pull-policy]: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
 [image-pull-secrets]: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -266,7 +266,7 @@ FiftyOne services can be scheduled on GPU-enabled hardware for more efficient
 computation.
 
 To schedule pods on GPU-enabled hardware, see the
-[configuring GPU workloads documentation](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/configuring-gpu-workloads.md).
+[configuring GPU workloads documentation][gpu-workloads].
 
 ### Highly Available FiftyOne `teams-api` Deployments
 
@@ -756,6 +756,7 @@ serviceAccount:
 [autoscaling]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
 [container-security-context]: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 [deployment]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
+[gpu-workloads]: https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/configuring-gpu-workloads.md
 [howto-wif]: https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
 [image-pull-policy]: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
 [image-pull-secrets]: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -71,6 +71,7 @@ for steps on how to upgrade your delegated operators.
   - [Builtin Delegated Operator Orchestrator](#builtin-delegated-operator-orchestrator)
   - [Central Authentication Service](#central-authentication-service)
   - [FiftyOne Enterprise Authenticated API](#fiftyone-enterprise-authenticated-api)
+  - [GPU Enabled Workloads](#gpu-enabled-workloads)
   - [Highly Available FiftyOne `teams-api` Deployments](#highly-available-fiftyone-teams-api-deployments)
   - [Plugins](#plugins)
   - [Proxies](#proxies)
@@ -258,6 +259,14 @@ To enable the FiftyOne Enterprise Authenticated API,
 [expose the FiftyOne Enterprise API endpoint](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/expose-teams-api.md)
 and
 [configure your SDK](https://docs.voxel51.com/enterprise/api_connection.html).
+
+### GPU Enabled Workloads
+
+FiftyOne services can be scheduled on GPU-enabled hardware for more efficient
+computation.
+
+To schedule pods on GPU-enabled hardware, see the
+[configuring GPU workloads documentation](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/configuring-gpu-workloads.md).
 
 ### Highly Available FiftyOne `teams-api` Deployments
 

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -71,6 +71,7 @@ for steps on how to upgrade your delegated operators.
   - [Builtin Delegated Operator Orchestrator](#builtin-delegated-operator-orchestrator)
   - [Central Authentication Service](#central-authentication-service)
   - [FiftyOne Enterprise Authenticated API](#fiftyone-enterprise-authenticated-api)
+  - [GPU Enabled Workloads](#gpu-enabled-workloads)
   - [Highly Available FiftyOne `teams-api` Deployments](#highly-available-fiftyone-teams-api-deployments)
   - [Plugins](#plugins)
   - [Proxies](#proxies)
@@ -259,6 +260,14 @@ To enable the FiftyOne Enterprise Authenticated API,
 [expose the FiftyOne Enterprise API endpoint](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/expose-teams-api.md)
 and
 [configure your SDK](https://docs.voxel51.com/enterprise/api_connection.html).
+
+### GPU Enabled Workloads
+
+FiftyOne services can be scheduled on GPU-enabled hardware for more efficient
+computation.
+
+To schedule pods on GPU-enabled hardware, see the
+[configuring GPU workloads documentation](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/configuring-gpu-workloads.md).
 
 ### Highly Available FiftyOne `teams-api` Deployments
 


### PR DESCRIPTION
# Rationale

We have an increasing amount of stakeholders (internal and external) utilizing GPUs. We should document how GPUs can be made accessible to either K8s pods or docker containers. While reviewing this PR, I also noticed that the `## Advanced Configuration` section of the compose docs were out of order, so I figured we could fix it.

## Changes

1. Adds GPU documentation for both docker compose and kubernetes
    1. For both, show an example with teamd-do 
    2. For K8s, only show a GKE example
1. Re-orders the `## Advanced Configuration` of the compose docs
2. Changes the `FiftyOne Enterprise Plugins` header in the docker docs to `Plugins` to match the helm docs

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
