### PR TITLE
fix: use gpu container in GPU smoketest example

### DIFF
--- a/docker/docs/configuring-gpu-workloads.md
+++ b/docker/docs/configuring-gpu-workloads.md
@@ -107,7 +107,7 @@ PyTorch's
 by execing into the container and running
 
 ```shell
-$ docker compose exec teams-do \
+$ docker compose exec teams-do-with-gpu \
     python -c 'import torch; print(torch.cuda.is_available())'
 True
 ```


### PR DESCRIPTION
# Rationale

GPU smoketest example uses CPU container, not GPU container

## Changes

fix typo

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

The helm example doesn't need an update as it uses an abstract envvar/name

## Testing

doc update