### PR TITLE
chore(helm): Rollback automount overrides

### DIFF
--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -729,7 +729,6 @@ follow
 | secret.labels | object | `{}` | Additional labels for the generated secret. [Reference][labels-and-selectors]. |
 | secret.name | string | `"fiftyone-teams-secrets"` | Name of the secret (existing or to be created) in the namespace `namespace.name`. |
 | serviceAccount.annotations | object | `{}` | Service Account annotations. [Reference][annotations]. |
-| serviceAccount.automount | bool | `true` | Whether to automount the service account's API credentials. |
 | serviceAccount.create | bool | `true` | Controls whether to create the service account named `serviceAccount.name`. |
 | serviceAccount.labels | object | `{}` | Additional labels for the generated service account. [Reference][labels-and-selectors]. |
 | serviceAccount.name | string | `"fiftyone-teams"` | Name of the service account (existing or to be created) in the namespace `namespace.name` used for deployments. [Reference][service-account]. |

--- a/helm/fiftyone-teams-app/templates/serviceaccount.yaml
+++ b/helm/fiftyone-teams-app/templates/serviceaccount.yaml
@@ -10,5 +10,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+automountServiceAccountToken: true
 {{- end }}

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -895,8 +895,6 @@ secret:
 serviceAccount:
   # -- Service Account annotations. [Reference][annotations].
   annotations: {}
-  # -- Whether to automount the service account's API credentials.
-  automount: true
   # -- Controls whether to create the service account named `serviceAccount.name`.
   create: true
   # -- Name of the service account (existing or to be created) in the namespace `namespace.name` used for deployments.

--- a/tests/unit/helm/serviceaccount_test.go
+++ b/tests/unit/helm/serviceaccount_test.go
@@ -299,7 +299,7 @@ func (s *serviceAccountTemplateTest) TestAutomountServiceAccountToken() {
 			map[string]string{
 				"serviceAccount.automount": "false",
 			},
-			false,
+			true, // We currently don't allow for the overriding of AutomountServiceAccountToken. `initContainers` use them to lookup namespaces.
 		},
 	}
 


### PR DESCRIPTION
# Rationale

In https://github.com/voxel51/fiftyone-teams-app-deploy/pull/359, we aded the ability to override the `automountServiceAccountToken` behavior of the service account. However, at this time, we need that to lookup the namespace for `initContainers`.

We could remove the `.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local/cas/api` in the `initContainers`. For now, it seems safer to just revert to the K8s default.

## Changes

Hard code `automountServiceAccountToken: true` and add test comments.

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
