### PR TITLE
chore(teams-api): AS-579 increase startup timeout

### DIFF
--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -479,7 +479,7 @@ follow
 | apiSettings.service.nodePort | int | `nil` | Service nodePort set only when `apiSettings.service.type: NodePort` for `teams-api`. |
 | apiSettings.service.port | int | `80` | Service port for `teams-api`. |
 | apiSettings.service.shortname | string | `"teams-api"` | Port name (maximum length is 15 characters) for `teams-api`. [Reference][ports]. |
-| apiSettings.service.startup.failureThreshold | int | `5` | Number of times to retry the startup probe for the `teams-api`. [Reference][probes]. |
+| apiSettings.service.startup.failureThreshold | int | `10` | Number of times to retry the startup probe for the `teams-api`. [Reference][probes]. |
 | apiSettings.service.startup.periodSeconds | int | `15` | How often (in seconds) to perform the startup probe for `teams-api`. [Reference][probes]. |
 | apiSettings.service.type | string | `"ClusterIP"` | Service type for `teams-api`. [Reference][service-type]. |
 | apiSettings.tolerations | list | `[]` | Allow the k8s scheduler to schedule pods with matching taints for `teams-api`. [Reference][taints-and-tolerations]. |

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -72,7 +72,7 @@ apiSettings:
     shortname: teams-api
     startup:
       # -- Number of times to retry the startup probe for the `teams-api`. [Reference][probes].
-      failureThreshold: 5
+      failureThreshold: 10
       # -- How often (in seconds) to perform the startup probe for `teams-api`. [Reference][probes].
       periodSeconds: 15
     # -- Service type for `teams-api`. [Reference][service-type].

--- a/tests/unit/helm/api-deployment_test.go
+++ b/tests/unit/helm/api-deployment_test.go
@@ -1214,7 +1214,7 @@ func (s *deploymentApiTemplateTest) TestContainerStartupProbe() {
             "path": "/health/",
             "port": "teams-api"
           },
-          "failureThreshold": 5,
+          "failureThreshold": 10,
           "periodSeconds": 15,
           "timeoutSeconds": 5
         }`
@@ -1228,7 +1228,7 @@ func (s *deploymentApiTemplateTest) TestContainerStartupProbe() {
 			"overrideServiceStartupFailureThresholdAndPeriodSecondsAndShortName",
 			map[string]string{
 				"apiSettings.service.shortname":                "test-service-shortname",
-				"apiSettings.service.startup.failureThreshold": "10",
+				"apiSettings.service.startup.failureThreshold": "15",
 				"apiSettings.service.startup.periodSeconds":    "10",
 			},
 			func(probe *corev1.Probe) {
@@ -1237,7 +1237,7 @@ func (s *deploymentApiTemplateTest) TestContainerStartupProbe() {
             "path": "/health/",
             "port": "test-service-shortname"
           },
-          "failureThreshold": 10,
+          "failureThreshold": 15,
           "periodSeconds": 10,
           "timeoutSeconds": 5
         }`


### PR DESCRIPTION
# Rationale

Internally, our pods are taking longer to start up. While this is a problem in itself, our chart should account for that known situation. This doubles the number of thresholds that has to fail before restarting the pod.

A failure threshold of 10 with a period of 15 seconds is 150 seconds dedicated to startup in the worst case scenario.

Increasing the failure threshold seems more appropriate than increasing the period between checks.

## Changes

* Increases the default `failureThresold` for `teams-api` from 5 to 10.
* Updates unit tests to reflect changes

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

```shell
make test-unit-helm
```

Helm templating returns:

```yaml
[... other templates ...]
          startupProbe:
            httpGet:
              path: /health/
              port: teams-api
            failureThreshold: 10
            periodSeconds: 15
            timeoutSeconds: 5
[... other templates ...]
```
<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
