### PR TITLE
docs(helm): fix indent of yaml code blocks to nest under lists.

### DIFF
--- a/helm/docs/configuring-delegated-operators.md
+++ b/helm/docs/configuring-delegated-operators.md
@@ -100,40 +100,40 @@ of the two ways below:
 
 1. The template (applies to all instances):
 
-```yaml
-delegatedOperatorDeployments:
-  template:
-    env:
-      FIFTYONE_PLUGINS_DIR: /opt/plugins
-    volumes:
-      - name: plugins-vol
-        persistentVolumeClaim:
-          claimName: plugins-pvc
-          readOnly: true
-    volumeMounts:
-      - name: plugins-vol
-        mountPath: /opt/plugins
-  deployments:
-    teamsDo: {}
-```
+    ```yaml
+    delegatedOperatorDeployments:
+      template:
+        env:
+          FIFTYONE_PLUGINS_DIR: /opt/plugins
+        volumes:
+          - name: plugins-vol
+            persistentVolumeClaim:
+              claimName: plugins-pvc
+              readOnly: true
+        volumeMounts:
+          - name: plugins-vol
+            mountPath: /opt/plugins
+      deployments:
+        teamsDo: {}
+    ```
 
 1. Or, per instance:
 
-```yaml
-delegatedOperatorDeployments:
-  deployments:
-    teamsDo:
-      env:
-        FIFTYONE_PLUGINS_DIR: /opt/plugins
-      volumes:
-        - name: plugins-vol
-          persistentVolumeClaim:
-            claimName: plugins-pvc
-            readOnly: true
-      volumeMounts:
-        - name: plugins-vol
-          mountPath: /opt/plugins
-```
+    ```yaml
+    delegatedOperatorDeployments:
+      deployments:
+        teamsDo:
+          env:
+            FIFTYONE_PLUGINS_DIR: /opt/plugins
+          volumes:
+            - name: plugins-vol
+              persistentVolumeClaim:
+                claimName: plugins-pvc
+                readOnly: true
+          volumeMounts:
+            - name: plugins-vol
+              mountPath: /opt/plugins
+    ```
 
 See
 [Adding Shared Storage for FiftyOne Enterprise Plugins](./plugins-storage.md)
@@ -149,22 +149,22 @@ In `values.yaml`, set `FIFTYONE_DELEGATED_OPERATION_LOG_PATH` in either:
 
 1. The template (applies to all instances):
 
-  ```yaml
-  delegatedOperatorDeployments:
-    template:
-      env:
-        FIFTYONE_DELEGATED_OPERATION_LOG_PATH: /your/path/
-  ```
+    ```yaml
+    delegatedOperatorDeployments:
+      template:
+        env:
+          FIFTYONE_DELEGATED_OPERATION_LOG_PATH: /your/path/
+    ```
 
 1. Or, per instance:
 
-  ```yaml
-  delegatedOperatorDeployments:
-    deployments:
-      teamsDo:
-        env:
-          FIFTYONE_DELEGATED_OPERATION_LOG_PATH: /your/path
-  ```
+    ```yaml
+    delegatedOperatorDeployments:
+      deployments:
+        teamsDo:
+          env:
+            FIFTYONE_DELEGATED_OPERATION_LOG_PATH: /your/path
+    ```
 
 To use plugins with custom dependencies, build and use
 [Custom Plugins Images](../../docs/custom-plugins.md).


### PR DESCRIPTION
# Rationale

While reviewing the release PR to main, also notice some markdown formatting that be easier for readers to comprehend (when looking at the raw text and the rendered page too).

## Changes

1. indents

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

I looked at the compose docs for the delegated operators and they are good.

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
