### PR TITLE
chore: include instructions for `FIFTYONE_PLUGINS_CACHE_ENABLED` in h…

### DIFF
--- a/docker/docs/configuring-plugins.md
+++ b/docker/docs/configuring-plugins.md
@@ -21,56 +21,53 @@ Enabled by default. No additional configurations are required.
 ## Shared Plugins
 
 Plugins run in the `fiftyone-app` service.
-To enable this mode, use the file
+To enable this mode
+
+1. Use the file
 [legacy-auth/compose.plugins.yaml](../legacy-auth/compose.plugins.yaml)
 instead of
 [legacy-auth/compose.yaml](../legacy-auth/compose.yaml)
-to create a new Docker Volume shared between FiftyOne Enterprise
-services.
+as part of your `docker compose` command to create a new Docker Volume shared
+between FiftyOne Enterprise services.
 
-1. Configure the services to access to the plugin volume
+Example `docker compose` command for this mode from the `legacy-auth` directory
 
-- `fiftyone-app` requires `read`
-- `fiftyone-api` requires `read-write`
-
-1. Example `docker compose` command for this mode from the `legacy-auth`
-directory
-
-    ```shell
-    docker compose \
-      -f compose.plugins.yaml \
-      -f compose.override.yaml \
-      up -d
-    ```
+```shell
+docker compose \
+  -f compose.plugins.yaml \
+  -f compose.override.yaml \
+  up -d
+```
 
 ## Dedicated Plugins
 
 Plugins run in the `teams-plugins` service.
-To enable this mode, use the file
+To enable this mode
+
+1. make sure `FIFTYONE_TEAMS_PLUGIN_URL` is set in your `.env`
+file
+
+    - `FIFTYONE_TEAMS_PLUGIN_URL=http://teams-plugins:5151`
+
+1. Use the file
 [legacy-auth/compose.dedicated-plugins.yaml](../legacy-auth/compose.dedicated-plugins.yaml)
 instead of
 [legacy-auth/compose.yaml](../legacy-auth/compose.yaml).
-to create a new Docker Volume shared between FiftyOne Enterprise
-services.
-
-1. Configure the services to access to the plugin volume
-
-- `teams-plugins` requires `read`
-- `fiftyone-api` requires `read-write`
+as part of your `docker comppse` command to create a new Docker Volume shared
+between FiftyOne Enterprise services.
 
 1. If you are
   [using a proxy](./configuring-proxies.md),
   add the `teams-plugins` service name to your environment variables
 
-- `no_proxy`
-- `NO_PROXY`
+    - `no_proxy`
+    - `NO_PROXY`
 
-1. Example `docker compose` command for this mode from the `legacy-auth`
-  directory
+Example `docker compose` command for this mode from the `legacy-auth` directory
 
-    ```shell
-    docker compose \
-      -f compose.dedicated-plugins.yaml \
-      -f compose.override.yaml \
-      up --d
-    ```
+```shell
+docker compose \
+  -f compose.dedicated-plugins.yaml \
+  -f compose.override.yaml \
+  up -d
+```

--- a/helm/docs/configuring-plugins.md
+++ b/helm/docs/configuring-plugins.md
@@ -24,35 +24,38 @@ No additional configurations are required.
 Plugins run in the `fiftyone-app` deployment.
 To enable this mode
 
-- In `values.yaml`, set the path for a Persistent Volume Claim (PVC)
-  mounted to the `teams-api` and `fiftyone-app` deployments in both
-  - `appSettings.env.FIFTYONE_PLUGINS_DIR`
-  - `apiSettings.env.FIFTYONE_PLUGINS_DIR`
-- See
-  [Adding Shared Storage for FiftyOne Enterprise Plugins][plugins-storage]
-  - Mount a PVC that provides
+- [Add Shared Storage for FiftyOne Enterprise Plugins][plugins-storage]
+  - Mount a Persistent Volume Claim (PVC) that provides
     - `ReadWrite` permissions to the `teams-api` deployment
       at the `FIFTYONE_PLUGINS_DIR` path
     - `ReadOnly` permission to the `fiftyone-app` deployment
       at the `FIFTYONE_PLUGINS_DIR` path
+- In `values.yaml`, set the path for a PVC
+  mounted to the `teams-api` and `fiftyone-app` deployments, and enable
+  plugins caching
+  - `apiSettings.env.FIFTYONE_PLUGINS_CACHE_ENABLED: true`
+  - `apiSettings.env.FIFTYONE_PLUGINS_DIR: /path/to/pvc`
+  - `appSettings.env.FIFTYONE_PLUGINS_CACHE_ENABLED: true`
+  - `appSettings.env.FIFTYONE_PLUGINS_DIR: /path/to/pvc`
 
 ## Dedicated Plugins
 
 To enable this mode
 
-- In `values.yaml`, set
-  - `pluginsSettings.enabled: true`
-  - The path for a Persistent Volume Claim mounted to the
-    `teams-api` and `teams-plugins` deployments in both
-    - `pluginsSettings.env.FIFTYONE_PLUGINS_DIR`
-    - `apiSettings.env.FIFTYONE_PLUGINS_DIR`
-- See
-  [Adding Shared Storage for FiftyOne Enterprise Plugins][plugins-storage]
+- [Add Shared Storage for FiftyOne Enterprise Plugins][plugins-storage]
   - Mount a Persistent Volume Claim (PVC) that provides
     - `ReadWrite` permissions to the `teams-api` deployment
       at the `FIFTYONE_PLUGINS_DIR` path
     - `ReadOnly` permission to the `teams-plugins` deployment
       at the `FIFTYONE_PLUGINS_DIR` path
+- In `values.yaml`, set
+  - `pluginsSettings.enabled: true`
+  - the path for a PVC mounted to the `teams-api` and `teams-plugins`
+    deployments, and enable plugins caching
+    - `apiSettings.env.FIFTYONE_PLUGINS_CACHE_ENABLED: true`
+    - `apiSettings.env.FIFTYONE_PLUGINS_DIR: /path/to/pvc`
+    - `pluginsSettings.env.FIFTYONE_PLUGINS_CACHE_ENABLED: true`
+    - `pluginsSettings.env.FIFTYONE_PLUGINS_DIR: /path/to/pvc`
 - If you are
   [using a proxy](./configuring-proxies.md),
   add the `teams-plugins` service name to your `no_proxy` and


### PR DESCRIPTION
…elm deployments

# Rationale

- It's recently become very clear that setting `FIFTYONE_PLUGINS_CACHE_ENABLED` for plugins is pretty important.  We should document that.
    - This is handled by the docker compose files already, so there is no change to the docker documentation.

- It also turns out that some customers aren't seeing the instructions to set `FIFTYONE_TEAMS_PLUGIN_URL`
    - This is handled by the helm chart already, so there is no change to the helm documentation

## Changes

- reordered helm plugins instructions
    - create the PVC - then configure the PVC
- added `FIFTYONE_PLUGINS_CACHE_ENABLED` instructions to helm instructions
- added `FIFTYONE_TEAMS_PLUGIN_URL` reminder to docker instructions

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
