### PR TITLE
chore(helm): AS-631 add automount token for service accounts

### DIFF
--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -724,6 +724,7 @@ follow
 | secret.labels | object | `{}` | Additional labels for the generated secret. [Reference][labels-and-selectors]. |
 | secret.name | string | `"fiftyone-teams-secrets"` | Name of the secret (existing or to be created) in the namespace `namespace.name`. |
 | serviceAccount.annotations | object | `{}` | Service Account annotations. [Reference][annotations]. |
+| serviceAccount.automount | bool | `true` | Whether to automount the service account's API credentials. |
 | serviceAccount.create | bool | `true` | Controls whether to create the service account named `serviceAccount.name`. |
 | serviceAccount.labels | object | `{}` | Additional labels for the generated service account. [Reference][labels-and-selectors]. |
 | serviceAccount.name | string | `"fiftyone-teams"` | Name of the service account (existing or to be created) in the namespace `namespace.name` used for deployments. [Reference][service-account]. |

--- a/helm/fiftyone-teams-app/templates/serviceaccount.yaml
+++ b/helm/fiftyone-teams-app/templates/serviceaccount.yaml
@@ -10,4 +10,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
 {{- end }}

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -886,6 +886,8 @@ secret:
 serviceAccount:
   # -- Service Account annotations. [Reference][annotations].
   annotations: {}
+  # -- Whether to automount the service account's API credentials.
+  automount: true
   # -- Controls whether to create the service account named `serviceAccount.name`.
   create: true
   # -- Name of the service account (existing or to be created) in the namespace `namespace.name` used for deployments.


### PR DESCRIPTION
# Rationale

We currently don't allow users to [opt out of API credentials](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting). We should add that as a configuration setting since nothing FOE does requires K8s API access.

To comply with current K8s deployments and K8s standards, this should default to true with an explicit "opt out" type of workflow.

## Changes

* Adds `automountServiceAccountToken` setting to the helm service account
* Adds tests to validate the configuration of `automountServiceAccountToken`

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

Go tests and `helm template`:

```yaml
$ helm template .
.
.
# Source: fiftyone-teams-app/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: fiftyone-teams
  namespace: fiftyone-teams
  labels:
    helm.sh/chart: fiftyone-teams-app-2.8.0
    app.kubernetes.io/version: "v2.8.0"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: fiftyone-teams
    app.kubernetes.io/instance: release-name
automountServiceAccountToken: true
```

```yaml
$ helm template . --set serviceAccount.automount=false
.
.
# Source: fiftyone-teams-app/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: fiftyone-teams
  namespace: fiftyone-teams
  labels:
    helm.sh/chart: fiftyone-teams-app-2.8.0
    app.kubernetes.io/version: "v2.8.0"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: fiftyone-teams
    app.kubernetes.io/instance: release-name
automountServiceAccountToken: false
```

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
