### PR TITLE
Fix incorrect admin role for custom Mongo permissions

### DIFF
--- a/docs/custom-mongodb-permissions.md
+++ b/docs/custom-mongodb-permissions.md
@@ -24,5 +24,5 @@ set of custom permissions may be used as of FiftyOne Teams v2.6.0:
 * `clusterMonitor@admin`
 * `read@admin`
 * `readWrite@cas`
-* `admin@fiftyone`
+* `dbAdmin@fiftyone`
 * `readWrite@fiftyone`


### PR DESCRIPTION
# Rationale

The existing doc incorrectly asks the user to set the `admin` role via `admin@fiftyone`, whereas the correct role should be `dbAdmin` as specified in the [MongoDB docs](https://www.mongodb.com/docs/manual/reference/built-in-roles/#mongodb-authrole-dbAdmin). 

## Changes

Updated with correct authrole.

Checklist

* [* ] This PR maintains parity between Docker Compose and Helm

