### PR TITLE
chore(helm): AS-628 adding resources to init containers

### DIFF
--- a/helm/docs/upgrading.md
+++ b/helm/docs/upgrading.md
@@ -172,7 +172,7 @@ Additionally,
 Kubernetes [`initContainers`][init-containers]
 were added in Version 2.2.0 to enforce the order of pod startup.
 The image and tag are customizable.
-Any image supporting `nslookup`, such as `docker.io/busybox`, are applicable
+Any image supporting `wget`, such as `docker.io/busybox`, are applicable
 replacements.
 
 For a full list of settings, please refer to the

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -478,6 +478,7 @@ follow
 | apiSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for `teams-api`. [Reference][init-containers]. |
 | apiSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for `teams-api`. [Reference][init-containers]. |
 | apiSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for `teams-api`. [Reference][init-containers]. |
+| apiSettings.initContainers.resources | object | `{"limits":{},"requests":{}}` | Container resource requests and limits for the `teams-api` `initContainers`. [Reference][resources]. |
 | apiSettings.labels | object | `{}` | Additional labels for the `teams-api` deployment. [Reference][labels-and-selectors]. |
 | apiSettings.nodeSelector | object | `{}` | nodeSelector for `teams-api`. [Reference][node-selector]. |
 | apiSettings.podAnnotations | object | `{}` | Annotations for pods for `teams-api`. [Reference][annotations]. |
@@ -519,6 +520,7 @@ follow
 | appSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for `fiftyone-app`. [Reference][init-containers]. |
 | appSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for `fiftyone-app`. [Reference][init-containers]. |
 | appSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for `fiftyone-app`. [Reference][init-containers]. |
+| appSettings.initContainers.resources | object | `{"limits":{},"requests":{}}` | Container resource requests and limits for the `fiftyone-app` `initContainers`. [Reference][resources]. |
 | appSettings.labels | object | `{}` | Additional labels for the `fiftyone-app` deployment. [Reference][labels-and-selectors]. |
 | appSettings.nodeSelector | object | `{}` | nodeSelector for `fiftyone-app`. [Reference][node-selector]. |
 | appSettings.podAnnotations | object | `{}` | Annotations for pods for `fiftyone-app`. [Reference][annotations]. |
@@ -557,6 +559,7 @@ follow
 | casSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for `teams-cas`. [Reference][init-containers]. |
 | casSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for `teams-cas`. [Reference][init-containers]. |
 | casSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for `teams-cas`. [Reference][init-containers]. |
+| casSettings.initContainers.resources | object | `{"limits":{},"requests":{}}` | Container resource requests and limits for the `teams-cas` `initContainers`. [Reference][resources]. |
 | casSettings.labels | object | `{}` | Additional labels for the `teams-cas` deployment. [Reference][labels-and-selectors]. |
 | casSettings.nodeSelector | object | `{}` | nodeSelector for `teams-cas`. [Reference][node-selector]. |
 | casSettings.podAnnotations | object | `{}` | Annotations for pods for `teams-cas`. [Reference][annotations]. |
@@ -687,6 +690,7 @@ follow
 | pluginsSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for `teams-plugins`. [Reference][init-containers]. |
 | pluginsSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for `teams-plugins`. [Reference][init-containers]. |
 | pluginsSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for `teams-plugins`. [Reference][init-containers]. |
+| pluginsSettings.initContainers.resources | object | `{"limits":{},"requests":{}}` | Container resource requests and limits for the `teams-plugins` `initContainers`. [Reference][resources]. |
 | pluginsSettings.labels | object | `{}` | Additional labels for the `teams-plugins` deployment. [Reference][labels-and-selectors]. |
 | pluginsSettings.nodeSelector | object | `{}` | nodeSelector for `teams-plugins`. [Reference][node-selector]. |
 | pluginsSettings.podAnnotations | object | `{}` | Annotations for `teams-plugins` pods. [Reference][annotations]. |
@@ -744,6 +748,7 @@ follow
 | teamsAppSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for `teams-app`.  [Reference][init-containers]. |
 | teamsAppSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for `teams-app`.  [Reference][init-containers]. |
 | teamsAppSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for `teams-app`.  [Reference][init-containers]. |
+| teamsAppSettings.initContainers.resources | object | `{"limits":{},"requests":{}}` | Container resource requests and limits for the `teams-app` `initContainers`. [Reference][resources]. |
 | teamsAppSettings.labels | object | `{}` | Additional labels for the `teams-app` deployment. [Reference][labels-and-selectors]. |
 | teamsAppSettings.nodeSelector | object | `{}` | nodeSelector for `teams-app`.  [Reference][node-selector]. |
 | teamsAppSettings.podAnnotations | object | `{}` | Annotations for `teams-app` pods. [Reference][annotations]. |

--- a/helm/fiftyone-teams-app/templates/_helpers.tpl
+++ b/helm/fiftyone-teams-app/templates/_helpers.tpl
@@ -309,7 +309,7 @@ Common Init Containers
     - "until wget -qO /dev/null {{ $.casServiceName }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local/cas/api; do echo waiting for cas; sleep 2; done"
   {{- if hasKey $ "resources" }}
   resources:
-    {{- toYaml $.resources | nindent 2 }}
+    {{- toYaml $.resources | nindent 4 }}
   {{- end }}
 {{- end }}
 

--- a/helm/fiftyone-teams-app/templates/_helpers.tpl
+++ b/helm/fiftyone-teams-app/templates/_helpers.tpl
@@ -307,6 +307,10 @@ Common Init Containers
     - 'sh'
     - '-c'
     - "until wget -qO /dev/null {{ $.casServiceName }}.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local/cas/api; do echo waiting for cas; sleep 2; done"
+  {{- if hasKey $ "resources" }}
+  resources:
+    {{- toYaml $.resources | nindent 2 }}
+  {{- end }}
 {{- end }}
 
 {{/*

--- a/helm/fiftyone-teams-app/templates/api-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/api-deployment.yaml
@@ -79,8 +79,12 @@ spec:
       initContainers:
         {{-
           include "fiftyone-teams-app.commonInitContainers"
-          (dict "repository" .Values.apiSettings.initContainers.image.repository "tag" .Values.apiSettings.initContainers.image.tag "casServiceName" (include "teams-cas.name" .) )
-          | nindent 8
+          (
+            dict "repository" .Values.apiSettings.initContainers.image.repository
+            "tag" .Values.apiSettings.initContainers.image.tag
+            "casServiceName" (include "teams-cas.name" .)
+            "resources" .Values.apiSettings.initContainers.resources
+          ) | nindent 8
         }}
       {{- end }}
       {{- with .Values.apiSettings.nodeSelector }}

--- a/helm/fiftyone-teams-app/templates/app-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/app-deployment.yaml
@@ -71,8 +71,12 @@ spec:
       initContainers:
         {{-
           include "fiftyone-teams-app.commonInitContainers"
-          (dict "repository" .Values.appSettings.initContainers.image.repository "tag" .Values.appSettings.initContainers.image.tag "casServiceName" (include "teams-cas.name" .) )
-          | nindent 8
+          (
+            dict "repository" .Values.appSettings.initContainers.image.repository
+            "tag" .Values.appSettings.initContainers.image.tag
+            "casServiceName" (include "teams-cas.name" .)
+            "resources" .Values.appSettings.initContainers.resources
+          ) | nindent 8
         }}
       {{- end }}
       {{- with .Values.appSettings.nodeSelector }}

--- a/helm/fiftyone-teams-app/templates/plugins-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/plugins-deployment.yaml
@@ -72,8 +72,12 @@ spec:
       initContainers:
         {{-
           include "fiftyone-teams-app.commonInitContainers"
-          (dict "repository" .Values.pluginsSettings.initContainers.image.repository "tag" .Values.pluginsSettings.initContainers.image.tag "casServiceName" (include "teams-cas.name" .) )
-          | nindent 8
+          (
+            dict "repository" .Values.pluginsSettings.initContainers.image.repository
+            "tag" .Values.pluginsSettings.initContainers.image.tag
+            "casServiceName" (include "teams-cas.name" .)
+            "resources" .Values.pluginsSettings.initContainers.resources
+          ) | nindent 8
         }}
       {{- end }}
       {{- with .Values.pluginsSettings.nodeSelector }}

--- a/helm/fiftyone-teams-app/templates/teams-app-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/teams-app-deployment.yaml
@@ -74,8 +74,12 @@ spec:
       initContainers:
         {{-
           include "fiftyone-teams-app.commonInitContainers"
-          (dict "repository" .Values.teamsAppSettings.initContainers.image.repository "tag" .Values.teamsAppSettings.initContainers.image.tag "casServiceName" (include "teams-cas.name" .) )
-          | nindent 8
+          (
+            dict "repository" .Values.teamsAppSettings.initContainers.image.repository
+            "tag" .Values.teamsAppSettings.initContainers.image.tag
+            "casServiceName" (include "teams-cas.name" .)
+            "resources" .Values.teamsAppSettings.initContainers.resources
+          ) | nindent 8
         }}
       {{- end }}
       {{- with .Values.teamsAppSettings.nodeSelector }}

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -43,10 +43,10 @@ apiSettings:
   # -- Additional labels for the `teams-api` deployment. [Reference][labels-and-selectors].
   labels: {}
 
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # Instead of setting default resources, we require the user define them
+  # This enables running on resource constrained environments
+  # (like Minikube). To set resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces (`{}`) after 'resources:'.
   # -- Container resource requests and limits for `teams-api`. [Reference][resources].
   resources:
     limits: {}
@@ -88,10 +88,10 @@ apiSettings:
       repository: docker.io/busybox
       # -- Init container images tags for `teams-api`. [Reference][init-containers].
       tag: stable-glibc
-    # We usually recommend not to specify default resources and to leave this as a conscious
-    # choice for the user. This also increases chances charts run on environments with little
-    # resources, such as Minikube. If you do want to specify resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # Instead of setting default resources, we require the user define them
+    # This enables running on resource constrained environments
+    # (like Minikube). To set resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces (`{}`) after 'resources:'.
     # -- Container resource requests and limits for the `teams-api` `initContainers`. [Reference][resources].
     resources:
       limits: {}
@@ -188,10 +188,10 @@ appSettings:
   # Ignored when `appSettings.autoscaling.enabled: true`. [Reference][deployment].
   replicaCount: 2
 
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # Instead of setting default resources, we require the user define them
+  # This enables running on resource constrained environments
+  # (like Minikube). To set resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces (`{}`) after 'resources:'.
   # -- Container resource requests and limits for `fiftyone-app`. [Reference][resources].
   resources:
     limits: {}
@@ -233,10 +233,10 @@ appSettings:
       repository: docker.io/busybox
       # -- Init container images tags for `fiftyone-app`. [Reference][init-containers].
       tag: stable-glibc
-    # We usually recommend not to specify default resources and to leave this as a conscious
-    # choice for the user. This also increases chances charts run on environments with little
-    # resources, such as Minikube. If you do want to specify resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # Instead of setting default resources, we require the user define them
+    # This enables running on resource constrained environments
+    # (like Minikube). To set resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces (`{}`) after 'resources:'.
     # -- Container resource requests and limits for the `fiftyone-app` `initContainers`. [Reference][resources].
     resources:
       limits: {}
@@ -322,10 +322,10 @@ casSettings:
   # -- Number of pods in the `teams-cas` deployment's ReplicaSet. [Reference][deployment].
   replicaCount: 2
 
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # Instead of setting default resources, we require the user define them
+  # This enables running on resource constrained environments
+  # (like Minikube). To set resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces (`{}`) after 'resources:'.
   # -- Container resource requests and limits for `teams-cas`. [Reference][resources].
   resources:
     limits: {}
@@ -367,10 +367,10 @@ casSettings:
       repository: docker.io/busybox
       # -- Init container images tags for `teams-cas`. [Reference][init-containers].
       tag: stable-glibc
-    # We usually recommend not to specify default resources and to leave this as a conscious
-    # choice for the user. This also increases chances charts run on environments with little
-    # resources, such as Minikube. If you do want to specify resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # Instead of setting default resources, we require the user define them
+    # This enables running on resource constrained environments
+    # (like Minikube). To set resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces (`{}`) after 'resources:'.
     # -- Container resource requests and limits for the `teams-cas` `initContainers`. [Reference][resources].
     resources:
       limits: {}
@@ -461,10 +461,10 @@ delegatedOperatorExecutorSettings:
   #  max concurrent delegated operators, which defaults to 3.
   replicaCount: 3
 
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # Instead of setting default resources, we require the user define them
+  # This enables running on resource constrained environments
+  # (like Minikube). To set resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces (`{}`) after 'resources:'.
   # -- Container resource requests and limits for `delegated-operator-executor`. [Reference][resources].
   resources:
     limits: {}
@@ -579,10 +579,10 @@ delegatedOperatorDeployments:
     #  max concurrent delegated operators, which defaults to 3.
     replicaCount: 3
 
-    # We usually recommend not to specify default resources and to leave this as a conscious
-    # choice for the user. This also increases chances charts run on environments with little
-    # resources, such as Minikube. If you do want to specify resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # Instead of setting default resources, we require the user define them
+    # This enables running on resource constrained environments
+    # (like Minikube). To set resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces (`{}`) after 'resources:'.
     # -- Container resource requests and limits for `delegated-operator-executor`. [Reference][resources].
     resources:
       limits: {}
@@ -772,10 +772,10 @@ pluginsSettings:
   # Ignored when `pluginsSettings.autoscaling.enabled: true`. [Reference][deployment].
   replicaCount: 2
 
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # Instead of setting default resources, we require the user define them
+  # This enables running on resource constrained environments
+  # (like Minikube). To set resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces (`{}`) after 'resources:'.
   # -- Container resource requests and limits for `teams-plugins`. [Reference][resources].
   resources:
     limits: {}
@@ -817,10 +817,10 @@ pluginsSettings:
       repository: docker.io/busybox
       # -- Init container images tags for `teams-plugins`. [Reference][init-containers].
       tag: stable-glibc
-    # We usually recommend not to specify default resources and to leave this as a conscious
-    # choice for the user. This also increases chances charts run on environments with little
-    # resources, such as Minikube. If you do want to specify resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # Instead of setting default resources, we require the user define them
+    # This enables running on resource constrained environments
+    # (like Minikube). To set resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces (`{}`) after 'resources:'.
     # -- Container resource requests and limits for the `teams-plugins` `initContainers`. [Reference][resources].
     resources:
       limits: {}
@@ -967,10 +967,10 @@ teamsAppSettings:
   # Ignored when `teamsAppSettings.autoscaling.enabled: true`. [Reference][deployment].
   replicaCount: 2
 
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # Instead of setting default resources, we require the user define them
+  # This enables running on resource constrained environments
+  # (like Minikube). To set resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces (`{}`) after 'resources:'.
   # -- Container resource requests and limits for `teams-app`.  [Reference][resources].
   resources:
     limits: {}
@@ -1012,10 +1012,10 @@ teamsAppSettings:
       repository: docker.io/busybox
       # -- Init container images tags for `teams-app`.  [Reference][init-containers].
       tag: stable-glibc
-    # We usually recommend not to specify default resources and to leave this as a conscious
-    # choice for the user. This also increases chances charts run on environments with little
-    # resources, such as Minikube. If you do want to specify resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # Instead of setting default resources, we require the user define them
+    # This enables running on resource constrained environments
+    # (like Minikube). To set resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces (`{}`) after 'resources:'.
     # -- Container resource requests and limits for the `teams-app` `initContainers`. [Reference][resources].
     resources:
       limits: {}

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -88,6 +88,18 @@ apiSettings:
       repository: docker.io/busybox
       # -- Init container images tags for `teams-api`. [Reference][init-containers].
       tag: stable-glibc
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # -- Container resource requests and limits for the `teams-api` `initContainers`. [Reference][resources].
+    resources:
+      limits: {}
+      #   cpu: 2
+      #   memory: 6Gi
+      requests: {}
+      #   cpu: 500m
+      #   memory: 512Mi
   # -- nodeSelector for `teams-api`. [Reference][node-selector].
   nodeSelector: {}
   # -- Annotations for pods for `teams-api`. [Reference][annotations].
@@ -221,6 +233,18 @@ appSettings:
       repository: docker.io/busybox
       # -- Init container images tags for `fiftyone-app`. [Reference][init-containers].
       tag: stable-glibc
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # -- Container resource requests and limits for the `fiftyone-app` `initContainers`. [Reference][resources].
+    resources:
+      limits: {}
+      #   cpu: 2
+      #   memory: 6Gi
+      requests: {}
+      #   cpu: 500m
+      #   memory: 512Mi
   # -- nodeSelector for `fiftyone-app`. [Reference][node-selector].
   nodeSelector: {}
   # -- Annotations for pods for `fiftyone-app`. [Reference][annotations].
@@ -343,6 +367,18 @@ casSettings:
       repository: docker.io/busybox
       # -- Init container images tags for `teams-cas`. [Reference][init-containers].
       tag: stable-glibc
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # -- Container resource requests and limits for the `teams-cas` `initContainers`. [Reference][resources].
+    resources:
+      limits: {}
+      #   cpu: 2
+      #   memory: 6Gi
+      requests: {}
+      #   cpu: 500m
+      #   memory: 512Mi
   # -- nodeSelector for `teams-cas`. [Reference][node-selector].
   nodeSelector: {}
   # -- Annotations for pods for `teams-cas`. [Reference][annotations].
@@ -781,6 +817,18 @@ pluginsSettings:
       repository: docker.io/busybox
       # -- Init container images tags for `teams-plugins`. [Reference][init-containers].
       tag: stable-glibc
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # -- Container resource requests and limits for the `teams-plugins` `initContainers`. [Reference][resources].
+    resources:
+      limits: {}
+      #   cpu: 2
+      #   memory: 6Gi
+      requests: {}
+      #   cpu: 500m
+      #   memory: 512Mi
   # -- nodeSelector for `teams-plugins`. [Reference][node-selector].
   nodeSelector: {}
   # -- Annotations for `teams-plugins` pods. [Reference][annotations].
@@ -964,6 +1012,18 @@ teamsAppSettings:
       repository: docker.io/busybox
       # -- Init container images tags for `teams-app`.  [Reference][init-containers].
       tag: stable-glibc
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # -- Container resource requests and limits for the `teams-app` `initContainers`. [Reference][resources].
+    resources:
+      limits: {}
+      #   cpu: 2
+      #   memory: 6Gi
+      requests: {}
+      #   cpu: 500m
+      #   memory: 512Mi
   # -- nodeSelector for `teams-app`.  [Reference][node-selector].
   nodeSelector: {}
   # -- Annotations for `teams-app` pods. [Reference][annotations].

--- a/tests/unit/helm/api-deployment_test.go
+++ b/tests/unit/helm/api-deployment_test.go
@@ -1585,6 +1585,64 @@ func (s *deploymentApiTemplateTest) TestInitContainerCommand() {
 	}
 }
 
+func (s *deploymentApiTemplateTest) TestInitContainerResourceRequirements() {
+	testCases := []struct {
+		name     string
+		values   map[string]string
+		expected func(resourceRequirements corev1.ResourceRequirements)
+	}{
+		{
+			"defaultValues",
+			nil,
+			func(resourceRequirements corev1.ResourceRequirements) {
+				s.Equal(resourceRequirements.Limits, corev1.ResourceList{}, "Limits should be equal")
+				s.Equal(resourceRequirements.Requests, corev1.ResourceList{}, "Requests should be equal")
+				s.Nil(resourceRequirements.Claims, "should be nil")
+			},
+		},
+		{
+			"overrideResources",
+			map[string]string{
+				"apiSettings.initContainers.resources.limits.cpu":      "1",
+				"apiSettings.initContainers.resources.limits.memory":   "1Gi",
+				"apiSettings.initContainers.resources.requests.cpu":    "500m",
+				"apiSettings.initContainers.resources.requests.memory": "512Mi",
+			},
+			func(resourceRequirements corev1.ResourceRequirements) {
+				resourceExpected := corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"cpu":    resource.MustParse("1"),
+						"memory": resource.MustParse("1Gi"),
+					},
+					Requests: corev1.ResourceList{
+						"cpu":    resource.MustParse("500m"),
+						"memory": resource.MustParse("512Mi"),
+					},
+				}
+				s.Equal(resourceExpected, resourceRequirements, "should be equal")
+				s.Nil(resourceRequirements.Claims, "should be nil")
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		s.Run(testCase.name, func() {
+			subT := s.T()
+			subT.Parallel()
+
+			options := &helm.Options{SetValues: testCase.values}
+			output := helm.RenderTemplate(subT, options, s.chartPath, s.releaseName, s.templates)
+
+			var deployment appsv1.Deployment
+			helm.UnmarshalK8SYaml(subT, output, &deployment)
+
+			testCase.expected(deployment.Spec.Template.Spec.InitContainers[0].Resources)
+		})
+	}
+}
+
 func (s *deploymentApiTemplateTest) TestAffinity() {
 	testCases := []struct {
 		name     string

--- a/tests/unit/helm/plugins-deployment_test.go
+++ b/tests/unit/helm/plugins-deployment_test.go
@@ -1890,6 +1890,67 @@ func (s *deploymentPluginsTemplateTest) TestInitContainerCommand() {
 	}
 }
 
+func (s *deploymentPluginsTemplateTest) TestInitContainerResourceRequirements() {
+	testCases := []struct {
+		name     string
+		values   map[string]string
+		expected func(resourceRequirements corev1.ResourceRequirements)
+	}{
+		{
+			"defaultValues",
+			map[string]string{
+				"pluginsSettings.enabled": "true",
+			},
+			func(resourceRequirements corev1.ResourceRequirements) {
+				s.Equal(resourceRequirements.Limits, corev1.ResourceList{}, "Limits should be equal")
+				s.Equal(resourceRequirements.Requests, corev1.ResourceList{}, "Requests should be equal")
+				s.Nil(resourceRequirements.Claims, "should be nil")
+			},
+		},
+		{
+			"overrideResources",
+			map[string]string{
+				"pluginsSettings.enabled":                                  "true",
+				"pluginsSettings.initContainers.resources.limits.cpu":      "1",
+				"pluginsSettings.initContainers.resources.limits.memory":   "1Gi",
+				"pluginsSettings.initContainers.resources.requests.cpu":    "500m",
+				"pluginsSettings.initContainers.resources.requests.memory": "512Mi",
+			},
+			func(resourceRequirements corev1.ResourceRequirements) {
+				resourceExpected := corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"cpu":    resource.MustParse("1"),
+						"memory": resource.MustParse("1Gi"),
+					},
+					Requests: corev1.ResourceList{
+						"cpu":    resource.MustParse("500m"),
+						"memory": resource.MustParse("512Mi"),
+					},
+				}
+				s.Equal(resourceExpected, resourceRequirements, "should be equal")
+				s.Nil(resourceRequirements.Claims, "should be nil")
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		s.Run(testCase.name, func() {
+			subT := s.T()
+			subT.Parallel()
+
+			options := &helm.Options{SetValues: testCase.values}
+			output := helm.RenderTemplate(subT, options, s.chartPath, s.releaseName, s.templates)
+
+			var deployment appsv1.Deployment
+			helm.UnmarshalK8SYaml(subT, output, &deployment)
+
+			testCase.expected(deployment.Spec.Template.Spec.InitContainers[0].Resources)
+		})
+	}
+}
+
 func (s *deploymentPluginsTemplateTest) TestAffinity() {
 	testCases := []struct {
 		name     string

--- a/tests/unit/helm/teams-app-deployment_test.go
+++ b/tests/unit/helm/teams-app-deployment_test.go
@@ -1734,6 +1734,64 @@ func (s *deploymentTeamsAppTemplateTest) TestInitContainerCommand() {
 	}
 }
 
+func (s *deploymentTeamsAppTemplateTest) TestInitContainerResourceRequirements() {
+	testCases := []struct {
+		name     string
+		values   map[string]string
+		expected func(resourceRequirements corev1.ResourceRequirements)
+	}{
+		{
+			"defaultValues",
+			nil,
+			func(resourceRequirements corev1.ResourceRequirements) {
+				s.Equal(resourceRequirements.Limits, corev1.ResourceList{}, "Limits should be equal")
+				s.Equal(resourceRequirements.Requests, corev1.ResourceList{}, "Requests should be equal")
+				s.Nil(resourceRequirements.Claims, "should be nil")
+			},
+		},
+		{
+			"overrideResources",
+			map[string]string{
+				"teamsAppSettings.initContainers.resources.limits.cpu":      "1",
+				"teamsAppSettings.initContainers.resources.limits.memory":   "1Gi",
+				"teamsAppSettings.initContainers.resources.requests.cpu":    "500m",
+				"teamsAppSettings.initContainers.resources.requests.memory": "512Mi",
+			},
+			func(resourceRequirements corev1.ResourceRequirements) {
+				resourceExpected := corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"cpu":    resource.MustParse("1"),
+						"memory": resource.MustParse("1Gi"),
+					},
+					Requests: corev1.ResourceList{
+						"cpu":    resource.MustParse("500m"),
+						"memory": resource.MustParse("512Mi"),
+					},
+				}
+				s.Equal(resourceExpected, resourceRequirements, "should be equal")
+				s.Nil(resourceRequirements.Claims, "should be nil")
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		s.Run(testCase.name, func() {
+			subT := s.T()
+			subT.Parallel()
+
+			options := &helm.Options{SetValues: testCase.values}
+			output := helm.RenderTemplate(subT, options, s.chartPath, s.releaseName, s.templates)
+
+			var deployment appsv1.Deployment
+			helm.UnmarshalK8SYaml(subT, output, &deployment)
+
+			testCase.expected(deployment.Spec.Template.Spec.InitContainers[0].Resources)
+		})
+	}
+}
+
 func (s *deploymentTeamsAppTemplateTest) TestAffinity() {
 	testCases := []struct {
 		name     string


### PR DESCRIPTION
# Rationale

When evicting nodes, kubernetes considers the pods [quality of service](https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/).

QoS has three classes:

* [Guaranteed](https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/#guaranteed)
* [Burstable](https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/#burstable)
* [BestEffort](https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/#besteffort)

These classes are derived from the resource constraints on each container in the pod, including init and ephemeral containers. We should give customers the ability to define these QoS classes by making sure every container has resource settings available to them from the `values.yaml`.

## Changes

1. Updates `_helpers.tpl` to allow for resource constraints:
    ```yaml
      {{- if hasKey $ "resources" }}
      resources:
        {{- toYaml $.resources | nindent 4 }}
      {{- end }}
    ```
1. Adds the values to the `values.yaml`
1. Updates unit tests accordingly
 
Checklist

* [x] This PR maintains parity between Docker Compose and Helm

## Testing

Go tests and helm templating.

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
