### PR TITLE
docs(teams-do): Update migration docs to include dropping of builtin

### DIFF
--- a/helm/docs/configuring-delegated-operators.md
+++ b/helm/docs/configuring-delegated-operators.md
@@ -341,6 +341,28 @@ delegatedOperatorDeployments:
           emptyDir: {}
 ```
 
+After this migration, you will have two delegated operators on FiftyOne:
+`builtin` and `teams-do`.
+`builtin` currently has no resources allocated to it and can be safely
+dropped via:
+
+```python
+# Import the FiftyOne Operators Orchestrator
+import fiftyone.operators.orchestrator as foo
+orc_svc = foo.OrchestratorService()
+
+# List the current operators
+for orc in orc_svc.list():
+    print("{} \"{}\" {}".format(orc.instance_id, orc.description, orc.id))
+
+# Delete the builtin operator
+orc_svc.delete(id='builtin')
+
+# Verify there is no longer a `builtin`
+for orc in orc_svc.list():
+    print("{} \"{}\" {}".format(orc.instance_id, orc.description, orc.id))
+```
+
 ## Prior to v2.7.0
 
 This option can be added to any of the three existing


### PR DESCRIPTION
# Rationale

We've seen some instances of our `teams-do` migration leaving two instances floating around: one with resources attached and one without.  The `builtin` operator no longer has a backing replicaset so it hogs the queue. We should add steps to remove it from the application.

## Changes

Add docs on how to remove the `builtin` orchestrator after the migration.

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
