### PR TITLE
docs(important): Reorder the IMPORTANT section of the docs

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -26,30 +26,6 @@ Please contact Voxel51 for more information regarding FiftyOne Enterprise.
 
 ## Important
 
-### Version 2.0+ License File Requirement
-
-FiftyOne Enterprise v2.0 introduces a new requirement for a license file.
-This license file should be obtained from your Customer Success Team
-before upgrading to FiftyOne Enterprise 2.0 or beyond.
-
-Please refer to the
-[upgrade documentation](./docs/upgrading.md#from-fiftyone-enterprise-versions-160-to-171)
-for steps on how to add your license file.
-
-### Version 2.2+ Delegated Operator Changes
-
-FiftyOne Enterprise v2.2 introduces some changes to delegated operators.
-Please refer to the
-[upgrade documentation](./docs/upgrading.md#fiftyone-enterprise-v22-delegated-operator-changes)
-for steps on how to upgrade your delegated operators.
-
-### Version 2.5+ Delegated Operator Changes
-
-FiftyOne Enterprise v2.5 introduces some changes to delegated operators.
-Please refer to the
-[upgrade documentation](./docs/upgrading.md#fiftyone-enterprise-v25-delegated-operator-changes)
-for steps on how to upgrade your delegated operators.
-
 ### Version 2.9+ Installation Changes
 
 FiftyOne Enterprise v2.9 no longer requires that operators set the
@@ -62,6 +38,30 @@ services:
     environment:
       FIFTYONE_DATABASE_ADMIN: true
 ```
+
+### Version 2.5+ Delegated Operator Changes
+
+FiftyOne Enterprise v2.5 introduces some changes to delegated operators.
+Please refer to the
+[upgrade documentation](./docs/upgrading.md#fiftyone-enterprise-v25-delegated-operator-changes)
+for steps on how to upgrade your delegated operators.
+
+### Version 2.2+ Delegated Operator Changes
+
+FiftyOne Enterprise v2.2 introduces some changes to delegated operators.
+Please refer to the
+[upgrade documentation](./docs/upgrading.md#fiftyone-enterprise-v22-delegated-operator-changes)
+for steps on how to upgrade your delegated operators.
+
+### Version 2.0+ License File Requirement
+
+FiftyOne Enterprise v2.0 introduces a new requirement for a license file.
+This license file should be obtained from your Customer Success Team
+before upgrading to FiftyOne Enterprise 2.0 or beyond.
+
+Please refer to the
+[upgrade documentation](./docs/upgrading.md#from-fiftyone-enterprise-versions-160-to-171)
+for steps on how to add your license file.
 
 ## Table of Contents
 

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -27,35 +27,13 @@ Please contact Voxel51 for more information regarding FiftyOne Enterprise.
 
 ## Important
 
-### Version 2.0+ License File Requirement
+### Version 2.9+ Delegated Operator Changes
 
-FiftyOne Enterprise v2.0 introduces a new requirement for a license file.
-This license file should be obtained from your Customer Success Team
-before upgrading to FiftyOne Enterprise 2.0 or beyond.
+<!-- Differs from docker-compose docs -->
 
+FiftyOne Enterprise v2.9 introduces some changes to delegated operators.
 Please refer to the
-[upgrade documentation](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/upgrading.md#from-fiftyone-enterprise-versions-160-to-171)
-for steps on how to add your license file.
-
-### Version 2.2+ Delegated Operator Changes
-
-FiftyOne Enterprise v2.2 introduces some changes to delegated operators.
-Please refer to the
-[upgrade documentation](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/upgrading.md#fiftyone-enterprise-v22-delegated-operator-changes)
-for steps on how to upgrade your delegated operators.
-
-### Version 2.5+ Delegated Operator Changes
-
-FiftyOne Enterprise v2.5 introduces some changes to delegated operators.
-Please refer to the
-[upgrade documentation](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/upgrading.md#fiftyone-enterprise-v25-delegated-operator-changes)
-for steps on how to upgrade your delegated operators.
-
-### Version 2.7+ Delegated Operator Changes
-
-FiftyOne Enterprise v2.7 introduces some changes to delegated operators.
-Please refer to the
-[upgrade documentation](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/upgrading.md#fiftyone-enterprise-v27-delegated-operator-changes)
+[upgrade documentation](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/upgrading.md#fiftyone-enterprise-v29-delegated-operator-changes)
 for steps on how to upgrade your delegated operators.
 
 ### Version 2.9+ Installation Changes
@@ -70,14 +48,36 @@ appSettings:
     FIFTYONE_DATABASE_ADMIN: true
 ```
 
-### Version 2.9+ Delegated Operator Changes
+### Version 2.7+ Delegated Operator Changes
 
-<!-- Differs from docker-compose docs -->
-
-FiftyOne Enterprise v2.9 introduces some changes to delegated operators.
+FiftyOne Enterprise v2.7 introduces some changes to delegated operators.
 Please refer to the
-[upgrade documentation](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/upgrading.md#fiftyone-enterprise-v29-delegated-operator-changes)
+[upgrade documentation](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/upgrading.md#fiftyone-enterprise-v27-delegated-operator-changes)
 for steps on how to upgrade your delegated operators.
+
+### Version 2.5+ Delegated Operator Changes
+
+FiftyOne Enterprise v2.5 introduces some changes to delegated operators.
+Please refer to the
+[upgrade documentation](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/upgrading.md#fiftyone-enterprise-v25-delegated-operator-changes)
+for steps on how to upgrade your delegated operators.
+
+### Version 2.2+ Delegated Operator Changes
+
+FiftyOne Enterprise v2.2 introduces some changes to delegated operators.
+Please refer to the
+[upgrade documentation](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/upgrading.md#fiftyone-enterprise-v22-delegated-operator-changes)
+for steps on how to upgrade your delegated operators.
+
+### Version 2.0+ License File Requirement
+
+FiftyOne Enterprise v2.0 introduces a new requirement for a license file.
+This license file should be obtained from your Customer Success Team
+before upgrading to FiftyOne Enterprise 2.0 or beyond.
+
+Please refer to the
+[upgrade documentation](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/upgrading.md#from-fiftyone-enterprise-versions-160-to-171)
+for steps on how to add your license file.
 
 ## Table of Contents
 

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -27,35 +27,13 @@ Please contact Voxel51 for more information regarding FiftyOne Enterprise.
 
 ## Important
 
-### Version 2.0+ License File Requirement
+### Version 2.9+ Delegated Operator Changes
 
-FiftyOne Enterprise v2.0 introduces a new requirement for a license file.
-This license file should be obtained from your Customer Success Team
-before upgrading to FiftyOne Enterprise 2.0 or beyond.
+<!-- Differs from docker-compose docs -->
 
+FiftyOne Enterprise v2.9 introduces some changes to delegated operators.
 Please refer to the
-[upgrade documentation](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/upgrading.md#from-fiftyone-enterprise-versions-160-to-171)
-for steps on how to add your license file.
-
-### Version 2.2+ Delegated Operator Changes
-
-FiftyOne Enterprise v2.2 introduces some changes to delegated operators.
-Please refer to the
-[upgrade documentation](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/upgrading.md#fiftyone-enterprise-v22-delegated-operator-changes)
-for steps on how to upgrade your delegated operators.
-
-### Version 2.5+ Delegated Operator Changes
-
-FiftyOne Enterprise v2.5 introduces some changes to delegated operators.
-Please refer to the
-[upgrade documentation](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/upgrading.md#fiftyone-enterprise-v25-delegated-operator-changes)
-for steps on how to upgrade your delegated operators.
-
-### Version 2.7+ Delegated Operator Changes
-
-FiftyOne Enterprise v2.7 introduces some changes to delegated operators.
-Please refer to the
-[upgrade documentation](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/upgrading.md#fiftyone-enterprise-v27-delegated-operator-changes)
+[upgrade documentation](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/upgrading.md#fiftyone-enterprise-v29-delegated-operator-changes)
 for steps on how to upgrade your delegated operators.
 
 ### Version 2.9+ Installation Changes
@@ -70,14 +48,36 @@ appSettings:
     FIFTYONE_DATABASE_ADMIN: true
 ```
 
-### Version 2.9+ Delegated Operator Changes
+### Version 2.7+ Delegated Operator Changes
 
-<!-- Differs from docker-compose docs -->
-
-FiftyOne Enterprise v2.9 introduces some changes to delegated operators.
+FiftyOne Enterprise v2.7 introduces some changes to delegated operators.
 Please refer to the
-[upgrade documentation](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/upgrading.md#fiftyone-enterprise-v29-delegated-operator-changes)
+[upgrade documentation](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/upgrading.md#fiftyone-enterprise-v27-delegated-operator-changes)
 for steps on how to upgrade your delegated operators.
+
+### Version 2.5+ Delegated Operator Changes
+
+FiftyOne Enterprise v2.5 introduces some changes to delegated operators.
+Please refer to the
+[upgrade documentation](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/upgrading.md#fiftyone-enterprise-v25-delegated-operator-changes)
+for steps on how to upgrade your delegated operators.
+
+### Version 2.2+ Delegated Operator Changes
+
+FiftyOne Enterprise v2.2 introduces some changes to delegated operators.
+Please refer to the
+[upgrade documentation](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/upgrading.md#fiftyone-enterprise-v22-delegated-operator-changes)
+for steps on how to upgrade your delegated operators.
+
+### Version 2.0+ License File Requirement
+
+FiftyOne Enterprise v2.0 introduces a new requirement for a license file.
+This license file should be obtained from your Customer Success Team
+before upgrading to FiftyOne Enterprise 2.0 or beyond.
+
+Please refer to the
+[upgrade documentation](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/docs/upgrading.md#from-fiftyone-enterprise-versions-160-to-171)
+for steps on how to add your license file.
 
 ## Table of Contents
 


### PR DESCRIPTION
# Rationale

Recently, we reordered our [deprecation docs](https://docs.voxel51.com/deprecation.html) to have the newest stuff on top. We should apply that to our `Important` sections in our deployment READMEs.

## Changes

Reorders the `Important` sections to have the newest stuff (2.9.0) at the top and the oldest stuff (2.0.0) at the bottom.

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

Docs only.

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
