### PR TITLE
chore(helm): AS-652 set default values

### DIFF
--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -475,11 +475,11 @@ follow
 | apiSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy]. |
 | apiSettings.image.repository | string | `"voxel51/fiftyone-teams-api"` | Container image for the `teams-api`. |
 | apiSettings.image.tag | string | `""` | Image tag for `teams-api`. Defaults to the chart version. |
-| apiSettings.initContainers.containerSecurityContext | object | `{}` | Container security configuration for `teams-api` `initContainers`. [Reference][container-security-context]. |
+| apiSettings.initContainers.containerSecurityContext | object | `{"allowPrivilegeEscalation":false}` | Container security configuration for `teams-api` `initContainers`. [Reference][container-security-context]. |
 | apiSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for `teams-api`. [Reference][init-containers]. |
 | apiSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for `teams-api`. [Reference][init-containers]. |
 | apiSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for `teams-api`. [Reference][init-containers]. |
-| apiSettings.initContainers.resources | object | `{"limits":{},"requests":{}}` | Container resource requests and limits for the `teams-api` `initContainers`. [Reference][resources]. |
+| apiSettings.initContainers.resources | object | `{"limits":{"cpu":"10m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"128Mi"}}` | Container resource requests and limits for the `teams-api` `initContainers`. [Reference][resources]. |
 | apiSettings.labels | object | `{}` | Additional labels for the `teams-api` related objects. [Reference][labels-and-selectors]. |
 | apiSettings.nodeSelector | object | `{}` | nodeSelector for `teams-api`. [Reference][node-selector]. |
 | apiSettings.podAnnotations | object | `{}` | Annotations for pods for `teams-api`. [Reference][annotations]. |
@@ -519,11 +519,11 @@ follow
 | appSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy]. |
 | appSettings.image.repository | string | `"voxel51/fiftyone-app"` | Container image for `fiftyone-app`. |
 | appSettings.image.tag | string | `""` | Image tag for `fiftyone-app`. Defaults to the chart version. |
-| appSettings.initContainers.containerSecurityContext | object | `{}` | Container security configuration for `fiftyone-app` `initContainers`. [Reference][container-security-context]. |
+| appSettings.initContainers.containerSecurityContext | object | `{"allowPrivilegeEscalation":false}` | Container security configuration for `fiftyone-app` `initContainers`. [Reference][container-security-context]. |
 | appSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for `fiftyone-app`. [Reference][init-containers]. |
 | appSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for `fiftyone-app`. [Reference][init-containers]. |
 | appSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for `fiftyone-app`. [Reference][init-containers]. |
-| appSettings.initContainers.resources | object | `{"limits":{},"requests":{}}` | Container resource requests and limits for the `fiftyone-app` `initContainers`. [Reference][resources]. |
+| appSettings.initContainers.resources | object | `{"limits":{"cpu":"10m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"128Mi"}}` | Container resource requests and limits for the `fiftyone-app` `initContainers`. [Reference][resources]. |
 | appSettings.labels | object | `{}` | Additional labels for the `fiftyone-app` related objects. [Reference][labels-and-selectors]. |
 | appSettings.nodeSelector | object | `{}` | nodeSelector for `fiftyone-app`. [Reference][node-selector]. |
 | appSettings.podAnnotations | object | `{}` | Annotations for pods for `fiftyone-app`. [Reference][annotations]. |
@@ -559,11 +559,11 @@ follow
 | casSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy]. |
 | casSettings.image.repository | string | `"voxel51/fiftyone-teams-cas"` | Container image for `teams-cas`. |
 | casSettings.image.tag | string | `""` | Image tag for `teams-cas`. Defaults to the chart version. |
-| casSettings.initContainers.containerSecurityContext | object | `{}` | Container security configuration for `teams-cas` `initContainers`. [Reference][container-security-context]. |
+| casSettings.initContainers.containerSecurityContext | object | `{"allowPrivilegeEscalation":false}` | Container security configuration for `teams-cas` `initContainers`. [Reference][container-security-context]. |
 | casSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for `teams-cas`. [Reference][init-containers]. |
 | casSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for `teams-cas`. [Reference][init-containers]. |
 | casSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for `teams-cas`. [Reference][init-containers]. |
-| casSettings.initContainers.resources | object | `{"limits":{},"requests":{}}` | Container resource requests and limits for the `teams-cas` `initContainers`. [Reference][resources]. |
+| casSettings.initContainers.resources | object | `{"limits":{"cpu":"10m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"128Mi"}}` | Container resource requests and limits for the `teams-cas` `initContainers`. [Reference][resources]. |
 | casSettings.labels | object | `{}` | Additional labels for the `teams-cas` related objects. [Reference][labels-and-selectors]. |
 | casSettings.nodeSelector | object | `{}` | nodeSelector for `teams-cas`. [Reference][node-selector]. |
 | casSettings.podAnnotations | object | `{}` | Annotations for pods for `teams-cas`. [Reference][annotations]. |
@@ -691,11 +691,11 @@ follow
 | pluginsSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy]. |
 | pluginsSettings.image.repository | string | `"voxel51/fiftyone-app"` | Container image for `teams-plugins`. |
 | pluginsSettings.image.tag | string | `""` | Image tag for `teams-plugins`. Defaults to the chart version. |
-| pluginsSettings.initContainers.containerSecurityContext | object | `{}` | Container security configuration for `teams-plugins` `initContainers`. [Reference][container-security-context]. |
+| pluginsSettings.initContainers.containerSecurityContext | object | `{"allowPrivilegeEscalation":false}` | Container security configuration for `teams-plugins` `initContainers`. [Reference][container-security-context]. |
 | pluginsSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for `teams-plugins`. [Reference][init-containers]. |
 | pluginsSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for `teams-plugins`. [Reference][init-containers]. |
 | pluginsSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for `teams-plugins`. [Reference][init-containers]. |
-| pluginsSettings.initContainers.resources | object | `{"limits":{},"requests":{}}` | Container resource requests and limits for the `teams-plugins` `initContainers`. [Reference][resources]. |
+| pluginsSettings.initContainers.resources | object | `{"limits":{"cpu":"10m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"128Mi"}}` | Container resource requests and limits for the `teams-plugins` `initContainers`. [Reference][resources]. |
 | pluginsSettings.labels | object | `{}` | Additional labels for the `teams-plugins` related objects. [Reference][labels-and-selectors]. |
 | pluginsSettings.nodeSelector | object | `{}` | nodeSelector for `teams-plugins`. [Reference][node-selector]. |
 | pluginsSettings.podAnnotations | object | `{}` | Annotations for `teams-plugins` pods. [Reference][annotations]. |
@@ -753,11 +753,11 @@ follow
 | teamsAppSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. Reference][image-pull-policy]. |
 | teamsAppSettings.image.repository | string | `"voxel51/fiftyone-teams-app"` | Container image for `teams-app`. |
 | teamsAppSettings.image.tag | string | `""` | Image tag for `teams-app`.  Defaults to the chart version. |
-| teamsAppSettings.initContainers.containerSecurityContext | object | `{}` | Container security configuration for `teams-app` `initContainers`. [Reference][container-security-context]. |
+| teamsAppSettings.initContainers.containerSecurityContext | object | `{"allowPrivilegeEscalation":false}` | Container security configuration for `teams-app` `initContainers`. [Reference][container-security-context]. |
 | teamsAppSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for `teams-app`.  [Reference][init-containers]. |
 | teamsAppSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for `teams-app`.  [Reference][init-containers]. |
 | teamsAppSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for `teams-app`.  [Reference][init-containers]. |
-| teamsAppSettings.initContainers.resources | object | `{"limits":{},"requests":{}}` | Container resource requests and limits for the `teams-app` `initContainers`. [Reference][resources]. |
+| teamsAppSettings.initContainers.resources | object | `{"limits":{"cpu":"10m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"128Mi"}}` | Container resource requests and limits for the `teams-app` `initContainers`. [Reference][resources]. |
 | teamsAppSettings.labels | object | `{}` | Additional labels for the `teams-app` related objects. [Reference][labels-and-selectors]. |
 | teamsAppSettings.nodeSelector | object | `{}` | nodeSelector for `teams-app`.  [Reference][node-selector]. |
 | teamsAppSettings.podAnnotations | object | `{}` | Annotations for `teams-app` pods. [Reference][annotations]. |

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -87,7 +87,8 @@ apiSettings:
   affinity: {}
   initContainers:
     # -- Container security configuration for `teams-api` `initContainers`. [Reference][container-security-context].
-    containerSecurityContext: {}
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
     # -- Whether to enable init containers for `teams-api`. [Reference][init-containers].
     enabled: true
     image:
@@ -95,18 +96,14 @@ apiSettings:
       repository: docker.io/busybox
       # -- Init container images tags for `teams-api`. [Reference][init-containers].
       tag: stable-glibc
-    # Instead of setting default resources, we require the user define them
-    # This enables running on resource constrained environments
-    # (like Minikube). To set resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces (`{}`) after 'resources:'.
     # -- Container resource requests and limits for the `teams-api` `initContainers`. [Reference][resources].
     resources:
-      limits: {}
-      #   cpu: 2
-      #   memory: 6Gi
-      requests: {}
-      #   cpu: 500m
-      #   memory: 512Mi
+      limits:
+        cpu: 10m
+        memory: 128Mi
+      requests:
+        cpu: 10m
+        memory: 128Mi
   # -- nodeSelector for `teams-api`. [Reference][node-selector].
   nodeSelector: {}
   # -- Annotations for pods for `teams-api`. [Reference][annotations].
@@ -234,7 +231,8 @@ appSettings:
   affinity: {}
   initContainers:
     # -- Container security configuration for `fiftyone-app` `initContainers`. [Reference][container-security-context].
-    containerSecurityContext: {}
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
     # -- Whether to enable init containers for `fiftyone-app`. [Reference][init-containers].
     enabled: true
     image:
@@ -242,18 +240,14 @@ appSettings:
       repository: docker.io/busybox
       # -- Init container images tags for `fiftyone-app`. [Reference][init-containers].
       tag: stable-glibc
-    # Instead of setting default resources, we require the user define them
-    # This enables running on resource constrained environments
-    # (like Minikube). To set resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces (`{}`) after 'resources:'.
     # -- Container resource requests and limits for the `fiftyone-app` `initContainers`. [Reference][resources].
     resources:
-      limits: {}
-      #   cpu: 2
-      #   memory: 6Gi
-      requests: {}
-      #   cpu: 500m
-      #   memory: 512Mi
+      limits:
+        cpu: 10m
+        memory: 128Mi
+      requests:
+        cpu: 10m
+        memory: 128Mi
   # -- nodeSelector for `fiftyone-app`. [Reference][node-selector].
   nodeSelector: {}
   # -- Annotations for pods for `fiftyone-app`. [Reference][annotations].
@@ -370,7 +364,8 @@ casSettings:
   affinity: {}
   initContainers:
     # -- Container security configuration for `teams-cas` `initContainers`. [Reference][container-security-context].
-    containerSecurityContext: {}
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
     # -- Whether to enable init containers for `teams-cas`. [Reference][init-containers].
     enabled: true
     image:
@@ -378,18 +373,14 @@ casSettings:
       repository: docker.io/busybox
       # -- Init container images tags for `teams-cas`. [Reference][init-containers].
       tag: stable-glibc
-    # Instead of setting default resources, we require the user define them
-    # This enables running on resource constrained environments
-    # (like Minikube). To set resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces (`{}`) after 'resources:'.
     # -- Container resource requests and limits for the `teams-cas` `initContainers`. [Reference][resources].
     resources:
-      limits: {}
-      #   cpu: 2
-      #   memory: 6Gi
-      requests: {}
-      #   cpu: 500m
-      #   memory: 512Mi
+      limits:
+        cpu: 10m
+        memory: 128Mi
+      requests:
+        cpu: 10m
+        memory: 128Mi
   # -- nodeSelector for `teams-cas`. [Reference][node-selector].
   nodeSelector: {}
   # -- Annotations for pods for `teams-cas`. [Reference][annotations].
@@ -822,7 +813,8 @@ pluginsSettings:
   affinity: {}
   initContainers:
     # -- Container security configuration for `teams-plugins` `initContainers`. [Reference][container-security-context].
-    containerSecurityContext: {}
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
     # -- Whether to enable init containers for `teams-plugins`. [Reference][init-containers].
     enabled: true
     image:
@@ -830,18 +822,14 @@ pluginsSettings:
       repository: docker.io/busybox
       # -- Init container images tags for `teams-plugins`. [Reference][init-containers].
       tag: stable-glibc
-    # Instead of setting default resources, we require the user define them
-    # This enables running on resource constrained environments
-    # (like Minikube). To set resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces (`{}`) after 'resources:'.
     # -- Container resource requests and limits for the `teams-plugins` `initContainers`. [Reference][resources].
     resources:
-      limits: {}
-      #   cpu: 2
-      #   memory: 6Gi
-      requests: {}
-      #   cpu: 500m
-      #   memory: 512Mi
+      limits:
+        cpu: 10m
+        memory: 128Mi
+      requests:
+        cpu: 10m
+        memory: 128Mi
   # -- nodeSelector for `teams-plugins`. [Reference][node-selector].
   nodeSelector: {}
   # -- Annotations for `teams-plugins` pods. [Reference][annotations].
@@ -1025,7 +1013,8 @@ teamsAppSettings:
   affinity: {}
   initContainers:
     # -- Container security configuration for `teams-app` `initContainers`. [Reference][container-security-context].
-    containerSecurityContext: {}
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
     # -- Whether to enable init containers for `teams-app`.  [Reference][init-containers].
     enabled: true
     image:
@@ -1033,18 +1022,14 @@ teamsAppSettings:
       repository: docker.io/busybox
       # -- Init container images tags for `teams-app`.  [Reference][init-containers].
       tag: stable-glibc
-    # Instead of setting default resources, we require the user define them
-    # This enables running on resource constrained environments
-    # (like Minikube). To set resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces (`{}`) after 'resources:'.
     # -- Container resource requests and limits for the `teams-app` `initContainers`. [Reference][resources].
     resources:
-      limits: {}
-      #   cpu: 2
-      #   memory: 6Gi
-      requests: {}
-      #   cpu: 500m
-      #   memory: 512Mi
+      limits:
+        cpu: 10m
+        memory: 128Mi
+      requests:
+        cpu: 10m
+        memory: 128Mi
   # -- nodeSelector for `teams-app`.  [Reference][node-selector].
   nodeSelector: {}
   # -- Annotations for `teams-app` pods. [Reference][annotations].

--- a/tests/unit/helm/api-deployment_test.go
+++ b/tests/unit/helm/api-deployment_test.go
@@ -1595,8 +1595,17 @@ func (s *deploymentApiTemplateTest) TestInitContainerResourceRequirements() {
 			"defaultValues",
 			nil,
 			func(resourceRequirements corev1.ResourceRequirements) {
-				s.Equal(resourceRequirements.Limits, corev1.ResourceList{}, "Limits should be equal")
-				s.Equal(resourceRequirements.Requests, corev1.ResourceList{}, "Requests should be equal")
+				resourceExpected := corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"cpu":    resource.MustParse("10m"),
+						"memory": resource.MustParse("128Mi"),
+					},
+					Requests: corev1.ResourceList{
+						"cpu":    resource.MustParse("10m"),
+						"memory": resource.MustParse("128Mi"),
+					},
+				}
+				s.Equal(resourceExpected, resourceRequirements, "should be equal")
 				s.Nil(resourceRequirements.Claims, "should be nil")
 			},
 		},
@@ -1653,7 +1662,7 @@ func (s *deploymentApiTemplateTest) TestInitContainerSecurityContext() {
 			"defaultValues",
 			nil,
 			func(securityContext *corev1.SecurityContext) {
-				s.Nil(securityContext.AllowPrivilegeEscalation, "should be nil")
+				s.Equal(false, *securityContext.AllowPrivilegeEscalation, "AllowPrivilegeEscalation should be equal")
 				s.Nil(securityContext.Capabilities, "should be nil")
 				s.Nil(securityContext.Privileged, "should be nil")
 				s.Nil(securityContext.ProcMount, "should be nil")
@@ -1673,6 +1682,7 @@ func (s *deploymentApiTemplateTest) TestInitContainerSecurityContext() {
 				"apiSettings.initContainers.containerSecurityContext.runAsUser":  "1000",
 			},
 			func(securityContext *corev1.SecurityContext) {
+				s.Equal(false, *securityContext.AllowPrivilegeEscalation, "AllowPrivilegeEscalation should be equal")
 				s.Equal(int64(3000), *securityContext.RunAsGroup, "runAsGroup should be 3000")
 				s.Equal(int64(1000), *securityContext.RunAsUser, "runAsUser should be 1000")
 			},

--- a/tests/unit/helm/app-deployment_test.go
+++ b/tests/unit/helm/app-deployment_test.go
@@ -1554,8 +1554,17 @@ func (s *deploymentAppTemplateTest) TestInitContainerResourceRequirements() {
 			"defaultValues",
 			nil,
 			func(resourceRequirements corev1.ResourceRequirements) {
-				s.Equal(resourceRequirements.Limits, corev1.ResourceList{}, "Limits should be equal")
-				s.Equal(resourceRequirements.Requests, corev1.ResourceList{}, "Requests should be equal")
+				resourceExpected := corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"cpu":    resource.MustParse("10m"),
+						"memory": resource.MustParse("128Mi"),
+					},
+					Requests: corev1.ResourceList{
+						"cpu":    resource.MustParse("10m"),
+						"memory": resource.MustParse("128Mi"),
+					},
+				}
+				s.Equal(resourceExpected, resourceRequirements, "should be equal")
 				s.Nil(resourceRequirements.Claims, "should be nil")
 			},
 		},
@@ -1612,7 +1621,7 @@ func (s *deploymentAppTemplateTest) TestInitContainerSecurityContext() {
 			"defaultValues",
 			nil,
 			func(securityContext *corev1.SecurityContext) {
-				s.Nil(securityContext.AllowPrivilegeEscalation, "should be nil")
+				s.Equal(false, *securityContext.AllowPrivilegeEscalation, "AllowPrivilegeEscalation should be equal")
 				s.Nil(securityContext.Capabilities, "should be nil")
 				s.Nil(securityContext.Privileged, "should be nil")
 				s.Nil(securityContext.ProcMount, "should be nil")
@@ -1632,6 +1641,7 @@ func (s *deploymentAppTemplateTest) TestInitContainerSecurityContext() {
 				"appSettings.initContainers.containerSecurityContext.runAsUser":  "1000",
 			},
 			func(securityContext *corev1.SecurityContext) {
+				s.Equal(false, *securityContext.AllowPrivilegeEscalation, "AllowPrivilegeEscalation should be equal")
 				s.Equal(int64(3000), *securityContext.RunAsGroup, "runAsGroup should be 3000")
 				s.Equal(int64(1000), *securityContext.RunAsUser, "runAsUser should be 1000")
 			},

--- a/tests/unit/helm/plugins-deployment_test.go
+++ b/tests/unit/helm/plugins-deployment_test.go
@@ -1902,8 +1902,17 @@ func (s *deploymentPluginsTemplateTest) TestInitContainerResourceRequirements() 
 				"pluginsSettings.enabled": "true",
 			},
 			func(resourceRequirements corev1.ResourceRequirements) {
-				s.Equal(resourceRequirements.Limits, corev1.ResourceList{}, "Limits should be equal")
-				s.Equal(resourceRequirements.Requests, corev1.ResourceList{}, "Requests should be equal")
+				resourceExpected := corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"cpu":    resource.MustParse("10m"),
+						"memory": resource.MustParse("128Mi"),
+					},
+					Requests: corev1.ResourceList{
+						"cpu":    resource.MustParse("10m"),
+						"memory": resource.MustParse("128Mi"),
+					},
+				}
+				s.Equal(resourceExpected, resourceRequirements, "should be equal")
 				s.Nil(resourceRequirements.Claims, "should be nil")
 			},
 		},
@@ -1963,7 +1972,7 @@ func (s *deploymentPluginsTemplateTest) TestInitContainerSecurityContext() {
 				"pluginsSettings.enabled": "true",
 			},
 			func(securityContext *corev1.SecurityContext) {
-				s.Nil(securityContext.AllowPrivilegeEscalation, "should be nil")
+				s.Equal(false, *securityContext.AllowPrivilegeEscalation, "AllowPrivilegeEscalation should be equal")
 				s.Nil(securityContext.Capabilities, "should be nil")
 				s.Nil(securityContext.Privileged, "should be nil")
 				s.Nil(securityContext.ProcMount, "should be nil")
@@ -1984,6 +1993,7 @@ func (s *deploymentPluginsTemplateTest) TestInitContainerSecurityContext() {
 				"pluginsSettings.initContainers.containerSecurityContext.runAsUser":  "1000",
 			},
 			func(securityContext *corev1.SecurityContext) {
+				s.Equal(false, *securityContext.AllowPrivilegeEscalation, "AllowPrivilegeEscalation should be equal")
 				s.Equal(int64(3000), *securityContext.RunAsGroup, "runAsGroup should be 3000")
 				s.Equal(int64(1000), *securityContext.RunAsUser, "runAsUser should be 1000")
 			},

--- a/tests/unit/helm/teams-app-deployment_test.go
+++ b/tests/unit/helm/teams-app-deployment_test.go
@@ -1744,8 +1744,17 @@ func (s *deploymentTeamsAppTemplateTest) TestInitContainerResourceRequirements()
 			"defaultValues",
 			nil,
 			func(resourceRequirements corev1.ResourceRequirements) {
-				s.Equal(resourceRequirements.Limits, corev1.ResourceList{}, "Limits should be equal")
-				s.Equal(resourceRequirements.Requests, corev1.ResourceList{}, "Requests should be equal")
+				resourceExpected := corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"cpu":    resource.MustParse("10m"),
+						"memory": resource.MustParse("128Mi"),
+					},
+					Requests: corev1.ResourceList{
+						"cpu":    resource.MustParse("10m"),
+						"memory": resource.MustParse("128Mi"),
+					},
+				}
+				s.Equal(resourceExpected, resourceRequirements, "should be equal")
 				s.Nil(resourceRequirements.Claims, "should be nil")
 			},
 		},
@@ -1802,7 +1811,7 @@ func (s *deploymentTeamsAppTemplateTest) TestInitContainerSecurityContext() {
 			"defaultValues",
 			nil,
 			func(securityContext *corev1.SecurityContext) {
-				s.Nil(securityContext.AllowPrivilegeEscalation, "should be nil")
+				s.Equal(false, *securityContext.AllowPrivilegeEscalation, "AllowPrivilegeEscalation should be equal")
 				s.Nil(securityContext.Capabilities, "should be nil")
 				s.Nil(securityContext.Privileged, "should be nil")
 				s.Nil(securityContext.ProcMount, "should be nil")
@@ -1822,6 +1831,7 @@ func (s *deploymentTeamsAppTemplateTest) TestInitContainerSecurityContext() {
 				"teamsAppSettings.initContainers.containerSecurityContext.runAsUser":  "1000",
 			},
 			func(securityContext *corev1.SecurityContext) {
+				s.Equal(false, *securityContext.AllowPrivilegeEscalation, "AllowPrivilegeEscalation should be equal")
 				s.Equal(int64(3000), *securityContext.RunAsGroup, "runAsGroup should be 3000")
 				s.Equal(int64(1000), *securityContext.RunAsUser, "runAsUser should be 1000")
 			},


### PR DESCRIPTION
# Rationale

We discussed in slack defaulting the `initContainers.allowPrivilegeEscalation` and `initContainers.resources` to known good values. These are very small pods and can run in secure ways, so we can default securely.
 
## Changes

* Default `initContainers.allowPrivilegeEscalation=false`
* Default `initContainers.resources` to `10m` and `128Mi`

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

Go tests updated

```
      initContainers:
        - name: init-cas
          image: docker.io/busybox:stable-glibc
          command:
            - 'sh'
            - '-c'
            - "until wget -qO /dev/null teams-cas.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local/cas/api; do echo waiting for cas; sleep 2; done"
          resources:
            limits:
              cpu: 10m
              memory: 128Mi
            requests:
              cpu: 10m
              memory: 128Mi
          securityContext:
            allowPrivilegeEscalation: false
```
<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
