### PR TITLE
chore(helm): AS-687 default capabilities.drop for initContainers

### DIFF
--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -482,7 +482,7 @@ follow
 | apiSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy]. |
 | apiSettings.image.repository | string | `"voxel51/fiftyone-teams-api"` | Container image for the `teams-api`. |
 | apiSettings.image.tag | string | `""` | Image tag for `teams-api`. Defaults to the chart version. |
-| apiSettings.initContainers.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"runAsNonRoot":true,"runAsUser":1000}` | Container security configuration for `teams-api` `initContainers`. [Reference][container-security-context]. |
+| apiSettings.initContainers.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsNonRoot":true,"runAsUser":1000}` | Container security configuration for `teams-api` `initContainers`. [Reference][container-security-context]. |
 | apiSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for `teams-api`. [Reference][init-containers]. |
 | apiSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for `teams-api`. [Reference][init-containers]. |
 | apiSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for `teams-api`. [Reference][init-containers]. |
@@ -534,7 +534,7 @@ follow
 | appSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy]. |
 | appSettings.image.repository | string | `"voxel51/fiftyone-app"` | Container image for `fiftyone-app`. |
 | appSettings.image.tag | string | `""` | Image tag for `fiftyone-app`. Defaults to the chart version. |
-| appSettings.initContainers.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"runAsNonRoot":true,"runAsUser":1000}` | Container security configuration for `fiftyone-app` `initContainers`. [Reference][container-security-context]. |
+| appSettings.initContainers.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsNonRoot":true,"runAsUser":1000}` | Container security configuration for `fiftyone-app` `initContainers`. [Reference][container-security-context]. |
 | appSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for `fiftyone-app`. [Reference][init-containers]. |
 | appSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for `fiftyone-app`. [Reference][init-containers]. |
 | appSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for `fiftyone-app`. [Reference][init-containers]. |
@@ -582,7 +582,7 @@ follow
 | casSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy]. |
 | casSettings.image.repository | string | `"voxel51/fiftyone-teams-cas"` | Container image for `teams-cas`. |
 | casSettings.image.tag | string | `""` | Image tag for `teams-cas`. Defaults to the chart version. |
-| casSettings.initContainers.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"runAsNonRoot":true,"runAsUser":1000}` | Container security configuration for `teams-cas` `initContainers`. [Reference][container-security-context]. |
+| casSettings.initContainers.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsNonRoot":true,"runAsUser":1000}` | Container security configuration for `teams-cas` `initContainers`. [Reference][container-security-context]. |
 | casSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for `teams-cas`. [Reference][init-containers]. |
 | casSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for `teams-cas`. [Reference][init-containers]. |
 | casSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for `teams-cas`. [Reference][init-containers]. |
@@ -688,7 +688,7 @@ follow
 | pluginsSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy]. |
 | pluginsSettings.image.repository | string | `"voxel51/fiftyone-app"` | Container image for `teams-plugins`. |
 | pluginsSettings.image.tag | string | `""` | Image tag for `teams-plugins`. Defaults to the chart version. |
-| pluginsSettings.initContainers.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"runAsNonRoot":true,"runAsUser":1000}` | Container security configuration for `teams-plugins` `initContainers`. [Reference][container-security-context]. |
+| pluginsSettings.initContainers.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsNonRoot":true,"runAsUser":1000}` | Container security configuration for `teams-plugins` `initContainers`. [Reference][container-security-context]. |
 | pluginsSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for `teams-plugins`. [Reference][init-containers]. |
 | pluginsSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for `teams-plugins`. [Reference][init-containers]. |
 | pluginsSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for `teams-plugins`. [Reference][init-containers]. |
@@ -757,7 +757,7 @@ follow
 | teamsAppSettings.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. Reference][image-pull-policy]. |
 | teamsAppSettings.image.repository | string | `"voxel51/fiftyone-teams-app"` | Container image for `teams-app`. |
 | teamsAppSettings.image.tag | string | `""` | Image tag for `teams-app`.  Defaults to the chart version. |
-| teamsAppSettings.initContainers.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"runAsNonRoot":true,"runAsUser":1000}` | Container security configuration for `teams-app` `initContainers`. [Reference][container-security-context]. |
+| teamsAppSettings.initContainers.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsNonRoot":true,"runAsUser":1000}` | Container security configuration for `teams-app` `initContainers`. [Reference][container-security-context]. |
 | teamsAppSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for `teams-app`.  [Reference][init-containers]. |
 | teamsAppSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for `teams-app`.  [Reference][init-containers]. |
 | teamsAppSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for `teams-app`.  [Reference][init-containers]. |

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -84,6 +84,8 @@ apiSettings:
     # -- Container security configuration for `teams-api` `initContainers`. [Reference][container-security-context].
     containerSecurityContext:
       allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
       runAsNonRoot: true
       runAsUser: 1000
     # -- Whether to enable init containers for `teams-api`. [Reference][init-containers].
@@ -251,6 +253,8 @@ appSettings:
     # -- Container security configuration for `fiftyone-app` `initContainers`. [Reference][container-security-context].
     containerSecurityContext:
       allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
       runAsNonRoot: true
       runAsUser: 1000
     # -- Whether to enable init containers for `fiftyone-app`. [Reference][init-containers].
@@ -407,6 +411,8 @@ casSettings:
     # -- Container security configuration for `teams-cas` `initContainers`. [Reference][container-security-context].
     containerSecurityContext:
       allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
       runAsNonRoot: true
       runAsUser: 1000
     # -- Whether to enable init containers for `teams-cas`. [Reference][init-containers].
@@ -771,6 +777,8 @@ pluginsSettings:
     # -- Container security configuration for `teams-plugins` `initContainers`. [Reference][container-security-context].
     containerSecurityContext:
       allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
       runAsNonRoot: true
       runAsUser: 1000
     # -- Whether to enable init containers for `teams-plugins`. [Reference][init-containers].
@@ -992,6 +1000,8 @@ teamsAppSettings:
     # -- Container security configuration for `teams-app` `initContainers`. [Reference][container-security-context].
     containerSecurityContext:
       allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
       runAsNonRoot: true
       runAsUser: 1000
     # -- Whether to enable init containers for `teams-app`.  [Reference][init-containers].

--- a/tests/unit/helm/api-deployment_test.go
+++ b/tests/unit/helm/api-deployment_test.go
@@ -1738,7 +1738,8 @@ func (s *deploymentApiTemplateTest) TestInitContainerSecurityContext() {
 			nil,
 			func(securityContext *corev1.SecurityContext) {
 				s.Equal(false, *securityContext.AllowPrivilegeEscalation, "AllowPrivilegeEscalation should be equal")
-				s.Nil(securityContext.Capabilities, "should be nil")
+				s.Empty(securityContext.Capabilities.Add, "Capability.Add should be empty")
+				s.Equal([]corev1.Capability{"ALL"}, securityContext.Capabilities.Drop, "Capability.Drop should be equal")
 				s.Nil(securityContext.Privileged, "should be nil")
 				s.Nil(securityContext.ProcMount, "should be nil")
 				s.Nil(securityContext.ReadOnlyRootFilesystem, "should be nil")
@@ -1753,11 +1754,15 @@ func (s *deploymentApiTemplateTest) TestInitContainerSecurityContext() {
 		{
 			"overrideSecurityContext",
 			map[string]string{
-				"apiSettings.initContainers.containerSecurityContext.runAsGroup": "3000",
-				"apiSettings.initContainers.containerSecurityContext.runAsUser":  "1001",
+				"apiSettings.initContainers.containerSecurityContext.capabilities.add[0]":  "CAP_AUDIT_CONTROL",
+				"apiSettings.initContainers.containerSecurityContext.capabilities.drop[0]": "CAP_AUDIT_READ",
+				"apiSettings.initContainers.containerSecurityContext.runAsGroup":           "3000",
+				"apiSettings.initContainers.containerSecurityContext.runAsUser":            "1001",
 			},
 			func(securityContext *corev1.SecurityContext) {
 				s.Equal(false, *securityContext.AllowPrivilegeEscalation, "AllowPrivilegeEscalation should be equal")
+				s.Equal([]corev1.Capability{"CAP_AUDIT_CONTROL"}, securityContext.Capabilities.Add, "Capability.Add should be equal")
+				s.Equal([]corev1.Capability{"CAP_AUDIT_READ"}, securityContext.Capabilities.Drop, "Capability.Drop should be equal")
 				s.Equal(int64(3000), *securityContext.RunAsGroup, "runAsGroup should be 3000")
 				s.Equal(true, *securityContext.RunAsNonRoot, "RunAsNonRoot should be equal")
 				s.Equal(int64(1001), *securityContext.RunAsUser, "runAsUser should be 1001")

--- a/tests/unit/helm/app-deployment_test.go
+++ b/tests/unit/helm/app-deployment_test.go
@@ -1694,7 +1694,8 @@ func (s *deploymentAppTemplateTest) TestInitContainerSecurityContext() {
 			nil,
 			func(securityContext *corev1.SecurityContext) {
 				s.Equal(false, *securityContext.AllowPrivilegeEscalation, "AllowPrivilegeEscalation should be equal")
-				s.Nil(securityContext.Capabilities, "should be nil")
+				s.Empty(securityContext.Capabilities.Add, "Capability.Add should be empty")
+				s.Equal([]corev1.Capability{"ALL"}, securityContext.Capabilities.Drop, "Capability.Drop should be equal")
 				s.Nil(securityContext.Privileged, "should be nil")
 				s.Nil(securityContext.ProcMount, "should be nil")
 				s.Nil(securityContext.ReadOnlyRootFilesystem, "should be nil")
@@ -1709,11 +1710,15 @@ func (s *deploymentAppTemplateTest) TestInitContainerSecurityContext() {
 		{
 			"overrideSecurityContext",
 			map[string]string{
-				"appSettings.initContainers.containerSecurityContext.runAsGroup": "3000",
-				"appSettings.initContainers.containerSecurityContext.runAsUser":  "1001",
+				"appSettings.initContainers.containerSecurityContext.capabilities.add[0]":  "CAP_AUDIT_CONTROL",
+				"appSettings.initContainers.containerSecurityContext.capabilities.drop[0]": "CAP_AUDIT_READ",
+				"appSettings.initContainers.containerSecurityContext.runAsGroup":           "3000",
+				"appSettings.initContainers.containerSecurityContext.runAsUser":            "1001",
 			},
 			func(securityContext *corev1.SecurityContext) {
 				s.Equal(false, *securityContext.AllowPrivilegeEscalation, "AllowPrivilegeEscalation should be equal")
+				s.Equal([]corev1.Capability{"CAP_AUDIT_CONTROL"}, securityContext.Capabilities.Add, "Capability.Add should be equal")
+				s.Equal([]corev1.Capability{"CAP_AUDIT_READ"}, securityContext.Capabilities.Drop, "Capability.Drop should be equal")
 				s.Equal(int64(3000), *securityContext.RunAsGroup, "runAsGroup should be 3000")
 				s.Equal(true, *securityContext.RunAsNonRoot, "RunAsNonRoot should be equal")
 				s.Equal(int64(1001), *securityContext.RunAsUser, "runAsUser should be 1001")

--- a/tests/unit/helm/plugins-deployment_test.go
+++ b/tests/unit/helm/plugins-deployment_test.go
@@ -2048,7 +2048,8 @@ func (s *deploymentPluginsTemplateTest) TestInitContainerSecurityContext() {
 			},
 			func(securityContext *corev1.SecurityContext) {
 				s.Equal(false, *securityContext.AllowPrivilegeEscalation, "AllowPrivilegeEscalation should be equal")
-				s.Nil(securityContext.Capabilities, "should be nil")
+				s.Empty(securityContext.Capabilities.Add, "Capability.Add should be empty")
+				s.Equal([]corev1.Capability{"ALL"}, securityContext.Capabilities.Drop, "Capability.Drop should be equal")
 				s.Nil(securityContext.Privileged, "should be nil")
 				s.Nil(securityContext.ProcMount, "should be nil")
 				s.Nil(securityContext.ReadOnlyRootFilesystem, "should be nil")
@@ -2064,11 +2065,15 @@ func (s *deploymentPluginsTemplateTest) TestInitContainerSecurityContext() {
 			"overrideSecurityContext",
 			map[string]string{
 				"pluginsSettings.enabled": "true",
-				"pluginsSettings.initContainers.containerSecurityContext.runAsGroup": "3000",
-				"pluginsSettings.initContainers.containerSecurityContext.runAsUser":  "1001",
+				"pluginsSettings.initContainers.containerSecurityContext.capabilities.add[0]":  "CAP_AUDIT_CONTROL",
+				"pluginsSettings.initContainers.containerSecurityContext.capabilities.drop[0]": "CAP_AUDIT_READ",
+				"pluginsSettings.initContainers.containerSecurityContext.runAsGroup":           "3000",
+				"pluginsSettings.initContainers.containerSecurityContext.runAsUser":            "1001",
 			},
 			func(securityContext *corev1.SecurityContext) {
 				s.Equal(false, *securityContext.AllowPrivilegeEscalation, "AllowPrivilegeEscalation should be equal")
+				s.Equal([]corev1.Capability{"CAP_AUDIT_CONTROL"}, securityContext.Capabilities.Add, "Capability.Add should be equal")
+				s.Equal([]corev1.Capability{"CAP_AUDIT_READ"}, securityContext.Capabilities.Drop, "Capability.Drop should be equal")
 				s.Equal(int64(3000), *securityContext.RunAsGroup, "runAsGroup should be 3000")
 				s.Equal(true, *securityContext.RunAsNonRoot, "RunAsNonRoot should be equal")
 				s.Equal(int64(1001), *securityContext.RunAsUser, "runAsUser should be 1001")

--- a/tests/unit/helm/teams-app-deployment_test.go
+++ b/tests/unit/helm/teams-app-deployment_test.go
@@ -1887,7 +1887,8 @@ func (s *deploymentTeamsAppTemplateTest) TestInitContainerSecurityContext() {
 			nil,
 			func(securityContext *corev1.SecurityContext) {
 				s.Equal(false, *securityContext.AllowPrivilegeEscalation, "AllowPrivilegeEscalation should be equal")
-				s.Nil(securityContext.Capabilities, "should be nil")
+				s.Empty(securityContext.Capabilities.Add, "Capability.Add should be empty")
+				s.Equal([]corev1.Capability{"ALL"}, securityContext.Capabilities.Drop, "Capability.Drop should be equal")
 				s.Nil(securityContext.Privileged, "should be nil")
 				s.Nil(securityContext.ProcMount, "should be nil")
 				s.Nil(securityContext.ReadOnlyRootFilesystem, "should be nil")
@@ -1902,11 +1903,15 @@ func (s *deploymentTeamsAppTemplateTest) TestInitContainerSecurityContext() {
 		{
 			"overrideSecurityContext",
 			map[string]string{
-				"teamsAppSettings.initContainers.containerSecurityContext.runAsGroup": "3000",
-				"teamsAppSettings.initContainers.containerSecurityContext.runAsUser":  "1001",
+				"teamsAppSettings.initContainers.containerSecurityContext.capabilities.add[0]":  "CAP_AUDIT_CONTROL",
+				"teamsAppSettings.initContainers.containerSecurityContext.capabilities.drop[0]": "CAP_AUDIT_READ",
+				"teamsAppSettings.initContainers.containerSecurityContext.runAsGroup":           "3000",
+				"teamsAppSettings.initContainers.containerSecurityContext.runAsUser":            "1001",
 			},
 			func(securityContext *corev1.SecurityContext) {
 				s.Equal(false, *securityContext.AllowPrivilegeEscalation, "AllowPrivilegeEscalation should be equal")
+				s.Equal([]corev1.Capability{"CAP_AUDIT_CONTROL"}, securityContext.Capabilities.Add, "Capability.Add should be equal")
+				s.Equal([]corev1.Capability{"CAP_AUDIT_READ"}, securityContext.Capabilities.Drop, "Capability.Drop should be equal")
 				s.Equal(int64(3000), *securityContext.RunAsGroup, "runAsGroup should be 3000")
 				s.Equal(true, *securityContext.RunAsNonRoot, "RunAsNonRoot should be equal")
 				s.Equal(int64(1001), *securityContext.RunAsUser, "runAsUser should be 1001")


### PR DESCRIPTION
# Rationale

We can drop all capabilities for `initContainers` as they don't do any privileged linux actions. This makes deploying them a bit safer.

## Changes

Sets the default `initContainer.containerSecurityContext` to

```yaml
    containerSecurityContext:
      allowPrivilegeEscalation: false
      capabilities:
        drop: [ALL] # ADDED
      runAsNonRoot: true
      runAsUser: 1000
```

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

Go tests were updated.
Helm template results below:

```yaml
      initContainers:
        - name: init-cas
          image: docker.io/busybox:stable-glibc
          command:
            - 'sh'
            - '-c'
            - "until wget -qO /dev/null teams-cas.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local/cas/api; do echo waiting for cas; sleep 2; done"
          resources:
            limits:
              cpu: 10m
              memory: 128Mi
            requests:
              cpu: 10m
              memory: 128Mi
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            runAsNonRoot: true
            runAsUser: 1000
```
<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
