### PR TITLE
chore: rename job in `.github/workflows/test-docker-pulls.yml`

### DIFF
--- a/.github/workflows/test-docker-pulls.yml
+++ b/.github/workflows/test-docker-pulls.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  unit-helm:
+  docker-pulls:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2


### PR DESCRIPTION
# Rationale

A PR Check on #374 failed.  I was confused by the name "Tests - Artifact Pulls / unit-helm (pull_request)". In the workflow, we don't run unit-helm, we run `validate-docker-pulls.sh`. I suspect this was a result of a copy/paste.

## Changes

* worklow
  * update job name

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

n/a

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
