### PR TITLE
docs: replace references to docker-compose with "docker compose" or "…

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -18,7 +18,7 @@ FiftyOne Enterprise is the enterprise version of the open source
 [FiftyOne](https://github.com/voxel51/fiftyone)
 project.
 
-The FiftyOne Enterprise docker-compose files are the recommended way to
+The FiftyOne Enterprise Docker Compose files are the recommended way to
 install and configure FiftyOne Enterprise on Docker.
 
 This page assumes general knowledge of FiftyOne Enterprise and how to use it.
@@ -149,7 +149,7 @@ To deploy FiftyOne Enterprise:
     1. In the same directory, run
 
         ```shell
-        docker-compose up -d
+        docker compose up -d
         ```
 
 1. After the successful installation, and logging into FiftyOne Enterprise

--- a/docker/internal-auth/env.template
+++ b/docker/internal-auth/env.template
@@ -69,7 +69,7 @@ CAS_DATABASE_NAME=fiftyone-cas
 CAS_DEBUG="cas:*,-cas:*:debug"
 CAS_DEFAULT_USER_ROLE=GUEST
 
-# The following are Docker Composee links and will work in most situations
+# The following are Docker Compose links and will work in most situations
 FIFTYONE_TEAMS_PROXY_URL=http://fiftyone-app:5151
 # This only gets used with a dedicated teams-plugins service
 FIFTYONE_TEAMS_PLUGIN_URL=http://teams-plugins:5151

--- a/docker/internal-auth/env.template
+++ b/docker/internal-auth/env.template
@@ -41,7 +41,7 @@ LOCAL_LICENSE_FILE_DIR=/some/directory/with/licenses/
 API_BIND_ADDRESS=127.0.0.1
 API_BIND_PORT=8000
 API_LOGGING_LEVEL=INFO
-# The following is a docker-compose link and will work in most situations
+# The following is a Docker Compose link and will work in most situations
 API_URL=http://teams-api:8000
 FIFTYONE_ENV=production
 GRAPHQL_DEFAULT_LIMIT=10
@@ -69,7 +69,7 @@ CAS_DATABASE_NAME=fiftyone-cas
 CAS_DEBUG="cas:*,-cas:*:debug"
 CAS_DEFAULT_USER_ROLE=GUEST
 
-# The following are docker-compose links and will work in most situations
+# The following are Docker Composee links and will work in most situations
 FIFTYONE_TEAMS_PROXY_URL=http://fiftyone-app:5151
 # This only gets used with a dedicated teams-plugins service
 FIFTYONE_TEAMS_PLUGIN_URL=http://teams-plugins:5151

--- a/docker/legacy-auth/env.template
+++ b/docker/legacy-auth/env.template
@@ -44,7 +44,7 @@ LOCAL_LICENSE_FILE_DIR=/some/directory/with/licenses/
 API_BIND_ADDRESS=127.0.0.1
 API_BIND_PORT=8000
 API_LOGGING_LEVEL=INFO
-# The following is a docker-compose link and will work in most situations
+# The following is a Docker Compose link and will work in most situations
 API_URL=http://teams-api:8000
 FIFTYONE_ENV=production
 GRAPHQL_DEFAULT_LIMIT=10
@@ -74,7 +74,7 @@ CAS_DATABASE_NAME=fiftyone-cas
 CAS_DEBUG="cas:*,-cas:*:debug"
 CAS_DEFAULT_USER_ROLE=GUEST
 
-# The following are docker-compose links and will work in most situations
+# The following are Docker Compose links and will work in most situations
 FIFTYONE_TEAMS_PROXY_URL=http://fiftyone-app:5151
 # This only gets used with a dedicated teams-plugins service
 FIFTYONE_TEAMS_PLUGIN_URL=http://teams-plugins:5151

--- a/docs/validating-deployment.md
+++ b/docs/validating-deployment.md
@@ -26,8 +26,8 @@ attempt to validate the connection between your SDK and your deployment.
 
 The following validation method assumes you:
 
-1. Deployed FiftyOne Enterprise in either kubernetes or
-   docker-compose
+1. Deployed FiftyOne Enterprise in either Kubernetes or
+   Docker Compose
 1. Configured a DNS record(s) for your application
 1. Configured TLS termination for your application
 1. Configured

--- a/utils/bump-fixtures-docker.sh
+++ b/utils/bump-fixtures-docker.sh
@@ -13,7 +13,7 @@ DRY_RUN='false'
 print_usage() {
   local package
   package=$(basename "$0")
-  echo "$package - Bump versions in a docker-compose fixture."
+  echo "$package - Bump versions in a Docker Compose fixture."
   echo " "
   echo "$package [options]"
   echo " "

--- a/utils/bump-fixtures.sh
+++ b/utils/bump-fixtures.sh
@@ -13,7 +13,7 @@ GIT_ROOT=$(git rev-parse --show-toplevel)
 print_usage() {
   local package
   package=$(basename "$0")
-  echo "$package - Bump versions in docker-compose and helm fixtures."
+  echo "$package - Bump versions in Docker Compose and helm fixtures."
   echo " "
   echo "$package [options]"
   echo " "


### PR DESCRIPTION
…Docker Compose".

# Rationale

In https://voxel51.slack.com/archives/C074AE4THEF/p1743617303861109 we were informed of a customer having issues following our docs `docker-compose` instead of `docker compose`. Let's fix that so it doesn't happen again.

## Changes

1. Replace `docker-compose` with `docker compose`
2. Replace "docker-compose" with "Docker Compose"

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

n/a ^ this is a compose only change.

## Testing

n/a docs and comments only changes.

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
