### PR TITLE
docs(wif): as-584 adding minimum permission set for gke wif

### DIFF
--- a/helm/docs/configure-workload-identity-federation.md
+++ b/helm/docs/configure-workload-identity-federation.md
@@ -1,28 +1,51 @@
+<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-disable-next-line first-line-heading -->
+<div align="center">
+<p align="center">
+
+<img src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
+
+</p>
+</div>
+<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
+
+---
+
 # Workload Identity With FiftyOne Enterprise
 
 FiftyOne enterprise supports authentication to your cloud provider via
 workload identity federation.
+
+<!-- toc -->
+
+- [Workload Identity With GCP](#workload-identity-with-gcp)
+  - [Via `gcloud` CLI](#via-gcloud-cli)
+  - [Via `terraform`](#via-terraform)
+- [References](#references)
+
+<!-- tocstop -->
 
 ## Workload Identity With GCP
 
 For bare-minimum access, FiftyOne Enterprise needs the following permissions
 for your media bucket(s) in GCP:
 
-* `iam.serviceAccounts.signBlob`
-* `storage.buckets.get`
-* `storage.buckets.list`
-* `storage.folders.create`
-* `storage.folders.get`
-* `storage.folders.list`
-* `storage.managedFolders.create`
-* `storage.managedFolders.get`
-* `storage.managedFolders.list`
-* `storage.multipartUploads.abort`
-* `storage.multipartUploads.create`
-* `storage.multipartUploads.listParts`
-* `storage.objects.create`
-* `storage.objects.get`
-* `storage.objects.list`
+- `iam.serviceAccounts.signBlob`
+- `storage.buckets.get`
+- `storage.buckets.list`
+- `storage.folders.create`
+- `storage.folders.get`
+- `storage.folders.list`
+- `storage.managedFolders.create`
+- `storage.managedFolders.get`
+- `storage.managedFolders.list`
+- `storage.multipartUploads.abort`
+- `storage.multipartUploads.create`
+- `storage.multipartUploads.listParts`
+- `storage.objects.create`
+- `storage.objects.get`
+- `storage.objects.list`
 
 ### Via `gcloud` CLI
 
@@ -168,4 +191,4 @@ To configure workload identity via the `terraform`:
 
 ## References
 
-* [How To: GKE Workload Identity Federation](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)
+- [How To: GKE Workload Identity Federation](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)

--- a/helm/docs/configure-workload-identity-federation.md
+++ b/helm/docs/configure-workload-identity-federation.md
@@ -1,0 +1,171 @@
+# Workload Identity With FiftyOne Enterprise
+
+FiftyOne enterprise supports authentication to your cloud provider via
+workload identity federation.
+
+## Workload Identity With GCP
+
+For bare-minimum access, FiftyOne Enterprise needs the following permissions
+for your media bucket(s) in GCP:
+
+* `iam.serviceAccounts.signBlob`
+* `storage.buckets.get`
+* `storage.buckets.list`
+* `storage.folders.create`
+* `storage.folders.get`
+* `storage.folders.list`
+* `storage.managedFolders.create`
+* `storage.managedFolders.get`
+* `storage.managedFolders.list`
+* `storage.multipartUploads.abort`
+* `storage.multipartUploads.create`
+* `storage.multipartUploads.listParts`
+* `storage.objects.create`
+* `storage.objects.get`
+* `storage.objects.list`
+
+### Via `gcloud` CLI
+
+To configure workload identity via the `gcloud` CLI:
+
+1. Create a custom IAM role in GCP:
+
+    ```shell
+    cat <<EOF >custom-role.yml
+    title: "Voxel51 FiftyOne Enterpise Custom Role"
+    description: "Bare Minimum FiftyOne Enterprise Service Account Role."
+    stage: GA
+    includedPermissions:
+        - iam.serviceAccounts.signBlob
+        - storage.buckets.get
+        - storage.buckets.list
+        - storage.folders.create
+        - storage.folders.get
+        - storage.folders.list
+        - storage.managedFolders.create
+        - storage.managedFolders.get
+        - storage.managedFolders.list
+        - storage.multipartUploads.abort
+        - storage.multipartUploads.create
+        - storage.multipartUploads.listParts
+        - storage.objects.create
+        - storage.objects.get
+        - storage.objects.list
+    EOF
+
+    gcloud iam roles create "Voxel51FiftyOneEnterpriseCustomRole" \
+        --project=IAM_SA_PROJECT_ID \
+        --file=custom-role.yml
+    ```
+
+1. Create a new GCP Service Account in your project
+
+    ```shell
+    gcloud iam service-accounts create IAM_SA_NAME \
+        --project=IAM_SA_PROJECT_ID
+    ```
+
+1. Grant your IAM service account access to the
+   `projects/IAM_SA_PROJECT_ID/roles/Voxel51FiftyOneEnterpriseCustomRole`
+   role:
+
+    ```shell
+    gcloud projects add-iam-policy-binding IAM_SA_PROJECT_ID \
+        --member "serviceAccount:IAM_SA_NAME@IAM_SA_PROJECT_ID.iam.gserviceaccount.com" \
+        --role "projects/IAM_SA_PROJECT_ID/roles/Voxel51FiftyOneEnterpriseCustomRole"  # pragma: allowlist secret
+    ```
+
+1. Create an IAM allow policy that gives the FiftyOne Enterprise ServiceAccount
+   access to impersonate the IAM service account:
+
+    ```shell
+    gcloud iam service-accounts add-iam-policy-binding IAM_SA_NAME@IAM_SA_PROJECT_ID.iam.gserviceaccount.com \
+        --role roles/iam.workloadIdentityUser \
+        --member "serviceAccount:IAM_SA_PROJECT_ID.svc.id.goog[FIFTYONE_NAMESPACE/FIFTYONE_SERVICEACCOUNT_NAME]"
+    ```
+
+1. Add the Kubernetes ServiceAccount annotations via your `values.yaml` file
+   so that GKE sees the link between the service accounts:
+
+    ```yaml
+    serviceAccount:
+        annotations:
+            iam.gke.io/gcp-service-account: IAM_SA_NAME@IAM_SA_PROJECT_ID.iam.gserviceaccount.com
+    ```
+
+### Via `terraform`
+
+To configure workload identity via the `terraform`:
+
+1. Create a custom IAM role in GCP:
+
+    ```hcl
+    resource "google_project_iam_custom_role" "voxel51_custom_role" {
+        role_id     = "Voxel51FiftyOneEnterpriseCustomRole"
+        title       = "Voxel51 FiftyOne Enterpise Custom Role"
+        description = "Bare Minimum FiftyOne Enterprise Service Account Role."
+        project     = IAM_SA_PROJECT_ID
+        permissions = [
+            "iam.serviceAccounts.signBlob",
+            "storage.buckets.get",
+            "storage.buckets.list",
+            "storage.folders.create",
+            "storage.folders.get",
+            "storage.folders.list",
+            "storage.managedFolders.create",
+            "storage.managedFolders.get",
+            "storage.managedFolders.list",
+            "storage.multipartUploads.abort",
+            "storage.multipartUploads.create",
+            "storage.multipartUploads.listParts",
+            "storage.objects.create",
+            "storage.objects.get",
+            "storage.objects.list",
+        ]
+    }
+    ```
+
+1. Create a new GCP Service Account in your project
+
+    ```hcl
+    resource "google_service_account" "voxel51_service_account" {
+        account_id   = IAM_SA_NAME
+        project      = IAM_SA_PROJECT_ID
+    }
+    ```
+
+1. Grant your IAM service account access to the
+    `projects/IAM_SA_PROJECT_ID/roles/Voxel51FiftyOneEnterpriseCustomRole`
+    role:
+
+    ```hcl
+    resource "google_project_iam_member" "custom_role_member" {
+        project  = IAM_SA_PROJECT_ID
+        role     = google_project_iam_custom_role.voxel51_custom_role.id
+        member   = "serviceAccount:${google_service_account.voxel51_service_account.email}"
+    }
+    ```
+
+1. Create an IAM allow policy that gives the FiftyOne Enterprise ServiceAccount
+   access to impersonate the IAM service account:
+
+    ```hcl
+    resource "google_service_account_iam_member" "voxel51_sa_workload_identity" {
+        service_account_id = google_service_account.voxel51_service_account.name
+        role               = "roles/iam.workloadIdentityUser"
+        member             = "serviceAccount:${IAM_SA_PROJECT_ID}.svc.id.goog[${FIFTYONE_NAMESPACE}/${FIFTYONE_SERVICEACCOUNT_NAME}]"
+    }
+    ```
+
+1. Add the Kubernetes ServiceAccount annotations via your `values.yaml` file
+   so that GKE sees the link between the service accounts:
+
+    ```yaml
+    serviceAccount:
+        annotations:
+            iam.gke.io/gcp-service-account: IAM_SA_NAME@IAM_SA_PROJECT_ID.iam.gserviceaccount.com
+    ```
+
+## References
+
+* [How To: GKE Workload Identity Federation](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -80,9 +80,9 @@ for steps on how to upgrade your delegated operators.
   - [Static Banner Configuration](#static-banner-configuration)
   - [Terms of Service, Privacy, and Imprint URLs](#terms-of-service-privacy-and-imprint-urls)
   - [Text Similarity](#text-similarity)
+  - [Workload Identity Federation](#workload-identity-federation)
 - [Validating](#validating)
 - [Values](#values)
-  - [Deploying On GKE](#deploying-on-gke)
 
 <!-- tocstop -->
 
@@ -443,6 +443,18 @@ appSettings:
     repository: voxel51/fiftyone-app-torch
 ```
 
+### Workload Identity Federation
+
+Voxel51 FiftyOne Enterprise supports Workload Identity Federation
+when installing via Helm into various cloud providers.
+Workload Identity is achieved using service account annotations
+that can be defined in the `values.yaml` file when installing
+or upgrading the application.
+
+See
+[configuring workload identity federation](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/configure-workload-identity-federation.md)
+for more information.
+
 ## Validating
 
 After deploying FiftyOne Enterprise and configuring authentication, please
@@ -737,38 +749,12 @@ follow
 | teamsAppSettings.volumeMounts | list | `[]` | Volume mounts for `teams-app` pods. [Reference][volumes]. |
 | teamsAppSettings.volumes | list | `[]` | Volumes for `teams-app` pods. [Reference][volumes]. |
 
-### Deploying On GKE
-
-Voxel51 FiftyOne Enterprise supports
-[Workload Identity Federation for GKE][about-wif]
-when installing via Helm into Google Kubernetes Engine (GKE).
-Workload Identity is achieved using service account annotations
-that can be defined in the `values.yaml` file when installing
-or upgrading the application.
-
-Please follow the steps
-[outlined by Google][howto-wif]
-to allow your cluster to utilize workload identity federation and to
-create a service account with the required IAM permissions.
-
-Once the cluster and service account are configured, you can permit your
-workloads to utilize the GCP service account via service account annotations
-defined in the `values.yaml` file:
-
-```yaml
-serviceAccount:
-  annotations:
-    iam.gke.io/gcp-service-account: <GSA_NAME>@<GSA_PROJECT>.iam.gserviceaccount.com
-```
-
 <!-- Reference Links -->
-[about-wif]: https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity
 [affinity]: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
 [annotations]: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 [autoscaling]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
 [container-security-context]: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 [deployment]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
-[howto-wif]: https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
 [image-pull-policy]: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
 [image-pull-secrets]: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
 [ingress-default-ingress-class]: https://kubernetes.io/docs/concepts/services-networking/ingress/#default-ingress-class

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -80,9 +80,9 @@ for steps on how to upgrade your delegated operators.
   - [Static Banner Configuration](#static-banner-configuration)
   - [Terms of Service, Privacy, and Imprint URLs](#terms-of-service-privacy-and-imprint-urls)
   - [Text Similarity](#text-similarity)
+  - [Workload Identity Federation](#workload-identity-federation)
 - [Validating](#validating)
 - [Values](#values)
-  - [Deploying On GKE](#deploying-on-gke)
 
 <!-- tocstop -->
 
@@ -444,6 +444,18 @@ appSettings:
     repository: voxel51/fiftyone-app-torch
 ```
 
+### Workload Identity Federation
+
+Voxel51 FiftyOne Enterprise supports Workload Identity Federation
+when installing via Helm into various cloud providers.
+Workload Identity is achieved using service account annotations
+that can be defined in the `values.yaml` file when installing
+or upgrading the application.
+
+See
+[configuring workload identity federation](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/configure-workload-identity-federation.md)
+for more information.
+
 ## Validating
 
 After deploying FiftyOne Enterprise and configuring authentication, please
@@ -460,38 +472,12 @@ follow
 
 {{ template "chart.valuesTable" . }}
 
-### Deploying On GKE
-
-Voxel51 FiftyOne Enterprise supports
-[Workload Identity Federation for GKE][about-wif]
-when installing via Helm into Google Kubernetes Engine (GKE).
-Workload Identity is achieved using service account annotations
-that can be defined in the `values.yaml` file when installing
-or upgrading the application.
-
-Please follow the steps
-[outlined by Google][howto-wif]
-to allow your cluster to utilize workload identity federation and to
-create a service account with the required IAM permissions.
-
-Once the cluster and service account are configured, you can permit your
-workloads to utilize the GCP service account via service account annotations
-defined in the `values.yaml` file:
-
-```yaml
-serviceAccount:
-  annotations:
-    iam.gke.io/gcp-service-account: <GSA_NAME>@<GSA_PROJECT>.iam.gserviceaccount.com
-```
-
 <!-- Reference Links -->
-[about-wif]: https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity
 [affinity]: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
 [annotations]: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 [autoscaling]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
 [container-security-context]: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 [deployment]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
-[howto-wif]: https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
 [image-pull-policy]: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
 [image-pull-secrets]: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
 [ingress-default-ingress-class]: https://kubernetes.io/docs/concepts/services-networking/ingress/#default-ingress-class


### PR DESCRIPTION
# Rationale

We have been asked what our minimum permissions sets are and now we are in a place to test those. This PR goes through the minimum permission sets that we need to deploy successfully on GKE. It walks through:

1. Adding a service account in GCP
2. Making custom roles in GCP
3. Assigning those roles and memberships to the service account
4. Creating IAM bindings and annotations so GKE and GCP can authenticate

## Changes

Adds a new document, `configure-workload-identity-federation.md`. This document outlines the above permissions. It does so in both gcloud CLI and via terraform.

This also removes the `deploying on GKE` section from our main helm README.

This was only done for K8s as it doesn't exist in docker docs. 

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

<details><summary>Gcloud testing</summary>

I ran through the below script (with variables substituted:

```shell
cat <<EOF >custom-role.yml
title: "Voxel51 FiftyOne Enterpise Custom Role"
description: "Bare Minimum FiftyOne Enterprise Service Account Role."
stage: GA
includedPermissions:
    - iam.serviceAccounts.signBlob
    - storage.buckets.get
    - storage.buckets.list
    - storage.folders.create
    - storage.folders.get
    - storage.folders.list
    - storage.managedFolders.create
    - storage.managedFolders.get
    - storage.managedFolders.list
    - storage.multipartUploads.abort
    - storage.multipartUploads.create
    - storage.multipartUploads.listParts
    - storage.objects.create
    - storage.objects.get
    - storage.objects.list
EOF

gcloud iam roles create "Voxel51FiftyOneEnterpriseCustomRole" \
    --project=IAM_SA_PROJECT_ID \
    --file=custom-role.yml

gcloud iam service-accounts create IAM_SA_NAME \
    --project=IAM_SA_PROJECT_ID

gcloud projects add-iam-policy-binding IAM_SA_PROJECT_ID \
    --member "serviceAccount:IAM_SA_NAME@IAM_SA_PROJECT_ID.iam.gserviceaccount.com" \
    --role "projects/IAM_SA_PROJECT_ID/roles/Voxel51FiftyOneEnterpriseCustomRole"

gcloud iam service-accounts add-iam-policy-binding IAM_SA_NAME@IAM_SA_PROJECT_ID.iam.gserviceaccount.com \
    --role roles/iam.workloadIdentityUser \
    --member "serviceAccount:IAM_SA_PROJECT_ID.svc.id.goog[FIFTYONE_NAMESPACE/FIFTYONE_SERVICEACCOUNT_NAME]"
```

Then I went into our validate environment and made sure it worked.

Then I removed the above.
</details>

<details><summary>Terraform testing</summary>

I used the below TF:

```hcl
resource "google_project_iam_custom_role" "voxel51_custom_role" {
    role_id     = "Voxel51FiftyOneEnterpriseCustomRole"
    title       = "Voxel51 FiftyOne Enterpise Custom Role"
    description = "Bare Minimum FiftyOne Enterprise Service Account Role."
    project     = IAM_SA_PROJECT_ID
    permissions = [
        "iam.serviceAccounts.signBlob",
        "storage.buckets.get",
        "storage.buckets.list",
        "storage.folders.create",
        "storage.folders.get",
        "storage.folders.list",
        "storage.managedFolders.create",
        "storage.managedFolders.get",
        "storage.managedFolders.list",
        "storage.multipartUploads.abort",
        "storage.multipartUploads.create",
        "storage.multipartUploads.listParts",
        "storage.objects.create",
        "storage.objects.get",
        "storage.objects.list",
    ]
}

resource "google_service_account" "voxel51_service_account" {
    account_id   = IAM_SA_NAME
    project      = IAM_SA_PROJECT_ID
}

resource "google_project_iam_member" "custom_role_member" {
    project  = IAM_SA_PROJECT_ID
    role     = google_project_iam_custom_role.voxel51_custom_role.id
    member   = "serviceAccount:${google_service_account.voxel51_service_account.email}"
}

resource "google_service_account_iam_member" "voxel51_sa_workload_identity" {
    service_account_id = google_service_account.voxel51_service_account.name
    role               = "roles/iam.workloadIdentityUser"
    member             = "serviceAccount:${IAM_SA_PROJECT_ID}.svc.id.goog[${FIFTYONE_NAMESPACE}/${FIFTYONE_SERVICEACCOUNT_NAME}]"
}
```

Then I went into our validate environment and made sure it worked.

Then I removed the above.

</details>
<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
