### PR TITLE
chore(pre-release): AS-701 test pre-release charts

### DIFF
--- a/.github/workflows/pre-release-internal-env.yml
+++ b/.github/workflows/pre-release-internal-env.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v4
         with:
-          version: v3.17.3  # TODO: AS-701 set to `latest` once `helm registry login ...` works again
+          version: latest
 
       - name: Set Up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -1,4 +1,5 @@
 ---
+# Remove before merging
 # FiftyOne Enterprise API (`teams-api`)
 apiSettings:
   # -- Controls whether `teams-api` is added to the chart's ingress.

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -1,5 +1,4 @@
 ---
-# Remove before merging
 # FiftyOne Enterprise API (`teams-api`)
 apiSettings:
   # -- Controls whether `teams-api` is added to the chart's ingress.


### PR DESCRIPTION
# Rationale

In a prior PR, we had pinned `helm` versions in our pre-release flow to `3.17.3` because there was an issue with OCI/HTTPS repos. This appears to be fixed in 3.18.1. This PR will serve as additional testing to ensure that everything works as expected.

## Changes

Removes the `3.17.3` pin on helm in the `pre-release-internal-env` workflow.

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

```shell
### OLD

% helm version
version.BuildInfo{Version:"v3.18.0", GitCommit:"cc58e3f5a3aa615c6a86275e6f4444b5fdd3cc4e", GitTreeState:"clean", GoVersion:"go1.24.3"}
% gcloud auth print-access-token | helm registry login -u oauth2accesstoken --password-stdin "https://us-central1-docker.pkg.dev"
Error: invalid reference: invalid registry "https://us-central1-docker.pkg.dev"
alexanderfoley@Alexanders-MacBook-Pro fiftyone-teams-app-deploy % 

### NEW

% helm version
version.BuildInfo{Version:"v3.18.1", GitCommit:"f6f8700a539c18101509434f3b59e6a21402a1b2", GitTreeState:"clean", GoVersion:"go1.24.3"}
% gcloud auth print-access-token | helm registry login -u oauth2accesstoken --password-stdin "https://us-central1-docker.pkg.dev"
Login Succeeded
```
<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
