### PR TITLE
chore(workflows/test-docker-pulls): update asdf install action to pin…

### DIFF
--- a/.github/workflows/test-docker-pulls.yml
+++ b/.github/workflows/test-docker-pulls.yml
@@ -27,12 +27,7 @@ jobs:
       - name: Temporary SQLite/LZMA - Install missing libraries
         run: sudo apt install -y libsqlite3-dev libbz2-dev
       - name: install asdf & tools
-        uses: asdf-vm/actions/install@v3.0.2
-        with:
-          # Issue with some of the tests. So pin to an older version for now. See
-          # https://github.com/voxel51/fiftyone-teams-app-deploy/actions/runs/13078221229/job/36495530561
-          # https://voxel51.atlassian.net/browse/AS-506
-          asdf_branch: v0.14.1
+        uses: asdf-vm/actions/install@1117842ea70e2711a0072e3a71265cbfe2c830be
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
…ned version after upstream support for adsf breaking changes in go rewrite.

# Rationale

Creating this draft PR so we can update the last asdf action version pinned to the bash version of asdf. It appears that as we completed AS-506, this lil guy slipped through the cracks.

## Changes

1. update asdf action to match the other action refs in other workflow files.

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
