### PR TITLE
docs: AS-597 Add alt-text to image headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
-<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-disable no-inline-html line-length -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
 
-<!-- prettier-ignore -->
-<img src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
-<img src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
-<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
+<img alt="Voxel51 Logo" src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img alt="Voxel51 FiftyOne" src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
+
+</p>
+</div>
+<!-- markdownlint-enable no-inline-html line-length -->
+
+---
 
 ## FiftyOne Enterprise Deployment Assets
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@
 
 ## FiftyOne Enterprise Deployment Assets
 
----
-
 | Directory | Purpose                                                                   |
 |-----------|---------------------------------------------------------------------------|
 | `docker`  | Contains configurations to run FiftyOne Enterprise in Docker Compose      |

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,14 +1,16 @@
-<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-disable no-inline-html line-length -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
 
-<img src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
-<img src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
+<img alt="Voxel51 Logo" src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img alt="Voxel51 FiftyOne" src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-enable no-inline-html line-length -->
+
+---
 
 # fiftyone-teams-app
 

--- a/docker/docs/configuring-delegated-operators.md
+++ b/docker/docs/configuring-delegated-operators.md
@@ -1,14 +1,14 @@
-<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-disable no-inline-html line-length -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
 
-<img src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
-<img src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
+<img alt="Voxel51 Logo" src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img alt="Voxel51 FiftyOne" src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-enable no-inline-html line-length -->
 
 ---
 

--- a/docker/docs/configuring-gpu-workloads.md
+++ b/docker/docs/configuring-gpu-workloads.md
@@ -1,14 +1,14 @@
-<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-disable no-inline-html line-length -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
 
-<img src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
-<img src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
+<img alt="Voxel51 Logo" src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img alt="Voxel51 FiftyOne" src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-enable no-inline-html line-length -->
 
 ---
 

--- a/docker/docs/configuring-plugins.md
+++ b/docker/docs/configuring-plugins.md
@@ -1,14 +1,14 @@
-<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-disable no-inline-html line-length -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
 
-<img src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
-<img src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
+<img alt="Voxel51 Logo" src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img alt="Voxel51 FiftyOne" src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-enable no-inline-html line-length -->
 
 ---
 

--- a/docker/docs/configuring-proxies.md
+++ b/docker/docs/configuring-proxies.md
@@ -1,14 +1,14 @@
-<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-disable no-inline-html line-length -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
 
-<img src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
-<img src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
+<img alt="Voxel51 Logo" src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img alt="Voxel51 FiftyOne" src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-enable no-inline-html line-length -->
 
 ---
 

--- a/docker/docs/configuring-snapshot-archival.md
+++ b/docker/docs/configuring-snapshot-archival.md
@@ -1,14 +1,14 @@
-<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-disable no-inline-html line-length -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
 
-<img src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
-<img src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
+<img alt="Voxel51 Logo" src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img alt="Voxel51 FiftyOne" src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-enable no-inline-html line-length -->
 
 ---
 

--- a/docker/docs/expose-teams-api.md
+++ b/docker/docs/expose-teams-api.md
@@ -1,14 +1,14 @@
-<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-disable no-inline-html line-length -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
 
-<img src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
-<img src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
+<img alt="Voxel51 Logo" src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img alt="Voxel51 FiftyOne" src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-enable no-inline-html line-length -->
 
 ---
 

--- a/docker/docs/known-issues.md
+++ b/docker/docs/known-issues.md
@@ -1,3 +1,17 @@
+<!-- markdownlint-disable no-inline-html line-length -->
+<!-- markdownlint-disable-next-line first-line-heading -->
+<div align="center">
+<p align="center">
+
+<img alt="Voxel51 Logo" src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img alt="Voxel51 FiftyOne" src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
+
+</p>
+</div>
+<!-- markdownlint-enable no-inline-html line-length -->
+
+---
+
 # Known Issues
 
 ## Known Issues for FiftyOne Enterprise v1.6.0 and Above

--- a/docker/docs/upgrading.md
+++ b/docker/docs/upgrading.md
@@ -1,3 +1,17 @@
+<!-- markdownlint-disable no-inline-html line-length -->
+<!-- markdownlint-disable-next-line first-line-heading -->
+<div align="center">
+<p align="center">
+
+<img alt="Voxel51 Logo" src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img alt="Voxel51 FiftyOne" src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
+
+</p>
+</div>
+<!-- markdownlint-enable no-inline-html line-length -->
+
+---
+
 # Upgrading FiftyOne Enterprise
 
 <!-- toc -->

--- a/docs/Release-v2.1.0-Database-Migration.md
+++ b/docs/Release-v2.1.0-Database-Migration.md
@@ -1,3 +1,17 @@
+<!-- markdownlint-disable no-inline-html line-length -->
+<!-- markdownlint-disable-next-line first-line-heading -->
+<div align="center">
+<p align="center">
+
+<img alt="Voxel51 Logo" src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img alt="Voxel51 FiftyOne" src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
+
+</p>
+</div>
+<!-- markdownlint-enable no-inline-html line-length -->
+
+---
+
 # FiftyOne Enterprise v2.1.0 SDK Upgrade and Database Migration
 
 ## What is happening?

--- a/docs/custom-mongodb-permissions.md
+++ b/docs/custom-mongodb-permissions.md
@@ -1,14 +1,14 @@
-<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-disable no-inline-html line-length -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
 
-<img src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
-<img src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
+<img alt="Voxel51 Logo" src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img alt="Voxel51 FiftyOne" src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-enable no-inline-html line-length -->
 
 ---
 

--- a/docs/custom-plugins.md
+++ b/docs/custom-plugins.md
@@ -1,14 +1,14 @@
-<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-disable no-inline-html line-length -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
 
-<img src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
-<img src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
+<img alt="Voxel51 Logo" src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img alt="Voxel51 FiftyOne" src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-enable no-inline-html line-length -->
 
 ---
 

--- a/docs/validating-deployment.md
+++ b/docs/validating-deployment.md
@@ -1,14 +1,14 @@
-<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-disable no-inline-html line-length -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
 
-<img src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
-<img src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
+<img alt="Voxel51 Logo" src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img alt="Voxel51 FiftyOne" src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-enable no-inline-html line-length -->
 
 # Validating Your Deployment
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,14 +1,14 @@
-<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-disable no-inline-html line-length -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
 
-<img src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
-<img src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
+<img alt="Voxel51 Logo" src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img alt="Voxel51 FiftyOne" src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-enable no-inline-html line-length -->
 
 <!-- toc -->
 

--- a/helm/docs/configure-ha-teams-api.md
+++ b/helm/docs/configure-ha-teams-api.md
@@ -1,14 +1,14 @@
-<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-disable no-inline-html line-length -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
 
-<img src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
-<img src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
+<img alt="Voxel51 Logo" src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img alt="Voxel51 FiftyOne" src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-enable no-inline-html line-length -->
 
 ---
 

--- a/helm/docs/configure-workload-identity-federation.md
+++ b/helm/docs/configure-workload-identity-federation.md
@@ -1,14 +1,14 @@
-<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-disable no-inline-html line-length -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
 
-<img src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
-<img src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
+<img alt="Voxel51 Logo" src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img alt="Voxel51 FiftyOne" src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-enable no-inline-html line-length -->
 
 ---
 

--- a/helm/docs/configuring-delegated-operators.md
+++ b/helm/docs/configuring-delegated-operators.md
@@ -1,14 +1,14 @@
-<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-disable no-inline-html line-length -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
 
-<img src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
-<img src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
+<img alt="Voxel51 Logo" src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img alt="Voxel51 FiftyOne" src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-enable no-inline-html line-length -->
 
 ---
 

--- a/helm/docs/configuring-gpu-workloads.md
+++ b/helm/docs/configuring-gpu-workloads.md
@@ -1,14 +1,14 @@
-<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-disable no-inline-html line-length -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
 
-<img src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
-<img src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
+<img alt="Voxel51 Logo" src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img alt="Voxel51 FiftyOne" src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-enable no-inline-html line-length -->
 
 ---
 

--- a/helm/docs/configuring-plugins.md
+++ b/helm/docs/configuring-plugins.md
@@ -1,14 +1,14 @@
-<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-disable no-inline-html line-length -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
 
-<img src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
-<img src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
+<img alt="Voxel51 Logo" src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img alt="Voxel51 FiftyOne" src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-enable no-inline-html line-length -->
 
 ---
 

--- a/helm/docs/configuring-proxies.md
+++ b/helm/docs/configuring-proxies.md
@@ -1,14 +1,14 @@
-<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-disable no-inline-html line-length -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
 
-<img src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
-<img src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
+<img alt="Voxel51 Logo" src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img alt="Voxel51 FiftyOne" src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-enable no-inline-html line-length -->
 
 ---
 

--- a/helm/docs/configuring-snapshot-archival.md
+++ b/helm/docs/configuring-snapshot-archival.md
@@ -1,14 +1,14 @@
-<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-disable no-inline-html line-length -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
 
-<img src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
-<img src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
+<img alt="Voxel51 Logo" src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img alt="Voxel51 FiftyOne" src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-enable no-inline-html line-length -->
 
 ---
 

--- a/helm/docs/expose-teams-api.md
+++ b/helm/docs/expose-teams-api.md
@@ -1,14 +1,14 @@
-<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-disable no-inline-html line-length -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
 
-<img src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
-<img src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
+<img alt="Voxel51 Logo" src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img alt="Voxel51 FiftyOne" src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-enable no-inline-html line-length -->
 
 ---
 

--- a/helm/docs/known-issues.md
+++ b/helm/docs/known-issues.md
@@ -1,3 +1,17 @@
+<!-- markdownlint-disable no-inline-html line-length -->
+<!-- markdownlint-disable-next-line first-line-heading -->
+<div align="center">
+<p align="center">
+
+<img alt="Voxel51 Logo" src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img alt="Voxel51 FiftyOne" src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
+
+</p>
+</div>
+<!-- markdownlint-enable no-inline-html line-length -->
+
+---
+
 # Known Issues
 
 ## Known Issues for FiftyOne Enterprise v1.6.0 and Above

--- a/helm/docs/plugins-storage.md
+++ b/helm/docs/plugins-storage.md
@@ -1,14 +1,14 @@
-<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-disable no-inline-html line-length -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
 
-<img src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
-<img src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
+<img alt="Voxel51 Logo" src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img alt="Voxel51 FiftyOne" src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-enable no-inline-html line-length -->
 
 ---
 

--- a/helm/docs/upgrading.md
+++ b/helm/docs/upgrading.md
@@ -1,3 +1,17 @@
+<!-- markdownlint-disable no-inline-html line-length -->
+<!-- markdownlint-disable-next-line first-line-heading -->
+<div align="center">
+<p align="center">
+
+<img alt="Voxel51 Logo" src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img alt="Voxel51 FiftyOne" src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
+
+</p>
+</div>
+<!-- markdownlint-enable no-inline-html line-length -->
+
+---
+
 # Upgrading FiftyOne Teams
 
 <!-- toc -->

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -1,14 +1,14 @@
-<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-disable no-inline-html line-length -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
 
-<img src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
-<img src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
+<img alt="Voxel51 Logo" src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img alt="Voxel51 FiftyOne" src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-enable no-inline-html line-length -->
 
 ---
 

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -1,14 +1,14 @@
-<!-- markdownlint-disable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-disable no-inline-html line-length -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 <div align="center">
 <p align="center">
 
-<img src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
-<img src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
+<img alt="Voxel51 Logo" src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img alt="Voxel51 FiftyOne" src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
 
 </p>
 </div>
-<!-- markdownlint-enable no-inline-html line-length no-alt-text -->
+<!-- markdownlint-enable no-inline-html line-length -->
 
 ---
 

--- a/helm/local-self-signed-example/README.md
+++ b/helm/local-self-signed-example/README.md
@@ -1,3 +1,17 @@
+<!-- markdownlint-disable no-inline-html line-length -->
+<!-- markdownlint-disable-next-line first-line-heading -->
+<div align="center">
+<p align="center">
+
+<img alt="Voxel51 Logo" src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img alt="Voxel51 FiftyOne" src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
+
+</p>
+</div>
+<!-- markdownlint-enable no-inline-html line-length -->
+
+---
+
 # Nginx Ingress with cert-manager self-singed TLS certificates
 
 The default behavior of Skaffold will install MongoDB and cert-manager.


### PR DESCRIPTION
# Rationale

We add logos to most pages, however, we were omitting alt-text from them. We can add the alt-text to follow best practices. Additionally, I came across a few pages that were missing he headers. Now seems like a good time to add them!

## Changes

* Removes the `markdownlint-disable alt-text` from headers
* Adds alt-text to each logo / FiftyOne word image
* Adds headers in documents that were missing headers

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

## Testing

Local previews of the markdown and previews on GitHub.

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
