### PR TITLE
docs(DATABASE_ADMIN): AS-578 remove `FIFTYONE_DATABASE_ADMIN=true`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -238,7 +238,6 @@ It takes a few minutes for the deployments to stabilize as
 we wait for Helm to install MongoDB and cert-managed (for self-signed certificates).
 The fiftyone-teams app installation also takes a few minutes.
 The fiftyone-app will start and upgrade the database
-(because `FIFTYONE_DATABASE_ADMIN: true`)
 and the teams-api will connect to and configure MongoDB.
 
 We use Skaffold "profiles" to control "modules".

--- a/docker/README.md
+++ b/docker/README.md
@@ -50,13 +50,26 @@ Please refer to the
 [upgrade documentation](./docs/upgrading.md#fiftyone-enterprise-v25-delegated-operator-changes)
 for steps on how to upgrade your delegated operators.
 
+### Version 2.9+ Installation Changes
+
+FiftyOne Enterprise v2.9 no longer requires that operators set the
+following `FIFTYONE_DATABASE_ADMIN` variable while doing an initial installation:
+
+```yaml
+# Required prior to 2.9.0
+services:
+  fiftyone-app:
+    environment:
+      FIFTYONE_DATABASE_ADMIN: true
+```
+
 ## Table of Contents
 
 <!-- toc -->
 
 - [Requirements](#requirements)
 - [Usage](#usage)
-- [Initial Installation vs. Upgrades](#initial-installation-vs-upgrades)
+- [Upgrades](#upgrades)
 - [Known Issues](#known-issues)
 - [Advanced Configuration](#advanced-configuration)
   - [Builtin Delegated Operator Orchestrator](#builtin-delegated-operator-orchestrator)
@@ -133,15 +146,6 @@ To deploy FiftyOne Enterprise:
        table.
     1. Create a `compose.override.yaml` with any configuration overrides for
        this deployment
-        1. For the first installation, set
-
-            ```yaml
-            services:
-              fiftyone-app:
-                environment:
-                  FIFTYONE_DATABASE_ADMIN: true
-            ```
-
 1. Make sure you have put your Voxel51-provided FiftyOne Enterprise license in the
    local directory identified by the `LOCAL_LICENSE_FILE_DIR` configured in
    your `.env` file.
@@ -150,28 +154,6 @@ To deploy FiftyOne Enterprise:
 
         ```shell
         docker compose up -d
-        ```
-
-1. After the successful installation, and logging into FiftyOne Enterprise
-    1. In `compose.override.yaml`, remove the `FIFTYONE_DATABASE_ADMIN` override
-
-        ```yaml
-        services:
-          fiftyone-app:
-            environment:
-              # FIFTYONE_DATABASE_ADMIN: true
-        ```
-
-        > **NOTE**: This example shows commenting this line,
-        > however you may remove the line.
-
-        or set it to `false` like in
-
-        ```yaml
-        services:
-          fiftyone-app:
-            environment:
-              FIFTYONE_DATABASE_ADMIN: false
         ```
 
 The FiftyOne Enterprise API is exposed on port `8000`.
@@ -188,55 +170,7 @@ for FiftyOne Enterprise App and FiftyOne Enterprise CAS services, and
 [here](./example-nginx-api.conf)
 for the FiftyOne Enterprise API service.
 
-## Initial Installation vs. Upgrades
-
-When performing an initial installation, in `compose.override.yaml` set
-`services.fiftyone-app.environment.FIFTYONE_DATABASE_ADMIN: true`.
-When performing a FiftyOne Enterprise upgrade, set
-`services.fiftyone-app.environment.FIFTYONE_DATABASE_ADMIN: false`.
-See
-[Upgrading From Previous Versions](./docs/upgrading.md)
-
-The environment variable `FIFTYONE_DATABASE_ADMIN`
-controls whether the database may be migrated.
-This is a safety check to prevent automatic database
-upgrades that will break other users' SDK connections.
-When false (or unset), either an error will occur
-
-```shell
-$ fiftyone migrate --all
-Traceback (most recent call last):
-...
-OSError: Cannot migrate database from v0.22.0 to v0.22.3 when database_admin=False.
-```
-
-or no action will be taken:
-
-```shell
-$ fiftyone migrate --info
-FiftyOne Enterprise version: 0.14.4
-
-FiftyOne compatibility version: 0.22.3
-Other compatible versions: >=0.19,<0.23
-
-Database version: 0.21.2
-
-dataset     version
-----------  ---------
-quickstart  0.22.0
-$ fiftyone migrate --all
-$ fiftyone migrate --info
-FiftyOne Enterprise version: 0.14.4
-
-FiftyOne compatibility version: 0.23.0
-Other compatible versions: >=0.19,<0.23
-
-Database version: 0.21.2
-
-dataset     version
-----------  ---------
-quickstart  0.21.2
-```
+## Upgrades
 
 When performing an upgrade, please review
 [Upgrading From Previous Versions](./docs/upgrading.md)

--- a/docker/docs/upgrading.md
+++ b/docker/docs/upgrading.md
@@ -17,6 +17,7 @@
 <!-- toc -->
 
 - [Upgrading From Previous Versions](#upgrading-from-previous-versions)
+  - [A Note On Database Migrations](#a-note-on-database-migrations)
   - [From FiftyOne Enterprise Version 2.0.0 and Later](#from-fiftyone-enterprise-version-200-and-later)
     - [FiftyOne Enterprise v2.7+ Delegated Operator Changes](#fiftyone-enterprise-v27-delegated-operator-changes)
     - [FiftyOne Enterprise v2.5+ Delegated Operator Changes](#fiftyone-enterprise-v25-delegated-operator-changes)
@@ -37,6 +38,43 @@ FiftyOne Enterprise environment.
 If you use custom deployment mechanisms, carefully review the changes in the
 [Docker Compose Files](../)
 and update your deployment accordingly.
+
+### A Note On Database Migrations
+
+The environment variable `FIFTYONE_DATABASE_ADMIN`
+controls whether the database may be migrated.
+This is a safety check to prevent automatic database
+upgrades that will break other users' SDK connections.
+When false (or unset), either an error will occur
+
+```shell
+$ fiftyone migrate --all
+Traceback (most recent call last):
+...
+OSError: Cannot migrate database from v0.22.0 to v0.22.3 when database_admin=False.
+```
+
+or no action will be taken:
+
+```shell
+$ fiftyone migrate --info
+FiftyOne Enterprise version: 0.14.4
+FiftyOne compatibility version: 0.22.3
+Other compatible versions: >=0.19,<0.23
+Database version: 0.21.2
+dataset     version
+----------  ---------
+quickstart  0.22.0
+$ fiftyone migrate --all
+$ fiftyone migrate --info
+FiftyOne Enterprise version: 0.14.4
+FiftyOne compatibility version: 0.23.0
+Other compatible versions: >=0.19,<0.23
+Database version: 0.21.2
+dataset     version
+----------  ---------
+quickstart  0.21.2
+```
 
 ### From FiftyOne Enterprise Version 2.0.0 and Later
 

--- a/helm/docs/upgrading.md
+++ b/helm/docs/upgrading.md
@@ -17,6 +17,7 @@
 <!-- toc -->
 
 - [Upgrading From Previous Versions](#upgrading-from-previous-versions)
+  - [A Note On Database Migrations](#a-note-on-database-migrations)
   - [From FiftyOne Enterprise Version 2.0.0 or Higher](#from-fiftyone-enterprise-version-200-or-higher)
     - [FiftyOne Enterprise v2.8+ `initContainer` Changes](#fiftyone-enterprise-v28-initcontainer-changes)
     - [FiftyOne Enterprise v2.7+ Delegated Operator Changes](#fiftyone-enterprise-v27-delegated-operator-changes)
@@ -76,6 +77,43 @@ A minimal example `values.yaml` may be found
     > ```shell
     > helm diff -C1 upgrade fiftyone-teams-app voxel51/fiftyone-teams-app -f values.yaml
     > ```
+
+### A Note On Database Migrations
+
+The environment variable `FIFTYONE_DATABASE_ADMIN`
+controls whether the database may be migrated.
+This is a safety check to prevent automatic database
+upgrades that will break other users' SDK connections.
+When false (or unset), either an error will occur
+
+```shell
+$ fiftyone migrate --all
+Traceback (most recent call last):
+...
+OSError: Cannot migrate database from v0.22.0 to v0.22.3 when database_admin=False.
+```
+
+or no action will be taken:
+
+```shell
+$ fiftyone migrate --info
+FiftyOne Enterprise version: 0.14.4
+FiftyOne compatibility version: 0.22.3
+Other compatible versions: >=0.19,<0.23
+Database version: 0.21.2
+dataset     version
+----------  ---------
+quickstart  0.22.0
+$ fiftyone migrate --all
+$ fiftyone migrate --info
+FiftyOne Enterprise version: 0.14.4
+FiftyOne compatibility version: 0.23.0
+Other compatible versions: >=0.19,<0.23
+Database version: 0.21.2
+dataset     version
+----------  ---------
+quickstart  0.21.2
+```
 
 ### From FiftyOne Enterprise Version 2.0.0 or Higher
 

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -58,6 +58,18 @@ Please refer to the
 [upgrade documentation](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/upgrading.md#fiftyone-enterprise-v27-delegated-operator-changes)
 for steps on how to upgrade your delegated operators.
 
+### Version 2.9+ Installation Changes
+
+FiftyOne Enterprise v2.9 no longer requires that operators set the
+following `FIFTYONE_DATABASE_ADMIN` variable while doing an initial installation:
+
+```yaml
+# Required prior to 2.9.0
+appSettings:
+  env:
+    FIFTYONE_DATABASE_ADMIN: true
+```
+
 ## Table of Contents
 
 <!-- toc -->
@@ -66,7 +78,7 @@ for steps on how to upgrade your delegated operators.
   - [Kubernetes/Kubectl](#kuberneteskubectl)
   - [Helm](#helm)
 - [Usage](#usage)
-- [Initial Installation vs. Upgrades](#initial-installation-vs-upgrades)
+- [Upgrades](#upgrades)
 - [Advanced Configuration](#advanced-configuration)
   - [Builtin Delegated Operator Orchestrator](#builtin-delegated-operator-orchestrator)
   - [Central Authentication Service](#central-authentication-service)
@@ -183,28 +195,7 @@ helm install fiftyone-teams-app voxel51/fiftyone-teams-app \
 A minimal example `values.yaml` may be found
 [here](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/values.yaml).
 
-## Initial Installation vs. Upgrades
-
-Upgrades are more frequent than new installations.
-The chart's default behavior supports upgrades and the `values.yaml` contains
-
-```yaml
-appSettings:
-  env:
-    FIFTYONE_DATABASE_ADMIN: false
-```
-
-When performing an initial installation,
-in your `values.yaml`, set
-
-```yaml
-appSettings:
-  env:
-    FIFTYONE_DATABASE_ADMIN: true
-```
-
-After the initial installation, we recommend either commenting
-this environment variable or changing the value to `false`.
+## Upgrades
 
 When performing an upgrade, please review
 [Upgrading From Previous Versions](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/upgrading.md).

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -58,6 +58,18 @@ Please refer to the
 [upgrade documentation](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/upgrading.md#fiftyone-enterprise-v27-delegated-operator-changes)
 for steps on how to upgrade your delegated operators.
 
+### Version 2.9+ Installation Changes
+
+FiftyOne Enterprise v2.9 no longer requires that operators set the
+following `FIFTYONE_DATABASE_ADMIN` variable while doing an initial installation:
+
+```yaml
+# Required prior to 2.9.0
+appSettings:
+  env:
+    FIFTYONE_DATABASE_ADMIN: true
+```
+
 ## Table of Contents
 
 <!-- toc -->
@@ -66,7 +78,7 @@ for steps on how to upgrade your delegated operators.
   - [Kubernetes/Kubectl](#kuberneteskubectl)
   - [Helm](#helm)
 - [Usage](#usage)
-- [Initial Installation vs. Upgrades](#initial-installation-vs-upgrades)
+- [Upgrades](#upgrades)
 - [Advanced Configuration](#advanced-configuration)
   - [Builtin Delegated Operator Orchestrator](#builtin-delegated-operator-orchestrator)
   - [Central Authentication Service](#central-authentication-service)
@@ -183,32 +195,10 @@ helm install fiftyone-teams-app voxel51/fiftyone-teams-app \
 A minimal example `values.yaml` may be found
 [here](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/values.yaml).
 
-## Initial Installation vs. Upgrades
-
-Upgrades are more frequent than new installations.
-The chart's default behavior supports upgrades and the `values.yaml` contains
-
-```yaml
-appSettings:
-  env:
-    FIFTYONE_DATABASE_ADMIN: false
-```
-
-When performing an initial installation,
-in your `values.yaml`, set
-
-```yaml
-appSettings:
-  env:
-    FIFTYONE_DATABASE_ADMIN: true
-```
-
-After the initial installation, we recommend either commenting
-this environment variable or changing the value to `false`.
+## Upgrades
 
 When performing an upgrade, please review
 [Upgrading From Previous Versions](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/upgrading.md).
-
 
 ## Advanced Configuration
 

--- a/helm/gke-example/values.yaml
+++ b/helm/gke-example/values.yaml
@@ -49,12 +49,6 @@ secret:
 # apiSettings:
 
 # appSettings:
-#   env:
-#     # FIFTYONE_DATABASE_ADMIN is set to `false` by default
-#     # If you are performing a new install or an upgrade from v1.0 or earlier
-#     # you may want to set this value to `true`.
-#     # Please see https://helm.fiftyone.ai/#initial-installation-vs-upgrades for details
-#     FIFTYONE_DATABASE_ADMIN: false
 
 teamsAppSettings:
   dnsName: replace.this.dns.name

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -72,11 +72,6 @@ secret:
 
 appSettings:
   env:
-    # FIFTYONE_DATABASE_ADMIN is set to `false` by default
-    # If you are performing a new install or an upgrade from v1.0 or earlier you may want to set
-    # this value to `true`.
-    # Please see https://helm.fiftyone.ai/#initial-installation-vs-upgrades for details
-    FIFTYONE_DATABASE_ADMIN: true
     # Set FIFTYONE_PLUGINS_DIR if you are enabling plugins in the `fiftyone-app`
     # deployment
     # See https://github.com/voxel51/fiftyone-teams-app-deploy/tree/main/helm/fiftyone-teams-app#fiftyone-enterprise-plugins

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -59,9 +59,6 @@ deploy:
           # FiftyOne App (fiftyone-app) configurations
           appSettings:
             env:
-              # Only set to true during the initial installation or during a database upgrade
-              # FIFTYONE_DATABASE_ADMIN: false
-              FIFTYONE_DATABASE_ADMIN: true
               # For local development without TLS certs, set `APP_USE_HTTPS=false` to
               # prohibit the app from setting Redirect URL protocol to `https`.
               # Must be set in both `appSettings.env` and `teamsAppSettings.env`.

--- a/tests/fixtures/docker/compose.override.yaml
+++ b/tests/fixtures/docker/compose.override.yaml
@@ -1,4 +1,4 @@
 services:
   fiftyone-app:
     environment:
-      FIFTYONE_DATABASE_ADMIN: true
+      FIFTYONE_DATABASE_ADMIN: false

--- a/tests/fixtures/helm/integration_values.yaml
+++ b/tests/fixtures/helm/integration_values.yaml
@@ -17,9 +17,7 @@ apiSettings:
       initialDelaySeconds: 15
 appSettings:
   env:
-    # Only set to true during the initial installation or during a database upgrade
-    # FIFTYONE_DATABASE_ADMIN: false
-    FIFTYONE_DATABASE_ADMIN: true
+    FIFTYONE_DATABASE_ADMIN: false
     # For local development without TLS certs, set `APP_USE_HTTPS=false` to
     # prohibit the app from setting Redirect URL protocol to `https`.
     # Must be set in both `appSettings.env` and `teamsAppSettings.env`.

--- a/tests/integration/compose/common_test.go
+++ b/tests/integration/compose/common_test.go
@@ -14,8 +14,7 @@ import (
 const (
 	legacyAuthEnvFixtureFilePath   = "../../fixtures/docker/integration_legacy_auth.env"
 	internalAuthFixtureEnvFilePath = "../../fixtures/docker/integration_internal_auth.env"
-	// Override FIFTYONE_DATABASE_ADMIN to true (until we can override via environment variable)
-	overrideFile = "../../tests/fixtures/docker/compose.override.yaml"
+	overrideFile                   = "../../tests/fixtures/docker/compose.override.yaml"
 	// To run the containers on macOS arm64, we need to set the platform
 	darwinOverrideFile        = "../../tests/fixtures/docker/compose.override.darwin.yaml"
 	darwinOverrideFilePlugins = "../../tests/fixtures/docker/compose.override.darwin_plugins.yaml"


### PR DESCRIPTION
# Rationale

Once upon a time, initial installations required that `FIFTYONE_DATABASE_ADMIN=true`. This is no longer the case as our backend systems have changed. This set of docs sometimes caused confusion and accidental DB modifications (if someone forgot to turn it off). It's really only required for database migrations which now only happen during upgrades. We should update our docs, tests, and references to remove that initial setting.

## Changes

1. Removes the `## Initial install vs upgrades` sections and changes them to `Upgrading`
2. Adds a `### Version 2.9+ Installation Changes` to each toolchain's README documenting the high level change
3. Moves the `fiftyone migrate` behavior to `upgrading.md` and add parity between helm and docker
4. Removes the `FIFTYONE_DATABASE_ADMIN=true` from integration tests

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

## Testing

Initial installs were done in the following locations with the DB admin set to false:

* Docker (GCP VM)
* Helm (ephemeral env)
* Helm (validate env)
* Helm (Skaffold)

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
