### PR TITLE
chore(deps): bump actions/setup-python from 5.5.0 to 5.6.0

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
-      - uses: actions/setup-python@v5.5.0
+      - uses: actions/setup-python@v5.6.0
       - name: Temporary SQLite/LZMA - Install missing libraries
         run: sudo apt install -y libsqlite3-dev libbz2-dev
       - name: install asdf & tools

--- a/.github/workflows/test-docker-pulls.yml
+++ b/.github/workflows/test-docker-pulls.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
-      - uses: actions/setup-python@v5.5.0
+      - uses: actions/setup-python@v5.6.0
       - name: Temporary SQLite/LZMA - Install missing libraries
         run: sudo apt install -y libsqlite3-dev libbz2-dev
       - name: install asdf & tools

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
-      - uses: actions/setup-python@v5.5.0
+      - uses: actions/setup-python@v5.6.0
       - name: install asdf & tools
         uses: asdf-vm/actions/install@1117842ea70e2711a0072e3a71265cbfe2c830be
       - name: Run unit tests
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
-      - uses: actions/setup-python@v5.5.0
+      - uses: actions/setup-python@v5.6.0
       - name: Temporary SQLite/LZMA - Install missing libraries
         run: sudo apt install -y libsqlite3-dev libbz2-dev
       - name: install asdf & tools
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
-      - uses: actions/setup-python@v5.5.0
+      - uses: actions/setup-python@v5.6.0
       - name: install asdf & tools
         uses: asdf-vm/actions/install@1117842ea70e2711a0072e3a71265cbfe2c830be
       - name: Authenticate to Google Cloud

--- a/.github/workflows/test-helm.yml
+++ b/.github/workflows/test-helm.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
-      - uses: actions/setup-python@v5.5.0
+      - uses: actions/setup-python@v5.6.0
       - name: Temporary SQLite/LZMA - Install missing libraries
         run: sudo apt install -y libsqlite3-dev libbz2-dev
       - name: install asdf & tools

--- a/.github/workflows/test-integration-helm.yml
+++ b/.github/workflows/test-integration-helm.yml
@@ -15,7 +15,7 @@ jobs:
       id-token: 'write'
     steps:
       - uses: actions/checkout@v4.2.2
-      - uses: actions/setup-python@v5.5.0
+      - uses: actions/setup-python@v5.6.0
       - name: Temporary SQLite/LZMA - Install missing libraries
         run: sudo apt install -y libsqlite3-dev libbz2-dev
       - name: install asdf & tools


### PR DESCRIPTION
# Rationale

Like https://github.com/voxel51/fiftyone-teams-app-deploy/pull/367 but from a GH user that can run the tests

## Changes

Bumps [actions/setup-python](https://github.com/actions/setup-python) from 5.5.0 to 5.6.0.
- [Release notes](https://github.com/actions/setup-python/releases)
- [Commits](https://github.com/actions/setup-python/compare/v5.5.0...v5.6.0)

---
updated-dependencies:
- dependency-name: actions/setup-python dependency-version: 5.6.0 dependency-type: direct:production update-type: version-update:semver-minor ...


Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
