### PR TITLE
chore: bump asdf-vm/actions to 1902764435ca0dd2f3388eea723a4f92a4eb8302

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -20,5 +20,5 @@ jobs:
       - name: Temporary SQLite/LZMA - Install missing libraries
         run: sudo apt install -y libsqlite3-dev libbz2-dev
       - name: install asdf & tools
-        uses: asdf-vm/actions/install@9cd779f40fe38688dd19505ccbc4eaaf018b44e7
+        uses: asdf-vm/actions/install@1902764435ca0dd2f3388eea723a4f92a4eb8302
       - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/test-docker-pulls.yml
+++ b/.github/workflows/test-docker-pulls.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Temporary SQLite/LZMA - Install missing libraries
         run: sudo apt install -y libsqlite3-dev libbz2-dev
       - name: install asdf & tools
-        uses: asdf-vm/actions/install@9cd779f40fe38688dd19505ccbc4eaaf018b44e7
+        uses: asdf-vm/actions/install@1902764435ca0dd2f3388eea723a4f92a4eb8302
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4.2.2
       - uses: actions/setup-python@v5.6.0
       - name: install asdf & tools
-        uses: asdf-vm/actions/install@9cd779f40fe38688dd19505ccbc4eaaf018b44e7
+        uses: asdf-vm/actions/install@1902764435ca0dd2f3388eea723a4f92a4eb8302
       - name: Run unit tests
         shell: bash
         run: |
@@ -34,7 +34,7 @@ jobs:
       - name: Temporary SQLite/LZMA - Install missing libraries
         run: sudo apt install -y libsqlite3-dev libbz2-dev
       - name: install asdf & tools
-        uses: asdf-vm/actions/install@9cd779f40fe38688dd19505ccbc4eaaf018b44e7
+        uses: asdf-vm/actions/install@1902764435ca0dd2f3388eea723a4f92a4eb8302
       - name: Authenticate to Google Cloud
         id: auth
         uses: google-github-actions/auth@v2.1.7
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/checkout@v4.2.2
       - uses: actions/setup-python@v5.6.0
       - name: install asdf & tools
-        uses: asdf-vm/actions/install@9cd779f40fe38688dd19505ccbc4eaaf018b44e7
+        uses: asdf-vm/actions/install@1902764435ca0dd2f3388eea723a4f92a4eb8302
       - name: Authenticate to Google Cloud
         id: auth
         uses: google-github-actions/auth@v2.1.7

--- a/.github/workflows/test-helm.yml
+++ b/.github/workflows/test-helm.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Temporary SQLite/LZMA - Install missing libraries
         run: sudo apt install -y libsqlite3-dev libbz2-dev
       - name: install asdf & tools
-        uses: asdf-vm/actions/install@9cd779f40fe38688dd19505ccbc4eaaf018b44e7
+        uses: asdf-vm/actions/install@1902764435ca0dd2f3388eea723a4f92a4eb8302
       - name: Run unit tests
         shell: bash
         run: |

--- a/.github/workflows/test-integration-helm.yml
+++ b/.github/workflows/test-integration-helm.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Temporary SQLite/LZMA - Install missing libraries
         run: sudo apt install -y libsqlite3-dev libbz2-dev
       - name: install asdf & tools
-        uses: asdf-vm/actions/install@9cd779f40fe38688dd19505ccbc4eaaf018b44e7
+        uses: asdf-vm/actions/install@1902764435ca0dd2f3388eea723a4f92a4eb8302
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:


### PR DESCRIPTION
# Rationale

Newer is better 

## Changes

- `perl -pi -e 's/9cd779f40fe38688dd19505ccbc4eaaf018b44e7/1902764435ca0dd2f3388eea723a4f92a4eb8302/g' *`

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

## Testing

This version is already used in other repos, including the internal-helm repo

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
