### PR TITLE
chore(helm): AS-637 security context for init containers

### DIFF
--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -475,6 +475,7 @@ follow
 | apiSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy]. |
 | apiSettings.image.repository | string | `"voxel51/fiftyone-teams-api"` | Container image for the `teams-api`. |
 | apiSettings.image.tag | string | `""` | Image tag for `teams-api`. Defaults to the chart version. |
+| apiSettings.initContainers.containerSecurityContext | object | `{}` | Container security configuration for `teams-api` `initContainers`. [Reference][container-security-context]. |
 | apiSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for `teams-api`. [Reference][init-containers]. |
 | apiSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for `teams-api`. [Reference][init-containers]. |
 | apiSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for `teams-api`. [Reference][init-containers]. |
@@ -518,6 +519,7 @@ follow
 | appSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy]. |
 | appSettings.image.repository | string | `"voxel51/fiftyone-app"` | Container image for `fiftyone-app`. |
 | appSettings.image.tag | string | `""` | Image tag for `fiftyone-app`. Defaults to the chart version. |
+| appSettings.initContainers.containerSecurityContext | object | `{}` | Container security configuration for `fiftyone-app` `initContainers`. [Reference][container-security-context]. |
 | appSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for `fiftyone-app`. [Reference][init-containers]. |
 | appSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for `fiftyone-app`. [Reference][init-containers]. |
 | appSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for `fiftyone-app`. [Reference][init-containers]. |
@@ -557,6 +559,7 @@ follow
 | casSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy]. |
 | casSettings.image.repository | string | `"voxel51/fiftyone-teams-cas"` | Container image for `teams-cas`. |
 | casSettings.image.tag | string | `""` | Image tag for `teams-cas`. Defaults to the chart version. |
+| casSettings.initContainers.containerSecurityContext | object | `{}` | Container security configuration for `teams-cas` `initContainers`. [Reference][container-security-context]. |
 | casSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for `teams-cas`. [Reference][init-containers]. |
 | casSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for `teams-cas`. [Reference][init-containers]. |
 | casSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for `teams-cas`. [Reference][init-containers]. |
@@ -688,6 +691,7 @@ follow
 | pluginsSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy]. |
 | pluginsSettings.image.repository | string | `"voxel51/fiftyone-app"` | Container image for `teams-plugins`. |
 | pluginsSettings.image.tag | string | `""` | Image tag for `teams-plugins`. Defaults to the chart version. |
+| pluginsSettings.initContainers.containerSecurityContext | object | `{}` | Container security configuration for `teams-plugins` `initContainers`. [Reference][container-security-context]. |
 | pluginsSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for `teams-plugins`. [Reference][init-containers]. |
 | pluginsSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for `teams-plugins`. [Reference][init-containers]. |
 | pluginsSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for `teams-plugins`. [Reference][init-containers]. |
@@ -749,6 +753,7 @@ follow
 | teamsAppSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. Reference][image-pull-policy]. |
 | teamsAppSettings.image.repository | string | `"voxel51/fiftyone-teams-app"` | Container image for `teams-app`. |
 | teamsAppSettings.image.tag | string | `""` | Image tag for `teams-app`.  Defaults to the chart version. |
+| teamsAppSettings.initContainers.containerSecurityContext | object | `{}` | Container security configuration for `teams-app` `initContainers`. [Reference][container-security-context]. |
 | teamsAppSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for `teams-app`.  [Reference][init-containers]. |
 | teamsAppSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for `teams-app`.  [Reference][init-containers]. |
 | teamsAppSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for `teams-app`.  [Reference][init-containers]. |

--- a/helm/fiftyone-teams-app/templates/_helpers.tpl
+++ b/helm/fiftyone-teams-app/templates/_helpers.tpl
@@ -326,6 +326,10 @@ Common Init Containers
   resources:
     {{- toYaml $.resources | nindent 4 }}
   {{- end }}
+  {{- if hasKey $ "containerSecurityContext" }}
+  securityContext:
+    {{- toYaml $.containerSecurityContext | nindent 4 }}
+  {{- end }}
 {{- end }}
 
 {{/*

--- a/helm/fiftyone-teams-app/templates/api-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/api-deployment.yaml
@@ -80,10 +80,11 @@ spec:
         {{-
           include "fiftyone-teams-app.commonInitContainers"
           (
-            dict "repository" .Values.apiSettings.initContainers.image.repository
-            "tag" .Values.apiSettings.initContainers.image.tag
-            "casServiceName" (include "teams-cas.name" .)
+            dict "casServiceName" (include "teams-cas.name" .)
+            "containerSecurityContext" .Values.apiSettings.initContainers.containerSecurityContext
+            "repository" .Values.apiSettings.initContainers.image.repository
             "resources" .Values.apiSettings.initContainers.resources
+            "tag" .Values.apiSettings.initContainers.image.tag
           ) | nindent 8
         }}
       {{- end }}

--- a/helm/fiftyone-teams-app/templates/app-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/app-deployment.yaml
@@ -72,10 +72,11 @@ spec:
         {{-
           include "fiftyone-teams-app.commonInitContainers"
           (
-            dict "repository" .Values.appSettings.initContainers.image.repository
-            "tag" .Values.appSettings.initContainers.image.tag
-            "casServiceName" (include "teams-cas.name" .)
+            dict "casServiceName" (include "teams-cas.name" .)
+            "containerSecurityContext" .Values.appSettings.initContainers.containerSecurityContext
+            "repository" .Values.appSettings.initContainers.image.repository
             "resources" .Values.appSettings.initContainers.resources
+            "tag" .Values.appSettings.initContainers.image.tag
           ) | nindent 8
         }}
       {{- end }}

--- a/helm/fiftyone-teams-app/templates/plugins-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/plugins-deployment.yaml
@@ -73,10 +73,11 @@ spec:
         {{-
           include "fiftyone-teams-app.commonInitContainers"
           (
-            dict "repository" .Values.pluginsSettings.initContainers.image.repository
-            "tag" .Values.pluginsSettings.initContainers.image.tag
-            "casServiceName" (include "teams-cas.name" .)
+            dict "casServiceName" (include "teams-cas.name" .)
+            "containerSecurityContext" .Values.pluginsSettings.initContainers.containerSecurityContext
+            "repository" .Values.pluginsSettings.initContainers.image.repository
             "resources" .Values.pluginsSettings.initContainers.resources
+            "tag" .Values.pluginsSettings.initContainers.image.tag
           ) | nindent 8
         }}
       {{- end }}

--- a/helm/fiftyone-teams-app/templates/teams-app-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/teams-app-deployment.yaml
@@ -75,10 +75,11 @@ spec:
         {{-
           include "fiftyone-teams-app.commonInitContainers"
           (
-            dict "repository" .Values.teamsAppSettings.initContainers.image.repository
-            "tag" .Values.teamsAppSettings.initContainers.image.tag
-            "casServiceName" (include "teams-cas.name" .)
+            dict "casServiceName" (include "teams-cas.name" .)
+            "containerSecurityContext" .Values.teamsAppSettings.initContainers.containerSecurityContext
+            "repository" .Values.teamsAppSettings.initContainers.image.repository
             "resources" .Values.teamsAppSettings.initContainers.resources
+            "tag" .Values.teamsAppSettings.initContainers.image.tag
           ) | nindent 8
         }}
       {{- end }}

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -86,6 +86,8 @@ apiSettings:
   # -- Affinity and anti-affinity for `teams-api`. [Reference][affinity].
   affinity: {}
   initContainers:
+    # -- Container security configuration for `teams-api` `initContainers`. [Reference][container-security-context].
+    containerSecurityContext: {}
     # -- Whether to enable init containers for `teams-api`. [Reference][init-containers].
     enabled: true
     image:
@@ -121,7 +123,7 @@ apiSettings:
     # maxUnavailable: ""
   # -- Pod-level security attributes and common container settings for `teams-api`. [Reference][security-context].
   podSecurityContext: {}
-  # TODO: Kevin/topher - Consider renaming `securityContext` to `containerSecurityContext``
+  # TODO: Kevin/topher - Consider renaming `securityContext` to `containerSecurityContext`
   # -- Container security configuration for `teams-api`. [Reference][container-security-context].
   securityContext: {}
   # -- Allow the k8s scheduler to schedule pods with matching taints for `teams-api`. [Reference][taints-and-tolerations].
@@ -231,6 +233,8 @@ appSettings:
   # -- Affinity and anti-affinity for `fiftyone-app`. [Reference][affinity].
   affinity: {}
   initContainers:
+    # -- Container security configuration for `fiftyone-app` `initContainers`. [Reference][container-security-context].
+    containerSecurityContext: {}
     # -- Whether to enable init containers for `fiftyone-app`. [Reference][init-containers].
     enabled: true
     image:
@@ -266,7 +270,7 @@ appSettings:
     # maxUnavailable: ""
   # -- Pod-level security attributes and common container settings for `fiftyone-app`. [Reference][security-context].
   podSecurityContext: {}
-  # TODO: Kevin/topher - Consider renaming `securityContext` to `containerSecurityContext
+  # TODO: Kevin/topher - Consider renaming `securityContext` to `containerSecurityContext`
   # -- Container security configuration for `fiftyone-app`. [Reference][container-security-context].
   securityContext: {}
   # -- Allow the k8s scheduler to schedule `fiftyone-app` pods with matching taints. [Reference][taints-and-tolerations].
@@ -365,6 +369,8 @@ casSettings:
   # -- Affinity and anti-affinity for `teams-cas`. [Reference][affinity].
   affinity: {}
   initContainers:
+    # -- Container security configuration for `teams-cas` `initContainers`. [Reference][container-security-context].
+    containerSecurityContext: {}
     # -- Whether to enable init containers for `teams-cas`. [Reference][init-containers].
     enabled: true
     image:
@@ -400,7 +406,7 @@ casSettings:
     # maxUnavailable: ""
   # -- Pod-level security attributes and common container settings for `teams-cas`. [Reference][security-context].
   podSecurityContext: {}
-  # TODO: Kevin/topher - Consider renaming `securityContext` to `containerSecurityContext
+  # TODO: Kevin/topher - Consider renaming `securityContext` to `containerSecurityContext`
   # -- Container security configuration for `teams-cas`. [Reference][container-security-context].
   securityContext: {}
   # -- Allow the k8s scheduler to schedule `teams-cas` pods with matching taints. [Reference][taints-and-tolerations].
@@ -815,6 +821,8 @@ pluginsSettings:
   # -- Affinity and anti-affinity for `teams-plugins`. [Reference][affinity].
   affinity: {}
   initContainers:
+    # -- Container security configuration for `teams-plugins` `initContainers`. [Reference][container-security-context].
+    containerSecurityContext: {}
     # -- Whether to enable init containers for `teams-plugins`. [Reference][init-containers].
     enabled: true
     image:
@@ -1016,6 +1024,8 @@ teamsAppSettings:
   # -- Affinity and anti-affinity for `teams-app`.  [Reference][affinity].
   affinity: {}
   initContainers:
+    # -- Container security configuration for `teams-app` `initContainers`. [Reference][container-security-context].
+    containerSecurityContext: {}
     # -- Whether to enable init containers for `teams-app`.  [Reference][init-containers].
     enabled: true
     image:

--- a/tests/unit/helm/app-deployment_test.go
+++ b/tests/unit/helm/app-deployment_test.go
@@ -1602,6 +1602,60 @@ func (s *deploymentAppTemplateTest) TestInitContainerResourceRequirements() {
 	}
 }
 
+func (s *deploymentAppTemplateTest) TestInitContainerSecurityContext() {
+	testCases := []struct {
+		name     string
+		values   map[string]string
+		expected func(securityContext *corev1.SecurityContext)
+	}{
+		{
+			"defaultValues",
+			nil,
+			func(securityContext *corev1.SecurityContext) {
+				s.Nil(securityContext.AllowPrivilegeEscalation, "should be nil")
+				s.Nil(securityContext.Capabilities, "should be nil")
+				s.Nil(securityContext.Privileged, "should be nil")
+				s.Nil(securityContext.ProcMount, "should be nil")
+				s.Nil(securityContext.ReadOnlyRootFilesystem, "should be nil")
+				s.Nil(securityContext.RunAsGroup, "should be nil")
+				s.Nil(securityContext.RunAsNonRoot, "should be nil")
+				s.Nil(securityContext.RunAsUser, "should be nil")
+				s.Nil(securityContext.SeccompProfile, "should be nil")
+				s.Nil(securityContext.SELinuxOptions, "should be nil")
+				s.Nil(securityContext.WindowsOptions, "should be nil")
+			},
+		},
+		{
+			"overrideSecurityContext",
+			map[string]string{
+				"appSettings.initContainers.containerSecurityContext.runAsGroup": "3000",
+				"appSettings.initContainers.containerSecurityContext.runAsUser":  "1000",
+			},
+			func(securityContext *corev1.SecurityContext) {
+				s.Equal(int64(3000), *securityContext.RunAsGroup, "runAsGroup should be 3000")
+				s.Equal(int64(1000), *securityContext.RunAsUser, "runAsUser should be 1000")
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		s.Run(testCase.name, func() {
+			subT := s.T()
+			subT.Parallel()
+
+			options := &helm.Options{SetValues: testCase.values}
+			output := helm.RenderTemplate(subT, options, s.chartPath, s.releaseName, s.templates)
+
+			var deployment appsv1.Deployment
+			helm.UnmarshalK8SYaml(subT, output, &deployment)
+
+			testCase.expected(deployment.Spec.Template.Spec.InitContainers[0].SecurityContext)
+		})
+	}
+}
+
 func (s *deploymentAppTemplateTest) TestAffinity() {
 	testCases := []struct {
 		name     string

--- a/tests/unit/helm/plugins-deployment_test.go
+++ b/tests/unit/helm/plugins-deployment_test.go
@@ -1951,6 +1951,63 @@ func (s *deploymentPluginsTemplateTest) TestInitContainerResourceRequirements() 
 	}
 }
 
+func (s *deploymentPluginsTemplateTest) TestInitContainerSecurityContext() {
+	testCases := []struct {
+		name     string
+		values   map[string]string
+		expected func(securityContext *corev1.SecurityContext)
+	}{
+		{
+			"defaultValues",
+			map[string]string{
+				"pluginsSettings.enabled": "true",
+			},
+			func(securityContext *corev1.SecurityContext) {
+				s.Nil(securityContext.AllowPrivilegeEscalation, "should be nil")
+				s.Nil(securityContext.Capabilities, "should be nil")
+				s.Nil(securityContext.Privileged, "should be nil")
+				s.Nil(securityContext.ProcMount, "should be nil")
+				s.Nil(securityContext.ReadOnlyRootFilesystem, "should be nil")
+				s.Nil(securityContext.RunAsGroup, "should be nil")
+				s.Nil(securityContext.RunAsNonRoot, "should be nil")
+				s.Nil(securityContext.RunAsUser, "should be nil")
+				s.Nil(securityContext.SeccompProfile, "should be nil")
+				s.Nil(securityContext.SELinuxOptions, "should be nil")
+				s.Nil(securityContext.WindowsOptions, "should be nil")
+			},
+		},
+		{
+			"overrideSecurityContext",
+			map[string]string{
+				"pluginsSettings.enabled": "true",
+				"pluginsSettings.initContainers.containerSecurityContext.runAsGroup": "3000",
+				"pluginsSettings.initContainers.containerSecurityContext.runAsUser":  "1000",
+			},
+			func(securityContext *corev1.SecurityContext) {
+				s.Equal(int64(3000), *securityContext.RunAsGroup, "runAsGroup should be 3000")
+				s.Equal(int64(1000), *securityContext.RunAsUser, "runAsUser should be 1000")
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		s.Run(testCase.name, func() {
+			subT := s.T()
+			subT.Parallel()
+
+			options := &helm.Options{SetValues: testCase.values}
+			output := helm.RenderTemplate(subT, options, s.chartPath, s.releaseName, s.templates)
+
+			var deployment appsv1.Deployment
+			helm.UnmarshalK8SYaml(subT, output, &deployment)
+
+			testCase.expected(deployment.Spec.Template.Spec.InitContainers[0].SecurityContext)
+		})
+	}
+}
+
 func (s *deploymentPluginsTemplateTest) TestAffinity() {
 	testCases := []struct {
 		name     string

--- a/tests/unit/helm/teams-app-deployment_test.go
+++ b/tests/unit/helm/teams-app-deployment_test.go
@@ -1792,6 +1792,60 @@ func (s *deploymentTeamsAppTemplateTest) TestInitContainerResourceRequirements()
 	}
 }
 
+func (s *deploymentTeamsAppTemplateTest) TestInitContainerSecurityContext() {
+	testCases := []struct {
+		name     string
+		values   map[string]string
+		expected func(securityContext *corev1.SecurityContext)
+	}{
+		{
+			"defaultValues",
+			nil,
+			func(securityContext *corev1.SecurityContext) {
+				s.Nil(securityContext.AllowPrivilegeEscalation, "should be nil")
+				s.Nil(securityContext.Capabilities, "should be nil")
+				s.Nil(securityContext.Privileged, "should be nil")
+				s.Nil(securityContext.ProcMount, "should be nil")
+				s.Nil(securityContext.ReadOnlyRootFilesystem, "should be nil")
+				s.Nil(securityContext.RunAsGroup, "should be nil")
+				s.Nil(securityContext.RunAsNonRoot, "should be nil")
+				s.Nil(securityContext.RunAsUser, "should be nil")
+				s.Nil(securityContext.SeccompProfile, "should be nil")
+				s.Nil(securityContext.SELinuxOptions, "should be nil")
+				s.Nil(securityContext.WindowsOptions, "should be nil")
+			},
+		},
+		{
+			"overrideSecurityContext",
+			map[string]string{
+				"teamsAppSettings.initContainers.containerSecurityContext.runAsGroup": "3000",
+				"teamsAppSettings.initContainers.containerSecurityContext.runAsUser":  "1000",
+			},
+			func(securityContext *corev1.SecurityContext) {
+				s.Equal(int64(3000), *securityContext.RunAsGroup, "runAsGroup should be 3000")
+				s.Equal(int64(1000), *securityContext.RunAsUser, "runAsUser should be 1000")
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		s.Run(testCase.name, func() {
+			subT := s.T()
+			subT.Parallel()
+
+			options := &helm.Options{SetValues: testCase.values}
+			output := helm.RenderTemplate(subT, options, s.chartPath, s.releaseName, s.templates)
+
+			var deployment appsv1.Deployment
+			helm.UnmarshalK8SYaml(subT, output, &deployment)
+
+			testCase.expected(deployment.Spec.Template.Spec.InitContainers[0].SecurityContext)
+		})
+	}
+}
+
 func (s *deploymentTeamsAppTemplateTest) TestAffinity() {
 	testCases := []struct {
 		name     string


### PR DESCRIPTION
# Rationale

Currently, we don't allow users to set the `securityContext` for init containers. They can inherit the pod's `securityContext` but, it wasn't possible to set container level security contexts. 

We should add that to allow for kubernetes best practices when launching pods.

> [!NOTE]
> I made the decision to name the value `*.initContainers.containerSecurityContext` instead of `*.initContainers.securityContext`. I saw a TODO about possibly renaming `securityContext` to `containerSecurityContext` and figured that new additions would be a good place to start. I am happy to default back if anyone feels differently.

## Changes

1. Adds `containerSecurityContext` entry in `values.yaml` for each `initContainers` setting.
2. Updates `_helpers.tpl` to add a security context if present:
    ```yaml
    {{- if hasKey $ "containerSecurityContext" }}
    securityContext:
        {{- toYaml $.containerSecurityContext | nindent 4 }}
    {{- end }}
    ```
3. Alpha-sorts the contexts before calling the initContainer template:
    ```yaml
          include "fiftyone-teams-app.commonInitContainers"
          (
            dict "casServiceName" (include "teams-cas.name" .)
            "containerSecurityContext" .Values.apiSettings.initContainers.containerSecurityContext
            "repository" .Values.apiSettings.initContainers.image.repository
            "resources" .Values.apiSettings.initContainers.resources
            "tag" .Values.apiSettings.initContainers.image.tag
          ) | nindent 8
    ```
4. Adds unit tests appropriately

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

Go tests and `helm template`. Templates shown below:

```yaml
$ helm template . --set apiSettings.initContainers.containerSecurityContext.runAsGroup=3000 --set apiSettings.initContainers.containerSecurityContext.runAsUser=1000
.
.
.
      initContainers:
        - name: init-cas
          image: docker.io/busybox:stable-glibc
          command:
            - 'sh'
            - '-c'
            - "until wget -qO /dev/null teams-cas.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local/cas/api; do echo waiting for cas; sleep 2; done"
          resources:
            limits: {}
            requests: {}
          securityContext:
            runAsGroup: 3000
            runAsUser: 1000
```
<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
