### PR TITLE
docs: make notes consistent by ending with ":".  Update language for …

### DIFF
--- a/docker/docs/upgrading.md
+++ b/docker/docs/upgrading.md
@@ -145,7 +145,7 @@ Additionally,
     1. To obtain the CLI command to install the FiftyOne SDK associated with
       your FiftyOne Enterprise version, navigate to `Account > Install FiftyOne`
 1. Upgrade all the datasets
-    > **NOTE** Any FiftyOne SDK less than 2.7.0
+    > **NOTE**: Any FiftyOne SDK less than 2.7.0
     > will lose connectivity at this point.
     > Upgrading to `fiftyone==2.7.0` is required.
 
@@ -237,7 +237,7 @@ Additionally,
     1. To obtain the CLI command to install the FiftyOne SDK associated with
       your FiftyOne Enterprise version, navigate to `Account > Install FiftyOne`
 1. Upgrade all the datasets
-    > **NOTE** Any FiftyOne SDK less than 2.7.0
+    > **NOTE**: Any FiftyOne SDK less than 2.7.0
     > will lose connectivity at this point.
     > Upgrading to `fiftyone==2.7.0` is required.
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -73,7 +73,7 @@ in this directory.
         helm upgrade fiftyone-teams-app voxel51/fiftyone-teams-app -f ./values.yaml
         ```
 
-        > **NOTE** Prior to running helm upgrade you may
+        > **NOTE**: Prior to running helm upgrade you may
         > view the changes Helm would apply by using
         > [helm diff](https://github.com/databus23/helm-diff)
         > helm plugin.
@@ -111,11 +111,16 @@ These instructions assume you have
   - If you have not received this information, please contact your
     Voxel51 Support Team via your agreed-upon mechanism (Slack, email, etc.)
 
-> **NOTE**
-> Anytime a license file is updated, you may need to restart the `teams-cas`
-> and `teams-api` services. You can do this by deleting the pods, or by running
-> the following command: </br>
-> `kubectl rollout restart deploy -n your-namespace teams-cas teams-api`
+> **NOTE**: Anytime a license file secret is updated, you
+> must restart the `teams-cas` and `teams-api` services.
+> You may delete the pods, or run
+>
+> ```shell
+> kubectl rollout restart deploy \
+>   -n your-namespace \
+>   teams-cas \
+>   teams-api
+> ```
 
 #### Download the Example Configuration Files
 

--- a/helm/docs/upgrading.md
+++ b/helm/docs/upgrading.md
@@ -51,7 +51,7 @@ A minimal example `values.yaml` may be found
           -f ./values.yaml
         ```
 
-    > **NOTE** To view the changes Helm would apply during installations
+    > **NOTE**: To view the changes Helm would apply during installations
     > and upgrades, consider using
     > [helm diff](https://github.com/databus23/helm-diff).
     > Voxel51 is not affiliated with the author of this plugin.
@@ -213,7 +213,7 @@ For a full list of settings, please refer to the
         ```
 
 1. Use the license file provided by the Voxel51 Customer Success Team to create
-   a new kubernetes secret:
+   a new kubernetes secret
 
     ```shell
     kubectl --namespace your-namespace-here create secret generic \
@@ -227,7 +227,7 @@ For a full list of settings, please refer to the
       your FiftyOne Enterprise version, navigate to `Account > Install FiftyOne`
 1. Upgrade all the datasets
 
-    > **NOTE** Any FiftyOne SDK less than 2.7.0 will lose connectivity after
+    > **NOTE**: Any FiftyOne SDK less than 2.7.0 will lose connectivity after
     > this point.
     > Upgrading all SDKs to `fiftyone==2.7.0` is recommended before migrating
     > your database.
@@ -310,7 +310,7 @@ For a full list of settings, please refer to the
       your FiftyOne Enterprise version, navigate to `Account > Install FiftyOne`
 1. Upgrade all the datasets
 
-    > **NOTE** Any FiftyOne SDK less than 2.7.0 will lose connectivity after
+    > **NOTE**: Any FiftyOne SDK less than 2.7.0 will lose connectivity after
     > this point.
     > Upgrading all SDKs to `fiftyone==2.7.0` is recommended before migrating
     > your database.

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -130,11 +130,16 @@ kubectl --namespace your-namespace-here create secret generic fiftyone-license \
 --from-file=license=./your-license-file
 ```
 
-> **NOTE**
-> To ensure that the new license values take effect
-> immediately, you may need to restart the `teams-cas` and `teams-api` services.
-> You can do this by deleting the pods, or by running the following command:
-> `kubectl rollout restart deploy -n your-namespace teams-cas teams-api`
+> **NOTE**: To ensure that the new license values take effect
+> immediately, you must to restart the `teams-cas` and `teams-api` services.
+> You may delete the pods, or run
+>
+> ```shell
+> kubectl rollout restart deploy \
+>   -n your-namespace \
+>   teams-cas \
+>   teams-api
+> ```
 
 We publish the following FiftyOne Enterprise private images to Docker Hub:
 

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -130,11 +130,16 @@ kubectl --namespace your-namespace-here create secret generic fiftyone-license \
 --from-file=license=./your-license-file
 ```
 
-> **NOTE**
-> To ensure that the new license values take effect
-> immediately, you may need to restart the `teams-cas` and `teams-api` services.
-> You can do this by deleting the pods, or by running the following command:
-> `kubectl rollout restart deploy -n your-namespace teams-cas teams-api`
+> **NOTE**: To ensure that the new license values take effect
+> immediately, you must to restart the `teams-cas` and `teams-api` services.
+> You may delete the pods, or run
+>
+> ```shell
+> kubectl rollout restart deploy \
+>   -n your-namespace \
+>   teams-cas \
+>   teams-api
+> ```
 
 We publish the following FiftyOne Enterprise private images to Docker Hub:
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -6,7 +6,7 @@ Module for deploying FiftyOne Enterprise Infrastructure
 
 ### Simple Two-Node Deploy
 
-**NOTE** This deploys a simple two-node infrastructure
+**NOTE**: This deploys a simple two-node infrastructure
 that does not provide High Availability.
 If High Availability is a requirement in your environment, consider modifying
 this deployment to include multiple MongoDB nodes and multiple app nodes.


### PR DESCRIPTION
# Rationale

While looking at another PR, I thought to look at the deploy regarding license secret upgrades.  Let's fix up the formatting a bit.  And make our `**NOTE**` consistent.

## Changes

* Formatting
* Adding  `:` after `**NOTE**`

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

n/a

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
