### PR TITLE
chore(helm): AS-688 adding deployment strategy parameters

### DIFF
--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -501,7 +501,8 @@ follow
 | apiSettings.service.startup.periodSeconds | int | `15` | How often (in seconds) to perform the startup probe for `teams-api`. [Reference][probes]. |
 | apiSettings.service.type | string | `"ClusterIP"` | Service type for `teams-api`. [Reference][service-type]. |
 | apiSettings.tolerations | list | `[]` | Allow the k8s scheduler to schedule pods with matching taints for `teams-api`. [Reference][taints-and-tolerations]. |
-| apiSettings.topologySpreadConstraints | list | `[]` | Control how Pods are spread across your distributed footprint. Label selectors will be defaulted to those of the `teams-api` deployment. [Reference][topology-spread-constraints]. |
+| apiSettings.topologySpreadConstraints | list | `[]` | Control how pods are spread across your distributed footprint. Label selectors will be defaulted to those of the `teams-api` deployment. [Reference][topology-spread-constraints]. |
+| apiSettings.updateStrategy | object | `{"type":"RollingUpdate"}` | Control how `teams-api` pods are redeployed during an upgrade. [Reference][upgrade-strategies] |
 | apiSettings.volumeMounts | list | `[]` | Volume mounts for `teams-api`. [Reference][volumes]. |
 | apiSettings.volumes | list | `[]` | Volumes for `teams-api`. [Reference][volumes]. |
 | appSettings.affinity | object | `{}` | Affinity and anti-affinity for `fiftyone-app`. [Reference][affinity]. |
@@ -546,6 +547,7 @@ follow
 | appSettings.service.type | string | `"ClusterIP"` | Service type for `fiftyone-app`. [Reference][service-type]. |
 | appSettings.tolerations | list | `[]` | Allow the k8s scheduler to schedule `fiftyone-app` pods with matching taints. [Reference][taints-and-tolerations]. |
 | appSettings.topologySpreadConstraints | list | `[]` | Control how Pods are spread across your distributed footprint. Label selectors will be defaulted to those of the `fiftyone-app` deployment. [Reference][topology-spread-constraints]. |
+| appSettings.updateStrategy | object | `{"type":"RollingUpdate"}` | Control how `fiftyone-app` pods are redeployed during an upgrade. [Reference][upgrade-strategies] |
 | appSettings.volumeMounts | list | `[]` | Volume mounts for `fiftyone-app`. [Reference][volumes]. |
 | appSettings.volumes | list | `[]` | Volumes for `fiftyone-app`. [Reference][volumes]. |
 | casSettings.affinity | object | `{}` | Affinity and anti-affinity for `teams-cas`. [Reference][affinity]. |
@@ -586,10 +588,11 @@ follow
 | casSettings.service.type | string | `"ClusterIP"` | Service type for `teams-cas`. [Reference][service-type]. |
 | casSettings.tolerations | list | `[]` | Allow the k8s scheduler to schedule `teams-cas` pods with matching taints. [Reference][taints-and-tolerations]. |
 | casSettings.topologySpreadConstraints | list | `[]` | Control how Pods are spread across your distributed footprint. Label selectors will be defaulted to those of the `teams-cas` deployment. [Reference][topology-spread-constraints]. |
+| casSettings.updateStrategy | object | `{"type":"RollingUpdate"}` | Control how `teams-cas` pods are redeployed during an upgrade. [Reference][upgrade-strategies] |
 | casSettings.volumeMounts | list | `[]` | Volume mounts for `teams-cas`. [Reference][volumes]. |
 | casSettings.volumes | list | `[]` | Volumes for `teams-cas`. [Reference][volumes]. |
 | delegatedOperatorDeployments.deployments | object | `{}` | Additional deployments to configure. Each template will use .Values.delegatedOperatorDeployments.template as a base. Each template value may be overridden. Maps/dictionaries will be merged key-wise, with the deployment instance taking precedence. List values will not be merged, but be overridden completely by the deployment instance. |
-| delegatedOperatorDeployments.template | object | `{"affinity":{},"deploymentAnnotations":{},"description":"","env":{"FIFTYONE_DELEGATED_OPERATION_LOG_PATH":"","FIFTYONE_INTERNAL_SERVICE":true,"FIFTYONE_MEDIA_CACHE_SIZE_BYTES":-1},"image":{"pullPolicy":"Always","repository":"voxel51/fiftyone-teams-cv-full","tag":""},"labels":{},"liveness":{"failureThreshold":5,"periodSeconds":30,"timeoutSeconds":30},"nodeSelector":{},"podAnnotations":{},"podDisruptionBudget":{"enabled":false,"minAvailable":""},"podSecurityContext":{},"readiness":{"failureThreshold":5,"periodSeconds":30,"timeoutSeconds":30},"replicaCount":3,"resources":{"limits":{},"requests":{}},"secretEnv":{},"securityContext":{},"startup":{"failureThreshold":5,"periodSeconds":30,"timeoutSeconds":30},"tolerations":[],"topologySpreadConstraints":[],"volumeMounts":[],"volumes":[]}` | A common template applied to all deployments. Each deployment can then override individual fields as needed by the operator. |
+| delegatedOperatorDeployments.template | object | `{"affinity":{},"deploymentAnnotations":{},"description":"","env":{"FIFTYONE_DELEGATED_OPERATION_LOG_PATH":"","FIFTYONE_INTERNAL_SERVICE":true,"FIFTYONE_MEDIA_CACHE_SIZE_BYTES":-1},"image":{"pullPolicy":"Always","repository":"voxel51/fiftyone-teams-cv-full","tag":""},"labels":{},"liveness":{"failureThreshold":5,"periodSeconds":30,"timeoutSeconds":30},"nodeSelector":{},"podAnnotations":{},"podDisruptionBudget":{"enabled":false,"minAvailable":""},"podSecurityContext":{},"readiness":{"failureThreshold":5,"periodSeconds":30,"timeoutSeconds":30},"replicaCount":3,"resources":{"limits":{},"requests":{}},"secretEnv":{},"securityContext":{},"startup":{"failureThreshold":5,"periodSeconds":30,"timeoutSeconds":30},"tolerations":[],"topologySpreadConstraints":[],"updateStrategy":{"type":"RollingUpdate"},"volumeMounts":[],"volumes":[]}` | A common template applied to all deployments. Each deployment can then override individual fields as needed by the operator. |
 | delegatedOperatorDeployments.template.affinity | object | `{}` | Affinity and anti-affinity for `delegated-operator-executor`. [Reference][affinity]. |
 | delegatedOperatorDeployments.template.deploymentAnnotations | object | `{}` | Annotations for the `teams-do` deployment. [Reference][annotations]. |
 | delegatedOperatorDeployments.template.description | string | `""` | A description for the delegated operator instance. This is unused in the template context. Each operator should either set their own description or, optionally, use the default. If unset at the operator context, it will be defaulted to `Long running operations delegated to $name` where `$name` is the name of the Deployment object. |
@@ -620,6 +623,7 @@ follow
 | delegatedOperatorDeployments.template.startup.timeoutSeconds | int | `30` | Timeout for the startup probe for the `teams-do`. [Reference][probes]. |
 | delegatedOperatorDeployments.template.tolerations | list | `[]` | Allow the k8s scheduler to schedule delegated-operator-executor pods with matching taints. [Reference][taints-and-tolerations]. |
 | delegatedOperatorDeployments.template.topologySpreadConstraints | list | `[]` | Control how Pods are spread across your distributed footprint. Label selectors will be defaulted to those of the `teams-do` deployment(s). [Reference][topology-spread-constraints]. |
+| delegatedOperatorDeployments.template.updateStrategy | object | `{"type":"RollingUpdate"}` | Control how `teams-do` pods are redeployed during an upgrade. [Reference][upgrade-strategies] |
 | delegatedOperatorDeployments.template.volumeMounts | list | `[]` | Volume mounts for delegated-operator-executor pods. [Reference][volumes]. |
 | delegatedOperatorDeployments.template.volumes | list | `[]` | Volumes for `delegated-operator-executor`. [Reference][volumes]. |
 | delegatedOperatorExecutorSettings.affinity | object | `{}` | Affinity and anti-affinity for `delegated-operator-executor`. [Reference][affinity]. |
@@ -655,6 +659,7 @@ follow
 | delegatedOperatorExecutorSettings.startup.timeoutSeconds | int | `30` | Timeout for the startup probe for the `teams-do`. [Reference][probes]. |
 | delegatedOperatorExecutorSettings.tolerations | list | `[]` | Allow the k8s scheduler to schedule delegated-operator-executor pods with matching taints. [Reference][taints-and-tolerations]. |
 | delegatedOperatorExecutorSettings.topologySpreadConstraints | list | `[]` | Control how Pods are spread across your distributed footprint. Label selectors will be defaulted to those of the `teams-do` deployment. [Reference][topology-spread-constraints]. |
+| delegatedOperatorExecutorSettings.updateStrategy | object | `{"type":"RollingUpdate"}` | Control how `teams-do` pods are redeployed during an upgrade. [Reference][upgrade-strategies] |
 | delegatedOperatorExecutorSettings.volumeMounts | list | `[]` | Volume mounts for delegated-operator-executor pods. [Reference][volumes]. |
 | delegatedOperatorExecutorSettings.volumes | list | `[]` | Volumes for `delegated-operator-executor`. [Reference][volumes]. |
 | fiftyoneLicenseSecrets | list | `["fiftyone-license"]` | List of secrets for FiftyOne Enterprise Licenses (one per org) |
@@ -718,6 +723,7 @@ follow
 | pluginsSettings.service.type | string | `"ClusterIP"` | Service type for `teams-plugins`. [Reference][service-type]. |
 | pluginsSettings.tolerations | list | `[]` | Allow the k8s scheduler to schedule `teams-plugins` pods with matching taints. [Reference][taints-and-tolerations]. |
 | pluginsSettings.topologySpreadConstraints | list | `[]` | Control how Pods are spread across your distributed footprint. Label selectors will be defaulted to those of the `teams-plugins` deployment. [Reference][topology-spread-constraints]. |
+| pluginsSettings.updateStrategy | object | `{"type":"RollingUpdate"}` | Control how `teams-plugins` pods are redeployed during an upgrade. [Reference][upgrade-strategies] |
 | pluginsSettings.volumeMounts | list | `[]` | Volume mounts for `teams-plugins` pods. [Reference][volumes]. |
 | pluginsSettings.volumes | list | `[]` | Volumes for `teams-plugins`. [Reference][volumes]. |
 | secret.create | bool | `true` | Controls whether to create the secret named `secret.name`. |
@@ -779,6 +785,7 @@ follow
 | teamsAppSettings.service.type | string | `"ClusterIP"` | Service type for `teams-app`.  [Reference][service-type]. |
 | teamsAppSettings.tolerations | list | `[]` | Allow the k8s scheduler to schedule `teams-app` pods with matching taints. [Reference][taints-and-tolerations]. |
 | teamsAppSettings.topologySpreadConstraints | list | `[]` | Control how Pods are spread across your distributed footprint. Label selectors will be defaulted to those of the `teams-app` deployment. [Reference][topology-spread-constraints]. |
+| teamsAppSettings.updateStrategy | object | `{"type":"RollingUpdate"}` | Control how `teams-app` pods are redeployed during an upgrade. [Reference][upgrade-strategies] |
 | teamsAppSettings.volumeMounts | list | `[]` | Volume mounts for `teams-app` pods. [Reference][volumes]. |
 | teamsAppSettings.volumes | list | `[]` | Volumes for `teams-app` pods. [Reference][volumes]. |
 
@@ -789,6 +796,8 @@ follow
 [configure-ha-teams-api]: #highly-available-fiftyone-teams-api-deployments
 [container-security-context]: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 [deployment]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
+[fiftyone-config]: https://docs.voxel51.com/user_guide/config.html
+[fiftyone-encryption-key]: https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/fiftyone-teams-app/#storage-credentials-and-fiftyone_encryption_key
 [image-pull-policy]: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
 [image-pull-secrets]: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
 [ingress-default-ingress-class]: https://kubernetes.io/docs/concepts/services-networking/ingress/#default-ingress-class
@@ -810,6 +819,5 @@ follow
 [service-type]: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
 [taints-and-tolerations]: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
 [topology-spread-constraints]: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+[upgrade-strategies]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
 [volumes]: https://kubernetes.io/docs/concepts/storage/volumes/
-[fiftyone-encryption-key]: https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/fiftyone-teams-app/#storage-credentials-and-fiftyone_encryption_key
-[fiftyone-config]: https://docs.voxel51.com/user_guide/config.html

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -479,6 +479,8 @@ follow
 [configure-ha-teams-api]: #highly-available-fiftyone-teams-api-deployments
 [container-security-context]: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 [deployment]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
+[fiftyone-config]: https://docs.voxel51.com/user_guide/config.html
+[fiftyone-encryption-key]: https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/fiftyone-teams-app/#storage-credentials-and-fiftyone_encryption_key
 [image-pull-policy]: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
 [image-pull-secrets]: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
 [ingress-default-ingress-class]: https://kubernetes.io/docs/concepts/services-networking/ingress/#default-ingress-class
@@ -500,6 +502,5 @@ follow
 [service-type]: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
 [taints-and-tolerations]: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
 [topology-spread-constraints]: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+[upgrade-strategies]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
 [volumes]: https://kubernetes.io/docs/concepts/storage/volumes/
-[fiftyone-encryption-key]: https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/fiftyone-teams-app/#storage-credentials-and-fiftyone_encryption_key
-[fiftyone-config]: https://docs.voxel51.com/user_guide/config.html

--- a/helm/fiftyone-teams-app/templates/api-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/api-deployment.yaml
@@ -20,6 +20,8 @@ spec:
     matchLabels:
       app: {{ include "teams-api.name" . }}
       {{- include "fiftyone-teams-api.selectorLabels" . | nindent 6 }}
+  strategy:
+    {{- toYaml .Values.apiSettings.updateStrategy | nindent 4 }}
   template:
     metadata:
       {{- with .Values.apiSettings.podAnnotations }}

--- a/helm/fiftyone-teams-app/templates/app-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/app-deployment.yaml
@@ -16,6 +16,8 @@ spec:
   selector:
     matchLabels:
       {{- include "fiftyone-app.selectorLabels" . | nindent 6 }}
+  strategy:
+    {{- toYaml .Values.appSettings.updateStrategy | nindent 4 }}
   template:
     metadata:
       {{- with .Values.appSettings.podAnnotations }}

--- a/helm/fiftyone-teams-app/templates/cas-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/cas-deployment.yaml
@@ -14,6 +14,8 @@ spec:
   selector:
     matchLabels:
       {{- include "fiftyone-teams-cas.selectorLabels" . | nindent 6 }}
+  strategy:
+    {{- toYaml .Values.casSettings.updateStrategy | nindent 4 }}
   template:
     metadata:
       {{- with .Values.casSettings.podAnnotations }}

--- a/helm/fiftyone-teams-app/templates/delegated-operator-executor-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/delegated-operator-executor-deployment.yaml
@@ -15,6 +15,8 @@ spec:
   selector:
     matchLabels:
       {{- include "delegated-operator-executor.selectorLabels" . | nindent 6 }}
+  strategy:
+    {{- toYaml .Values.delegatedOperatorExecutorSettings.updateStrategy | nindent 4 }}
   template:
     metadata:
       {{- with .Values.delegatedOperatorExecutorSettings.podAnnotations }}

--- a/helm/fiftyone-teams-app/templates/delegated-operator-instance-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/delegated-operator-instance-deployment.yaml
@@ -13,6 +13,7 @@
   )
 }}
 {{- $defaultDescription := printf "Long running operations delegated to %s" $name }}
+{{- $updateStrategy := merge (dict) ($v.updateStrategy|default dict) ($baseTpl.updateStrategy) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -29,6 +30,8 @@ spec:
   selector:
     matchLabels:
       {{- include "delegated-operator-deployments.selectorLabels" $labelContext | nindent 6 }}
+  strategy:
+    {{- toYaml $updateStrategy | nindent 4 }}
   template:
     metadata:
       {{- with (merge (dict) ($v.podAnnotations|default dict) ($baseTpl.podAnnotations)) }}

--- a/helm/fiftyone-teams-app/templates/plugins-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/plugins-deployment.yaml
@@ -17,6 +17,8 @@ spec:
   selector:
     matchLabels:
       {{- include "teams-plugins.selectorLabels" . | nindent 6 }}
+  strategy:
+    {{- toYaml .Values.pluginsSettings.updateStrategy | nindent 4 }}
   template:
     metadata:
       {{- with .Values.pluginsSettings.podAnnotations }}

--- a/helm/fiftyone-teams-app/templates/teams-app-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/teams-app-deployment.yaml
@@ -16,6 +16,8 @@ spec:
   selector:
     matchLabels:
       {{- include "teams-app.selectorLabels" . | nindent 6 }}
+  strategy:
+    {{- toYaml .Values.teamsAppSettings.updateStrategy | nindent 4 }}
   template:
     metadata:
       {{- with .Values.teamsAppSettings.podAnnotations }}

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -127,9 +127,14 @@ apiSettings:
   securityContext: {}
   # -- Allow the k8s scheduler to schedule pods with matching taints for `teams-api`. [Reference][taints-and-tolerations].
   tolerations: []
-  # -- Control how Pods are spread across your distributed footprint.
+  # -- Control how pods are spread across your distributed footprint.
   # Label selectors will be defaulted to those of the `teams-api` deployment. [Reference][topology-spread-constraints].
   topologySpreadConstraints: []
+  # -- Control how `teams-api` pods are redeployed during an upgrade. [Reference][upgrade-strategies]
+  updateStrategy:
+    type: RollingUpdate
+    # rollingUpdate:
+    #   maxUnavailable: 1
   # -- Volume mounts for `teams-api`. [Reference][volumes].
   volumeMounts: []
   # -- Volumes for `teams-api`. [Reference][volumes].
@@ -276,6 +281,11 @@ appSettings:
   # -- Control how Pods are spread across your distributed footprint.
   # Label selectors will be defaulted to those of the `fiftyone-app` deployment. [Reference][topology-spread-constraints].
   topologySpreadConstraints: []
+  # -- Control how `fiftyone-app` pods are redeployed during an upgrade. [Reference][upgrade-strategies]
+  updateStrategy:
+    type: RollingUpdate
+    # rollingUpdate:
+    #   maxUnavailable: 1
   # -- Volume mounts for `fiftyone-app`. [Reference][volumes].
   volumeMounts: []
   # -- Volumes for `fiftyone-app`. [Reference][volumes].
@@ -411,6 +421,11 @@ casSettings:
   # -- Control how Pods are spread across your distributed footprint.
   # Label selectors will be defaulted to those of the `teams-cas` deployment. [Reference][topology-spread-constraints].
   topologySpreadConstraints: []
+  # -- Control how `teams-cas` pods are redeployed during an upgrade. [Reference][upgrade-strategies]
+  updateStrategy:
+    type: RollingUpdate
+    # rollingUpdate:
+    #   maxUnavailable: 1
   # -- Volume mounts for `teams-cas`. [Reference][volumes].
   volumeMounts: []
   # -- Volumes for `teams-cas`. [Reference][volumes].
@@ -524,6 +539,11 @@ delegatedOperatorExecutorSettings:
   # -- Control how Pods are spread across your distributed footprint.
   # Label selectors will be defaulted to those of the `teams-do` deployment. [Reference][topology-spread-constraints].
   topologySpreadConstraints: []
+  # -- Control how `teams-do` pods are redeployed during an upgrade. [Reference][upgrade-strategies]
+  updateStrategy:
+    type: RollingUpdate
+    # rollingUpdate:
+    #   maxUnavailable: 1
   # -- Volume mounts for delegated-operator-executor pods. [Reference][volumes].
   volumeMounts: []
   # -- Volumes for `delegated-operator-executor`. [Reference][volumes].
@@ -637,6 +657,11 @@ delegatedOperatorDeployments:
     # -- Control how Pods are spread across your distributed footprint.
     # Label selectors will be defaulted to those of the `teams-do` deployment(s). [Reference][topology-spread-constraints].
     topologySpreadConstraints: []
+    # -- Control how `teams-do` pods are redeployed during an upgrade. [Reference][upgrade-strategies]
+    updateStrategy:
+      type: RollingUpdate
+      # rollingUpdate:
+      #   maxUnavailable: 1
     # -- Allow the k8s scheduler to schedule delegated-operator-executor pods with matching taints. [Reference][taints-and-tolerations].
     tolerations: []
     # -- Volume mounts for delegated-operator-executor pods. [Reference][volumes].
@@ -862,6 +887,11 @@ pluginsSettings:
   # -- Control how Pods are spread across your distributed footprint.
   # Label selectors will be defaulted to those of the `teams-plugins` deployment. [Reference][topology-spread-constraints].
   topologySpreadConstraints: []
+  # -- Control how `teams-plugins` pods are redeployed during an upgrade. [Reference][upgrade-strategies]
+  updateStrategy:
+    type: RollingUpdate
+    # rollingUpdate:
+    #   maxUnavailable: 1
   # -- Volume mounts for `teams-plugins` pods. [Reference][volumes].
   volumeMounts: []
   # -- Volumes for `teams-plugins`. [Reference][volumes].
@@ -1062,6 +1092,11 @@ teamsAppSettings:
   # -- Control how Pods are spread across your distributed footprint.
   # Label selectors will be defaulted to those of the `teams-app` deployment. [Reference][topology-spread-constraints].
   topologySpreadConstraints: []
+  # -- Control how `teams-app` pods are redeployed during an upgrade. [Reference][upgrade-strategies]
+  updateStrategy:
+    type: RollingUpdate
+    # rollingUpdate:
+    #   maxUnavailable: 1
   # -- Volume mounts for `teams-app` pods. [Reference][volumes].
   volumeMounts: []
   # -- Volumes for `teams-app` pods. [Reference][volumes].

--- a/tests/unit/helm/api-deployment_test.go
+++ b/tests/unit/helm/api-deployment_test.go
@@ -2270,3 +2270,76 @@ func (s *deploymentApiTemplateTest) TestVolumes() {
 		})
 	}
 }
+
+func (s *deploymentApiTemplateTest) TestDeploymentUpdateStrategy() {
+	testCases := []struct {
+		name     string
+		values   map[string]string
+		expected func(deploymentStrategy appsv1.DeploymentStrategy)
+	}{
+		{
+			"defaultValues",
+			nil,
+			func(deploymentStrategy appsv1.DeploymentStrategy) {
+				expectedJSON := `{
+            "type": "RollingUpdate"
+          }`
+				var expectedDeploymentStrategy appsv1.DeploymentStrategy
+				err := json.Unmarshal([]byte(expectedJSON), &expectedDeploymentStrategy)
+				s.NoError(err)
+				s.Equal(expectedDeploymentStrategy, deploymentStrategy, "Deployment strategies should be equal")
+			},
+		},
+		{
+			"overrideUpdateStrategyType",
+			map[string]string{
+				"apiSettings.updateStrategy.type": "Recreate",
+			},
+			func(deploymentStrategy appsv1.DeploymentStrategy) {
+				expectedJSON := `{
+            "type": "Recreate"
+          }`
+				var expectedDeploymentStrategy appsv1.DeploymentStrategy
+				err := json.Unmarshal([]byte(expectedJSON), &expectedDeploymentStrategy)
+				s.NoError(err)
+				s.Equal(expectedDeploymentStrategy, deploymentStrategy, "Deployment strategies should be equal")
+			},
+		},
+		{
+			"overrideUpdateStrategyRollingUpdate",
+			map[string]string{
+				"apiSettings.updateStrategy.type":                         "RollingUpdate",
+				"apiSettings.updateStrategy.rollingUpdate.maxUnavailable": "5",
+			},
+			func(deploymentStrategy appsv1.DeploymentStrategy) {
+				expectedJSON := `{
+            "type": "RollingUpdate",
+            "rollingUpdate": {
+              "maxUnavailable": 5
+            }
+          }`
+				var expectedDeploymentStrategy appsv1.DeploymentStrategy
+				err := json.Unmarshal([]byte(expectedJSON), &expectedDeploymentStrategy)
+				s.NoError(err)
+				s.Equal(expectedDeploymentStrategy, deploymentStrategy, "Deployment strategies should be equal")
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		s.Run(testCase.name, func() {
+			subT := s.T()
+			subT.Parallel()
+
+			options := &helm.Options{SetValues: testCase.values}
+			output := helm.RenderTemplate(subT, options, s.chartPath, s.releaseName, s.templates)
+
+			var deployment appsv1.Deployment
+			helm.UnmarshalK8SYaml(subT, output, &deployment)
+
+			testCase.expected(deployment.Spec.Strategy)
+		})
+	}
+}

--- a/tests/unit/helm/cas-deployment_test.go
+++ b/tests/unit/helm/cas-deployment_test.go
@@ -2241,3 +2241,76 @@ func (s *deploymentCasTemplateTest) TestVolumes() {
 		})
 	}
 }
+
+func (s *deploymentCasTemplateTest) TestDeploymentUpdateStrategy() {
+	testCases := []struct {
+		name     string
+		values   map[string]string
+		expected func(deploymentStrategy appsv1.DeploymentStrategy)
+	}{
+		{
+			"defaultValues",
+			nil,
+			func(deploymentStrategy appsv1.DeploymentStrategy) {
+				expectedJSON := `{
+            "type": "RollingUpdate"
+          }`
+				var expectedDeploymentStrategy appsv1.DeploymentStrategy
+				err := json.Unmarshal([]byte(expectedJSON), &expectedDeploymentStrategy)
+				s.NoError(err)
+				s.Equal(expectedDeploymentStrategy, deploymentStrategy, "Deployment strategies should be equal")
+			},
+		},
+		{
+			"overrideUpdateStrategyType",
+			map[string]string{
+				"casSettings.updateStrategy.type": "Recreate",
+			},
+			func(deploymentStrategy appsv1.DeploymentStrategy) {
+				expectedJSON := `{
+            "type": "Recreate"
+          }`
+				var expectedDeploymentStrategy appsv1.DeploymentStrategy
+				err := json.Unmarshal([]byte(expectedJSON), &expectedDeploymentStrategy)
+				s.NoError(err)
+				s.Equal(expectedDeploymentStrategy, deploymentStrategy, "Deployment strategies should be equal")
+			},
+		},
+		{
+			"overrideUpdateStrategyRollingUpdate",
+			map[string]string{
+				"casSettings.updateStrategy.type":                         "RollingUpdate",
+				"casSettings.updateStrategy.rollingUpdate.maxUnavailable": "5",
+			},
+			func(deploymentStrategy appsv1.DeploymentStrategy) {
+				expectedJSON := `{
+            "type": "RollingUpdate",
+            "rollingUpdate": {
+              "maxUnavailable": 5
+            }
+          }`
+				var expectedDeploymentStrategy appsv1.DeploymentStrategy
+				err := json.Unmarshal([]byte(expectedJSON), &expectedDeploymentStrategy)
+				s.NoError(err)
+				s.Equal(expectedDeploymentStrategy, deploymentStrategy, "Deployment strategies should be equal")
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		s.Run(testCase.name, func() {
+			subT := s.T()
+			subT.Parallel()
+
+			options := &helm.Options{SetValues: testCase.values}
+			output := helm.RenderTemplate(subT, options, s.chartPath, s.releaseName, s.templates)
+
+			var deployment appsv1.Deployment
+			helm.UnmarshalK8SYaml(subT, output, &deployment)
+
+			testCase.expected(deployment.Spec.Strategy)
+		})
+	}
+}

--- a/tests/unit/helm/delegated-operator-executor-deployment_test.go
+++ b/tests/unit/helm/delegated-operator-executor-deployment_test.go
@@ -2297,3 +2297,99 @@ func (s *deploymentDelegatedOperatorExecutorTemplateTest) TestContainerStartupPr
 		})
 	}
 }
+
+func (s *deploymentDelegatedOperatorExecutorTemplateTest) TestDeploymentUpdateStrategy() {
+	testCases := []struct {
+		name     string
+		values   map[string]string
+		expected func(deploymentStrategy appsv1.DeploymentStrategy)
+	}{
+		{
+			"defaultValues",
+			nil,
+			func(deploymentStrategy appsv1.DeploymentStrategy) {
+				s.Empty(deploymentStrategy.Type, "Type should be be empty")
+			},
+		},
+		{
+			"defaultValuesDelegatedOperatorsEnabled",
+			map[string]string{
+				"delegatedOperatorExecutorSettings.enabled": "true",
+			},
+			func(deploymentStrategy appsv1.DeploymentStrategy) {
+				expectedJSON := `{
+            "type": "RollingUpdate"
+          }`
+				var expectedDeploymentStrategy appsv1.DeploymentStrategy
+				err := json.Unmarshal([]byte(expectedJSON), &expectedDeploymentStrategy)
+				s.NoError(err)
+				s.Equal(expectedDeploymentStrategy, deploymentStrategy, "Deployment strategies should be equal")
+			},
+		},
+		{
+			"overrideUpdateStrategyType",
+			map[string]string{
+				"delegatedOperatorExecutorSettings.enabled":             "true",
+				"delegatedOperatorExecutorSettings.updateStrategy.type": "Recreate",
+			},
+			func(deploymentStrategy appsv1.DeploymentStrategy) {
+				expectedJSON := `{
+            "type": "Recreate"
+          }`
+				var expectedDeploymentStrategy appsv1.DeploymentStrategy
+				err := json.Unmarshal([]byte(expectedJSON), &expectedDeploymentStrategy)
+				s.NoError(err)
+				s.Equal(expectedDeploymentStrategy, deploymentStrategy, "Deployment strategies should be equal")
+			},
+		},
+		{
+			"overrideUpdateStrategyRollingUpdate",
+			map[string]string{
+				"delegatedOperatorExecutorSettings.enabled":                                     "true",
+				"delegatedOperatorExecutorSettings.updateStrategy.type":                         "RollingUpdate",
+				"delegatedOperatorExecutorSettings.updateStrategy.rollingUpdate.maxUnavailable": "5",
+			},
+			func(deploymentStrategy appsv1.DeploymentStrategy) {
+				expectedJSON := `{
+            "type": "RollingUpdate",
+            "rollingUpdate": {
+              "maxUnavailable": 5
+            }
+          }`
+				var expectedDeploymentStrategy appsv1.DeploymentStrategy
+				err := json.Unmarshal([]byte(expectedJSON), &expectedDeploymentStrategy)
+				s.NoError(err)
+				s.Equal(expectedDeploymentStrategy, deploymentStrategy, "Deployment strategies should be equal")
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		s.Run(testCase.name, func() {
+			subT := s.T()
+			subT.Parallel()
+
+			options := &helm.Options{SetValues: testCase.values}
+			var deployment appsv1.Deployment
+
+			if testCase.values == nil {
+
+				output, err := helm.RenderTemplateE(subT, options, s.chartPath, s.releaseName, s.templates)
+
+				s.ErrorContains(err, "could not find template templates/delegated-operator-executor-deployment.yaml in chart")
+
+				helm.UnmarshalK8SYaml(subT, output, &deployment)
+
+				testCase.expected(deployment.Spec.Strategy)
+			} else {
+				output := helm.RenderTemplate(subT, options, s.chartPath, s.releaseName, s.templates)
+
+				helm.UnmarshalK8SYaml(subT, output, &deployment)
+
+				testCase.expected(deployment.Spec.Strategy)
+			}
+		})
+	}
+}

--- a/tests/unit/helm/teams-app-deployment_test.go
+++ b/tests/unit/helm/teams-app-deployment_test.go
@@ -2415,3 +2415,76 @@ func (s *deploymentTeamsAppTemplateTest) TestVolumes() {
 		})
 	}
 }
+
+func (s *deploymentTeamsAppTemplateTest) TestDeploymentUpdateStrategy() {
+	testCases := []struct {
+		name     string
+		values   map[string]string
+		expected func(deploymentStrategy appsv1.DeploymentStrategy)
+	}{
+		{
+			"defaultValues",
+			nil,
+			func(deploymentStrategy appsv1.DeploymentStrategy) {
+				expectedJSON := `{
+            "type": "RollingUpdate"
+          }`
+				var expectedDeploymentStrategy appsv1.DeploymentStrategy
+				err := json.Unmarshal([]byte(expectedJSON), &expectedDeploymentStrategy)
+				s.NoError(err)
+				s.Equal(expectedDeploymentStrategy, deploymentStrategy, "Deployment strategies should be equal")
+			},
+		},
+		{
+			"overrideUpdateStrategyType",
+			map[string]string{
+				"teamsAppSettings.updateStrategy.type": "Recreate",
+			},
+			func(deploymentStrategy appsv1.DeploymentStrategy) {
+				expectedJSON := `{
+            "type": "Recreate"
+          }`
+				var expectedDeploymentStrategy appsv1.DeploymentStrategy
+				err := json.Unmarshal([]byte(expectedJSON), &expectedDeploymentStrategy)
+				s.NoError(err)
+				s.Equal(expectedDeploymentStrategy, deploymentStrategy, "Deployment strategies should be equal")
+			},
+		},
+		{
+			"overrideUpdateStrategyRollingUpdate",
+			map[string]string{
+				"teamsAppSettings.updateStrategy.type":                         "RollingUpdate",
+				"teamsAppSettings.updateStrategy.rollingUpdate.maxUnavailable": "5",
+			},
+			func(deploymentStrategy appsv1.DeploymentStrategy) {
+				expectedJSON := `{
+            "type": "RollingUpdate",
+            "rollingUpdate": {
+              "maxUnavailable": 5
+            }
+          }`
+				var expectedDeploymentStrategy appsv1.DeploymentStrategy
+				err := json.Unmarshal([]byte(expectedJSON), &expectedDeploymentStrategy)
+				s.NoError(err)
+				s.Equal(expectedDeploymentStrategy, deploymentStrategy, "Deployment strategies should be equal")
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		s.Run(testCase.name, func() {
+			subT := s.T()
+			subT.Parallel()
+
+			options := &helm.Options{SetValues: testCase.values}
+			output := helm.RenderTemplate(subT, options, s.chartPath, s.releaseName, s.templates)
+
+			var deployment appsv1.Deployment
+			helm.UnmarshalK8SYaml(subT, output, &deployment)
+
+			testCase.expected(deployment.Spec.Strategy)
+		})
+	}
+}


### PR DESCRIPTION
# Rationale

There are some cases where a customer needs to use a `Recreate` strategy instead of the default `RollingUpgrade` strategy on their deployment objects. For example, if a customer has a specific hardware limit that rolling upgrades can't accommodate. We should allow these for those cases and for all of the deployment objects we provision. This PR aims to add that capability.

*NOTE*

For `delegatedOperatorDeployments`, the following is a possible case:

```yaml
delegatedOperatorDeployments:
  template:
    updateStrategy:
      type: RollingUpgrade
      rollingUpgrade:
       maxUnavailable: 5
  deployments:
    teamsDo: {}
    teamsDoTwo:
      updateStrategy:
        type: Recreate
```

This would result in 

```yaml
# Source: fiftyone-teams-app/templates/delegated-operator-instance-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: teams-do-two
  namespace: fiftyone-teams
  labels:
    helm.sh/chart: fiftyone-teams-app-2.9.0
    app.kubernetes.io/version: "v2.9.0"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: teams-do-two
    app.kubernetes.io/instance: release-name
spec:
  replicas: 3
  selector:
    matchLabels:
      app.kubernetes.io/name: teams-do-two
      app.kubernetes.io/instance: release-name
  strategy:
    rollingUpgrade:
      maxUnavailable: 5
    type: Recreate
  template:
    metadata:
      labels: 
        app.kubernetes.io/name: teams-do-two
        app.kubernetes.io/instance: release-name
```

This is a design decision so that we adhere to our method of dict-wise merging. We give people this flexibility in other places and enforcing structure in select places seems odd.

## Changes

Adds `updateStrategy` to each deployment object. An example is below:

```yaml
  strategy:
    {{- toYaml .Values.appSettings.updateStrategy | nindent 4 }}
```

Adds `updateStrategy` to each values block. An example is below:

```yaml
  updateStrategy:
    type: RollingUpdate
    # rollingUpdate:
    #   maxUnavailable: 1
```

Updates tests and docs accordingly.

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

Go tests are added.
Helm templating for manual inspection:

```yaml
# Test yaml file
delegatedOperatorDeployments:
  template:
    updateStrategy:
      type: RollingUpgrade
      rollingUpgrade:
       maxUnavailable: 5
  deployments:
    teamsDo: {}
    teamsDoTwo:
      updateStrategy:
        type: Recreate
```

```yaml
# result
% helm template . -f f.yaml | grep -B2 -A4 strategy
      app.kubernetes.io/name: teams-api
      app.kubernetes.io/instance: release-name
  strategy:
    type: RollingUpdate
  template:
    metadata:
      labels:
--
      app.kubernetes.io/name: fiftyone-app
      app.kubernetes.io/instance: release-name
  strategy:
    type: RollingUpdate
  template:
    metadata:
      labels:
--
      app.kubernetes.io/name: teams-cas
      app.kubernetes.io/instance: release-name
  strategy:
    type: RollingUpdate
  template:
    metadata:
      labels:
--
      app.kubernetes.io/name: teams-do
      app.kubernetes.io/instance: release-name
  strategy:
    rollingUpgrade:
      maxUnavailable: 5
    type: RollingUpgrade
  template:
--
      app.kubernetes.io/name: teams-do-two
      app.kubernetes.io/instance: release-name
  strategy:
    rollingUpgrade:
      maxUnavailable: 5
    type: Recreate
  template:
--
      app.kubernetes.io/name: fiftyone-teams-app
      app.kubernetes.io/instance: release-name
  strategy:
    type: RollingUpdate
  template:
    metadata:
      labels:
```

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
