### PR TITLE
chore(helm): AS-650 Run `initContainers` as non-root

### DIFF
--- a/helm/docs/upgrading.md
+++ b/helm/docs/upgrading.md
@@ -102,9 +102,9 @@ A minimal example `values.yaml` may be found
 #### FiftyOne Enterprise v2.8+ `initContainer` Changes
 
 FiftyOne Enterprise v2.8.0 introduces numerous changes to the default settings
-for each system's `initContainers`.
+for each component's `initContainers`.
 
-1. `initContainers` will get, by default, the container security context
+1. `initContainers` default to the container security context
    shown below in order to comply with kubernetes security best practices.
    This configuration prevents privilege escalation and running any
    initialization processes as root.
@@ -116,8 +116,8 @@ for each system's `initContainers`.
         runAsUser: 1000  # Runs the init processes as UID 1000
     ```
 
-1. `initContainers` will get, be default, the resources shown below.
-   These initialization processes are designed to be small and lightweight
+1. `initContainers` default to the resources shown below.
+   These initialization processes are lightweight
    and can therefore set small resource requests and limits instead of using
    a cluster's defaults.
 

--- a/helm/docs/upgrading.md
+++ b/helm/docs/upgrading.md
@@ -18,7 +18,7 @@
 
 - [Upgrading From Previous Versions](#upgrading-from-previous-versions)
   - [From FiftyOne Enterprise Version 2.0.0 or Higher](#from-fiftyone-enterprise-version-200-or-higher)
-    - [FiftyOne Enterprise v2.8+ InitContainer Changes](#fiftyone-enterprise-v28-initcontainer-changes)
+    - [FiftyOne Enterprise v2.8+ `initContainer` Changes](#fiftyone-enterprise-v28-initcontainer-changes)
     - [FiftyOne Enterprise v2.7+ Delegated Operator Changes](#fiftyone-enterprise-v27-delegated-operator-changes)
     - [FiftyOne Enterprise v2.5+ Delegated Operator Changes](#fiftyone-enterprise-v25-delegated-operator-changes)
     - [FiftyOne Enterprise v2.2+ Delegated Operator Changes](#fiftyone-enterprise-v22-delegated-operator-changes)
@@ -99,7 +99,7 @@ A minimal example `values.yaml` may be found
    fiftyone migrate --info
    ```
 
-#### FiftyOne Enterprise v2.8+ InitContainer Changes
+#### FiftyOne Enterprise v2.8+ `initContainer` Changes
 
 FiftyOne Enterprise v2.8.0 introduces numerous changes to the default settings
 for each system's `initContainers`.

--- a/helm/docs/upgrading.md
+++ b/helm/docs/upgrading.md
@@ -18,6 +18,7 @@
 
 - [Upgrading From Previous Versions](#upgrading-from-previous-versions)
   - [From FiftyOne Enterprise Version 2.0.0 or Higher](#from-fiftyone-enterprise-version-200-or-higher)
+    - [FiftyOne Enterprise v2.8+ InitContainer Changes](#fiftyone-enterprise-v28-initcontainer-changes)
     - [FiftyOne Enterprise v2.7+ Delegated Operator Changes](#fiftyone-enterprise-v27-delegated-operator-changes)
     - [FiftyOne Enterprise v2.5+ Delegated Operator Changes](#fiftyone-enterprise-v25-delegated-operator-changes)
     - [FiftyOne Enterprise v2.2+ Delegated Operator Changes](#fiftyone-enterprise-v22-delegated-operator-changes)
@@ -97,6 +98,38 @@ A minimal example `values.yaml` may be found
    ```shell
    fiftyone migrate --info
    ```
+
+#### FiftyOne Enterprise v2.8+ InitContainer Changes
+
+FiftyOne Enterprise v2.8.0 introduces numerous changes to the default settings
+for each system's `initContainers`.
+
+1. `initContainers` will get, by default, the container security context
+   shown below in order to comply with kubernetes security best practices.
+   This configuration prevents privilege escalation and running any
+   initialization processes as root.
+
+    ```yaml
+      containerSecurityContext:
+        allowPrivilegeEscalation: false  # Disables privilege escalation
+        runAsNonRoot: true  # Disables running as the `root` user
+        runAsUser: 1000  # Runs the init processes as UID 1000
+    ```
+
+1. `initContainers` will get, be default, the resources shown below.
+   These initialization processes are designed to be small and lightweight
+   and can therefore set small resource requests and limits instead of using
+   a cluster's defaults.
+
+   ```yaml
+      resources:
+        limits:
+          cpu: 10m
+          memory: 128Mi
+        requests:
+          cpu: 10m
+          memory: 128Mi
+    ```
 
 #### FiftyOne Enterprise v2.7+ Delegated Operator Changes
 

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -475,7 +475,7 @@ follow
 | apiSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy]. |
 | apiSettings.image.repository | string | `"voxel51/fiftyone-teams-api"` | Container image for the `teams-api`. |
 | apiSettings.image.tag | string | `""` | Image tag for `teams-api`. Defaults to the chart version. |
-| apiSettings.initContainers.containerSecurityContext | object | `{"allowPrivilegeEscalation":false}` | Container security configuration for `teams-api` `initContainers`. [Reference][container-security-context]. |
+| apiSettings.initContainers.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"runAsNonRoot":true,"runAsUser":1000}` | Container security configuration for `teams-api` `initContainers`. [Reference][container-security-context]. |
 | apiSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for `teams-api`. [Reference][init-containers]. |
 | apiSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for `teams-api`. [Reference][init-containers]. |
 | apiSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for `teams-api`. [Reference][init-containers]. |
@@ -519,7 +519,7 @@ follow
 | appSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy]. |
 | appSettings.image.repository | string | `"voxel51/fiftyone-app"` | Container image for `fiftyone-app`. |
 | appSettings.image.tag | string | `""` | Image tag for `fiftyone-app`. Defaults to the chart version. |
-| appSettings.initContainers.containerSecurityContext | object | `{"allowPrivilegeEscalation":false}` | Container security configuration for `fiftyone-app` `initContainers`. [Reference][container-security-context]. |
+| appSettings.initContainers.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"runAsNonRoot":true,"runAsUser":1000}` | Container security configuration for `fiftyone-app` `initContainers`. [Reference][container-security-context]. |
 | appSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for `fiftyone-app`. [Reference][init-containers]. |
 | appSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for `fiftyone-app`. [Reference][init-containers]. |
 | appSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for `fiftyone-app`. [Reference][init-containers]. |
@@ -559,7 +559,7 @@ follow
 | casSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy]. |
 | casSettings.image.repository | string | `"voxel51/fiftyone-teams-cas"` | Container image for `teams-cas`. |
 | casSettings.image.tag | string | `""` | Image tag for `teams-cas`. Defaults to the chart version. |
-| casSettings.initContainers.containerSecurityContext | object | `{"allowPrivilegeEscalation":false}` | Container security configuration for `teams-cas` `initContainers`. [Reference][container-security-context]. |
+| casSettings.initContainers.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"runAsNonRoot":true,"runAsUser":1000}` | Container security configuration for `teams-cas` `initContainers`. [Reference][container-security-context]. |
 | casSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for `teams-cas`. [Reference][init-containers]. |
 | casSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for `teams-cas`. [Reference][init-containers]. |
 | casSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for `teams-cas`. [Reference][init-containers]. |
@@ -691,7 +691,7 @@ follow
 | pluginsSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy]. |
 | pluginsSettings.image.repository | string | `"voxel51/fiftyone-app"` | Container image for `teams-plugins`. |
 | pluginsSettings.image.tag | string | `""` | Image tag for `teams-plugins`. Defaults to the chart version. |
-| pluginsSettings.initContainers.containerSecurityContext | object | `{"allowPrivilegeEscalation":false}` | Container security configuration for `teams-plugins` `initContainers`. [Reference][container-security-context]. |
+| pluginsSettings.initContainers.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"runAsNonRoot":true,"runAsUser":1000}` | Container security configuration for `teams-plugins` `initContainers`. [Reference][container-security-context]. |
 | pluginsSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for `teams-plugins`. [Reference][init-containers]. |
 | pluginsSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for `teams-plugins`. [Reference][init-containers]. |
 | pluginsSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for `teams-plugins`. [Reference][init-containers]. |
@@ -753,7 +753,7 @@ follow
 | teamsAppSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. Reference][image-pull-policy]. |
 | teamsAppSettings.image.repository | string | `"voxel51/fiftyone-teams-app"` | Container image for `teams-app`. |
 | teamsAppSettings.image.tag | string | `""` | Image tag for `teams-app`.  Defaults to the chart version. |
-| teamsAppSettings.initContainers.containerSecurityContext | object | `{"allowPrivilegeEscalation":false}` | Container security configuration for `teams-app` `initContainers`. [Reference][container-security-context]. |
+| teamsAppSettings.initContainers.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"runAsNonRoot":true,"runAsUser":1000}` | Container security configuration for `teams-app` `initContainers`. [Reference][container-security-context]. |
 | teamsAppSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for `teams-app`.  [Reference][init-containers]. |
 | teamsAppSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for `teams-app`.  [Reference][init-containers]. |
 | teamsAppSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for `teams-app`.  [Reference][init-containers]. |

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -89,6 +89,8 @@ apiSettings:
     # -- Container security configuration for `teams-api` `initContainers`. [Reference][container-security-context].
     containerSecurityContext:
       allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      runAsUser: 1000
     # -- Whether to enable init containers for `teams-api`. [Reference][init-containers].
     enabled: true
     image:
@@ -233,6 +235,8 @@ appSettings:
     # -- Container security configuration for `fiftyone-app` `initContainers`. [Reference][container-security-context].
     containerSecurityContext:
       allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      runAsUser: 1000
     # -- Whether to enable init containers for `fiftyone-app`. [Reference][init-containers].
     enabled: true
     image:
@@ -366,6 +370,8 @@ casSettings:
     # -- Container security configuration for `teams-cas` `initContainers`. [Reference][container-security-context].
     containerSecurityContext:
       allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      runAsUser: 1000
     # -- Whether to enable init containers for `teams-cas`. [Reference][init-containers].
     enabled: true
     image:
@@ -815,6 +821,8 @@ pluginsSettings:
     # -- Container security configuration for `teams-plugins` `initContainers`. [Reference][container-security-context].
     containerSecurityContext:
       allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      runAsUser: 1000
     # -- Whether to enable init containers for `teams-plugins`. [Reference][init-containers].
     enabled: true
     image:
@@ -1015,6 +1023,8 @@ teamsAppSettings:
     # -- Container security configuration for `teams-app` `initContainers`. [Reference][container-security-context].
     containerSecurityContext:
       allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      runAsUser: 1000
     # -- Whether to enable init containers for `teams-app`.  [Reference][init-containers].
     enabled: true
     image:

--- a/tests/unit/helm/api-deployment_test.go
+++ b/tests/unit/helm/api-deployment_test.go
@@ -1668,8 +1668,8 @@ func (s *deploymentApiTemplateTest) TestInitContainerSecurityContext() {
 				s.Nil(securityContext.ProcMount, "should be nil")
 				s.Nil(securityContext.ReadOnlyRootFilesystem, "should be nil")
 				s.Nil(securityContext.RunAsGroup, "should be nil")
-				s.Nil(securityContext.RunAsNonRoot, "should be nil")
-				s.Nil(securityContext.RunAsUser, "should be nil")
+				s.Equal(true, *securityContext.RunAsNonRoot, "RunAsNonRoot should be equal")
+				s.Equal(int64(1000), *securityContext.RunAsUser, "runAsUser should be 1000")
 				s.Nil(securityContext.SeccompProfile, "should be nil")
 				s.Nil(securityContext.SELinuxOptions, "should be nil")
 				s.Nil(securityContext.WindowsOptions, "should be nil")
@@ -1679,12 +1679,13 @@ func (s *deploymentApiTemplateTest) TestInitContainerSecurityContext() {
 			"overrideSecurityContext",
 			map[string]string{
 				"apiSettings.initContainers.containerSecurityContext.runAsGroup": "3000",
-				"apiSettings.initContainers.containerSecurityContext.runAsUser":  "1000",
+				"apiSettings.initContainers.containerSecurityContext.runAsUser":  "1001",
 			},
 			func(securityContext *corev1.SecurityContext) {
 				s.Equal(false, *securityContext.AllowPrivilegeEscalation, "AllowPrivilegeEscalation should be equal")
 				s.Equal(int64(3000), *securityContext.RunAsGroup, "runAsGroup should be 3000")
-				s.Equal(int64(1000), *securityContext.RunAsUser, "runAsUser should be 1000")
+				s.Equal(true, *securityContext.RunAsNonRoot, "RunAsNonRoot should be equal")
+				s.Equal(int64(1001), *securityContext.RunAsUser, "runAsUser should be 1001")
 			},
 		},
 	}

--- a/tests/unit/helm/app-deployment_test.go
+++ b/tests/unit/helm/app-deployment_test.go
@@ -1627,8 +1627,8 @@ func (s *deploymentAppTemplateTest) TestInitContainerSecurityContext() {
 				s.Nil(securityContext.ProcMount, "should be nil")
 				s.Nil(securityContext.ReadOnlyRootFilesystem, "should be nil")
 				s.Nil(securityContext.RunAsGroup, "should be nil")
-				s.Nil(securityContext.RunAsNonRoot, "should be nil")
-				s.Nil(securityContext.RunAsUser, "should be nil")
+				s.Equal(true, *securityContext.RunAsNonRoot, "RunAsNonRoot should be equal")
+				s.Equal(int64(1000), *securityContext.RunAsUser, "runAsUser should be 1000")
 				s.Nil(securityContext.SeccompProfile, "should be nil")
 				s.Nil(securityContext.SELinuxOptions, "should be nil")
 				s.Nil(securityContext.WindowsOptions, "should be nil")
@@ -1638,12 +1638,13 @@ func (s *deploymentAppTemplateTest) TestInitContainerSecurityContext() {
 			"overrideSecurityContext",
 			map[string]string{
 				"appSettings.initContainers.containerSecurityContext.runAsGroup": "3000",
-				"appSettings.initContainers.containerSecurityContext.runAsUser":  "1000",
+				"appSettings.initContainers.containerSecurityContext.runAsUser":  "1001",
 			},
 			func(securityContext *corev1.SecurityContext) {
 				s.Equal(false, *securityContext.AllowPrivilegeEscalation, "AllowPrivilegeEscalation should be equal")
 				s.Equal(int64(3000), *securityContext.RunAsGroup, "runAsGroup should be 3000")
-				s.Equal(int64(1000), *securityContext.RunAsUser, "runAsUser should be 1000")
+				s.Equal(true, *securityContext.RunAsNonRoot, "RunAsNonRoot should be equal")
+				s.Equal(int64(1001), *securityContext.RunAsUser, "runAsUser should be 1001")
 			},
 		},
 	}

--- a/tests/unit/helm/plugins-deployment_test.go
+++ b/tests/unit/helm/plugins-deployment_test.go
@@ -1978,8 +1978,8 @@ func (s *deploymentPluginsTemplateTest) TestInitContainerSecurityContext() {
 				s.Nil(securityContext.ProcMount, "should be nil")
 				s.Nil(securityContext.ReadOnlyRootFilesystem, "should be nil")
 				s.Nil(securityContext.RunAsGroup, "should be nil")
-				s.Nil(securityContext.RunAsNonRoot, "should be nil")
-				s.Nil(securityContext.RunAsUser, "should be nil")
+				s.Equal(true, *securityContext.RunAsNonRoot, "RunAsNonRoot should be equal")
+				s.Equal(int64(1000), *securityContext.RunAsUser, "runAsUser should be 1000")
 				s.Nil(securityContext.SeccompProfile, "should be nil")
 				s.Nil(securityContext.SELinuxOptions, "should be nil")
 				s.Nil(securityContext.WindowsOptions, "should be nil")
@@ -1990,12 +1990,13 @@ func (s *deploymentPluginsTemplateTest) TestInitContainerSecurityContext() {
 			map[string]string{
 				"pluginsSettings.enabled": "true",
 				"pluginsSettings.initContainers.containerSecurityContext.runAsGroup": "3000",
-				"pluginsSettings.initContainers.containerSecurityContext.runAsUser":  "1000",
+				"pluginsSettings.initContainers.containerSecurityContext.runAsUser":  "1001",
 			},
 			func(securityContext *corev1.SecurityContext) {
 				s.Equal(false, *securityContext.AllowPrivilegeEscalation, "AllowPrivilegeEscalation should be equal")
 				s.Equal(int64(3000), *securityContext.RunAsGroup, "runAsGroup should be 3000")
-				s.Equal(int64(1000), *securityContext.RunAsUser, "runAsUser should be 1000")
+				s.Equal(true, *securityContext.RunAsNonRoot, "RunAsNonRoot should be equal")
+				s.Equal(int64(1001), *securityContext.RunAsUser, "runAsUser should be 1001")
 			},
 		},
 	}

--- a/tests/unit/helm/teams-app-deployment_test.go
+++ b/tests/unit/helm/teams-app-deployment_test.go
@@ -1817,8 +1817,8 @@ func (s *deploymentTeamsAppTemplateTest) TestInitContainerSecurityContext() {
 				s.Nil(securityContext.ProcMount, "should be nil")
 				s.Nil(securityContext.ReadOnlyRootFilesystem, "should be nil")
 				s.Nil(securityContext.RunAsGroup, "should be nil")
-				s.Nil(securityContext.RunAsNonRoot, "should be nil")
-				s.Nil(securityContext.RunAsUser, "should be nil")
+				s.Equal(true, *securityContext.RunAsNonRoot, "RunAsNonRoot should be equal")
+				s.Equal(int64(1000), *securityContext.RunAsUser, "runAsUser should be 1000")
 				s.Nil(securityContext.SeccompProfile, "should be nil")
 				s.Nil(securityContext.SELinuxOptions, "should be nil")
 				s.Nil(securityContext.WindowsOptions, "should be nil")
@@ -1828,12 +1828,13 @@ func (s *deploymentTeamsAppTemplateTest) TestInitContainerSecurityContext() {
 			"overrideSecurityContext",
 			map[string]string{
 				"teamsAppSettings.initContainers.containerSecurityContext.runAsGroup": "3000",
-				"teamsAppSettings.initContainers.containerSecurityContext.runAsUser":  "1000",
+				"teamsAppSettings.initContainers.containerSecurityContext.runAsUser":  "1001",
 			},
 			func(securityContext *corev1.SecurityContext) {
 				s.Equal(false, *securityContext.AllowPrivilegeEscalation, "AllowPrivilegeEscalation should be equal")
 				s.Equal(int64(3000), *securityContext.RunAsGroup, "runAsGroup should be 3000")
-				s.Equal(int64(1000), *securityContext.RunAsUser, "runAsUser should be 1000")
+				s.Equal(true, *securityContext.RunAsNonRoot, "RunAsNonRoot should be equal")
+				s.Equal(int64(1001), *securityContext.RunAsUser, "runAsUser should be 1001")
 			},
 		},
 	}


### PR DESCRIPTION
# Rationale

In https://github.com/voxel51/fiftyone-teams-app-deploy/pull/362, we decided to default to a secure configuration for `initContainers`. This follows a similar mentality and enforces that the containers run as UID 1000 and disabled running as root. It also seems like a good idea to update our `upgrading` doc to reflect these changes so that any users already configuring `initContainers` aren't impacted negatively.

## Changes

1. Updates `initContainer.containerSecurityContext` to
    ```yaml
        containerSecurityContext:
          allowPrivilegeEscalation: false
          runAsNonRoot: true
          runAsUser: 1000
    ```

1. Updates `upgrading.md` to reflect the new defaults
2. Updates unit tests accordingly

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

Go tests and `helm template` (shown below)

```yaml
      initContainers:
        - name: init-cas
          image: docker.io/busybox:stable-glibc
          command:
            - 'sh'
            - '-c'
            - "until wget -qO /dev/null teams-cas.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local/cas/api; do echo waiting for cas; sleep 2; done"
          resources:
            limits:
              cpu: 10m
              memory: 128Mi
            requests:
              cpu: 10m
              memory: 128Mi
          securityContext:
            allowPrivilegeEscalation: false
            runAsNonRoot: true
            runAsUser: 1000
```
<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
