### PR TITLE
Broken link fix

### DIFF
--- a/helm/docs/configuring-plugins.md
+++ b/helm/docs/configuring-plugins.md
@@ -24,7 +24,7 @@ No additional configurations are required.
 Plugins run in the `fiftyone-app` deployment.
 To enable this mode
 
-- [Add Shared Storage for FiftyOne Enterprise Plugins][./plugins-storage]
+- [Add Shared Storage for FiftyOne Enterprise Plugins][plugins-storage]
   - Mount a Persistent Volume Claim (PVC) that provides
     - `ReadWrite` permissions to the `teams-api` deployment
       at the `FIFTYONE_PLUGINS_DIR` path
@@ -40,7 +40,7 @@ To enable this mode
 
 To enable this mode
 
-- [Add Shared Storage for FiftyOne Enterprise Plugins][./plugins-storage]
+- [Add Shared Storage for FiftyOne Enterprise Plugins][plugins-storage]
   - Mount a Persistent Volume Claim (PVC) that provides
     - `ReadWrite` permissions to the `teams-api` deployment
       at the `FIFTYONE_PLUGINS_DIR` path

--- a/helm/docs/configuring-plugins.md
+++ b/helm/docs/configuring-plugins.md
@@ -24,7 +24,7 @@ No additional configurations are required.
 Plugins run in the `fiftyone-app` deployment.
 To enable this mode
 
-- [Add Shared Storage for FiftyOne Enterprise Plugins][plugins-storage]
+- [Add Shared Storage for FiftyOne Enterprise Plugins][./plugins-storage]
   - Mount a Persistent Volume Claim (PVC) that provides
     - `ReadWrite` permissions to the `teams-api` deployment
       at the `FIFTYONE_PLUGINS_DIR` path
@@ -40,7 +40,7 @@ To enable this mode
 
 To enable this mode
 
-- [Add Shared Storage for FiftyOne Enterprise Plugins][plugins-storage]
+- [Add Shared Storage for FiftyOne Enterprise Plugins][./plugins-storage]
   - Mount a Persistent Volume Claim (PVC) that provides
     - `ReadWrite` permissions to the `teams-api` deployment
       at the `FIFTYONE_PLUGINS_DIR` path

--- a/helm/docs/configuring-plugins.md
+++ b/helm/docs/configuring-plugins.md
@@ -57,4 +57,4 @@ To enable this mode
   add the `teams-plugins` service name to your `no_proxy` and
   `NO_PROXY` environment variables.
 
-[plugins-storage]: ,/plugins-storage.md
+[plugins-storage]: ./plugins-storage.md


### PR DESCRIPTION
# Rationale and Changes

Links to the custom plugins doc are broken due to a comma:  `,/plugins-storage.md`. Changed to ` ./plugins-storage.md` to fix.