### PR TITLE
chore(integration): AS-696 address integration test flakes

### DIFF
--- a/tests/integration/compose/docker-compose-internal-auth_test.go
+++ b/tests/integration/compose/docker-compose-internal-auth_test.go
@@ -339,7 +339,7 @@ func (s *commonServicesInternalAuthDockerComposeUpTest) TestDockerComposeUp() {
 					validate_endpoint(subT, expected.url, expected.responsePayload, expected.httpResponseCode)
 				}
 				// Validate log output is expected
-				s.Contains(get_logs(subT, dockerOptions, expected.name), expected.log, fmt.Sprintf("%s - %s - log should contain matching entry", testCase.name, expected.name))
+				checkContainerLogsWithRetries(subT, dockerOptions, expected.name, testCase.name, expected.log)
 			}
 		})
 	}

--- a/tests/integration/compose/docker-compose-legacy-auth_test.go
+++ b/tests/integration/compose/docker-compose-legacy-auth_test.go
@@ -337,11 +337,7 @@ func (s *commonServicesLegacyAuthDockerComposeUpTest) TestDockerComposeUp() {
 				}
 
 				// Validate log output is expected
-				s.Contains(
-					get_logs(subT, dockerOptions, expected.name),
-					expected.log,
-					fmt.Sprintf("%s - %s - log should contain matching entry", testCase.name, expected.name),
-				)
+				checkContainerLogsWithRetries(subT, dockerOptions, expected.name, testCase.name, expected.log)
 			}
 		})
 	}


### PR DESCRIPTION
# Rationale

I've noticed recently that, as our packages get bigger, it takes them longer to start up. Let's make our tests less flakey by adding logging retries.

## Changes

* Adds the `checkContainerLogsWithRetries` function which re-attempts to get logs
* Switches the original test implementation of `get_logs` with `checkContainerLogsWithRetries`

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
