### PR TITLE
chore(initContainers): Smaller ephemeral storage request

### DIFF
--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -486,7 +486,7 @@ follow
 | apiSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for `teams-api`. [Reference][init-containers]. |
 | apiSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for `teams-api`. [Reference][init-containers]. |
 | apiSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for `teams-api`. [Reference][init-containers]. |
-| apiSettings.initContainers.resources | object | `{"limits":{"cpu":"10m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"128Mi"}}` | Container resource requests and limits for the `teams-api` `initContainers`. [Reference][resources]. |
+| apiSettings.initContainers.resources | object | `{"limits":{"cpu":"10m","ephemeral-storage":"64Mi","memory":"128Mi"},"requests":{"cpu":"10m","ephemeral-storage":"64Mi","memory":"128Mi"}}` | Container resource requests and limits for the `teams-api` `initContainers`. [Reference][resources]. |
 | apiSettings.labels | object | `{}` | Additional labels for the `teams-api` related objects. [Reference][labels-and-selectors]. |
 | apiSettings.liveness.failureThreshold | int | `5` | Number of times to retry the liveness probe for the `teams-api`. [Reference][probes]. |
 | apiSettings.liveness.periodSeconds | int | `15` | How often (in seconds) to perform the liveness probe for `teams-api`. [Reference][probes]. |
@@ -538,7 +538,7 @@ follow
 | appSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for `fiftyone-app`. [Reference][init-containers]. |
 | appSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for `fiftyone-app`. [Reference][init-containers]. |
 | appSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for `fiftyone-app`. [Reference][init-containers]. |
-| appSettings.initContainers.resources | object | `{"limits":{"cpu":"10m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"128Mi"}}` | Container resource requests and limits for the `fiftyone-app` `initContainers`. [Reference][resources]. |
+| appSettings.initContainers.resources | object | `{"limits":{"cpu":"10m","ephemeral-storage":"64Mi","memory":"128Mi"},"requests":{"cpu":"10m","ephemeral-storage":"64Mi","memory":"128Mi"}}` | Container resource requests and limits for the `fiftyone-app` `initContainers`. [Reference][resources]. |
 | appSettings.labels | object | `{}` | Additional labels for the `fiftyone-app` related objects. [Reference][labels-and-selectors]. |
 | appSettings.liveness.failureThreshold | int | `5` | Number of times to retry the liveness probe for the `fiftyone-app`. [Reference][probes]. |
 | appSettings.liveness.periodSeconds | int | `15` | How often (in seconds) to perform the liveness probe for `fiftyone-app`. [Reference][probes]. |
@@ -586,7 +586,7 @@ follow
 | casSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for `teams-cas`. [Reference][init-containers]. |
 | casSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for `teams-cas`. [Reference][init-containers]. |
 | casSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for `teams-cas`. [Reference][init-containers]. |
-| casSettings.initContainers.resources | object | `{"limits":{"cpu":"10m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"128Mi"}}` | Container resource requests and limits for the `teams-cas` `initContainers`. [Reference][resources]. |
+| casSettings.initContainers.resources | object | `{"limits":{"cpu":"10m","ephemeral-storage":"64Mi","memory":"128Mi"},"requests":{"cpu":"10m","ephemeral-storage":"64Mi","memory":"128Mi"}}` | Container resource requests and limits for the `teams-cas` `initContainers`. [Reference][resources]. |
 | casSettings.labels | object | `{}` | Additional labels for the `teams-cas` related objects. [Reference][labels-and-selectors]. |
 | casSettings.liveness.failureThreshold | int | `5` | Number of times to retry the liveness probe for the `teams-cas`. [Reference][probes]. |
 | casSettings.liveness.periodSeconds | int | `15` | How often (in seconds) to perform the liveness probe for `teams-cas`. [Reference][probes]. |
@@ -692,7 +692,7 @@ follow
 | pluginsSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for `teams-plugins`. [Reference][init-containers]. |
 | pluginsSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for `teams-plugins`. [Reference][init-containers]. |
 | pluginsSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for `teams-plugins`. [Reference][init-containers]. |
-| pluginsSettings.initContainers.resources | object | `{"limits":{"cpu":"10m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"128Mi"}}` | Container resource requests and limits for the `teams-plugins` `initContainers`. [Reference][resources]. |
+| pluginsSettings.initContainers.resources | object | `{"limits":{"cpu":"10m","ephemeral-storage":"64Mi","memory":"128Mi"},"requests":{"cpu":"10m","ephemeral-storage":"64Mi","memory":"128Mi"}}` | Container resource requests and limits for the `teams-plugins` `initContainers`. [Reference][resources]. |
 | pluginsSettings.labels | object | `{}` | Additional labels for the `teams-plugins` related objects. [Reference][labels-and-selectors]. |
 | pluginsSettings.liveness.failureThreshold | int | `5` | Number of times to retry the liveness probe for the `teams-plugins`. [Reference][probes]. |
 | pluginsSettings.liveness.periodSeconds | int | `15` | How often (in seconds) to perform the liveness probe for `teams-plugins`. [Reference][probes]. |
@@ -761,7 +761,7 @@ follow
 | teamsAppSettings.initContainers.enabled | bool | `true` | Whether to enable init containers for `teams-app`.  [Reference][init-containers]. |
 | teamsAppSettings.initContainers.image.repository | string | `"docker.io/busybox"` | Init container images repositories for `teams-app`.  [Reference][init-containers]. |
 | teamsAppSettings.initContainers.image.tag | string | `"stable-glibc"` | Init container images tags for `teams-app`.  [Reference][init-containers]. |
-| teamsAppSettings.initContainers.resources | object | `{"limits":{"cpu":"10m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"128Mi"}}` | Container resource requests and limits for the `teams-app` `initContainers`. [Reference][resources]. |
+| teamsAppSettings.initContainers.resources | object | `{"limits":{"cpu":"10m","ephemeral-storage":"64Mi","memory":"128Mi"},"requests":{"cpu":"10m","ephemeral-storage":"64Mi","memory":"128Mi"}}` | Container resource requests and limits for the `teams-app` `initContainers`. [Reference][resources]. |
 | teamsAppSettings.labels | object | `{}` | Additional labels for the `teams-app` related objects. [Reference][labels-and-selectors]. |
 | teamsAppSettings.liveness.failureThreshold | int | `5` | Number of times to retry the liveness probe for the `teams-app`.  [Reference][probes]. |
 | teamsAppSettings.liveness.periodSeconds | int | `15` | How often (in seconds) to perform the liveness probe for `teams-app`.  [Reference][probes]. |

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -99,9 +99,11 @@ apiSettings:
     resources:
       limits:
         cpu: 10m
+        ephemeral-storage: 64Mi
         memory: 128Mi
       requests:
         cpu: 10m
+        ephemeral-storage: 64Mi
         memory: 128Mi
   liveness:
     # -- Number of times to retry the liveness probe for the `teams-api`. [Reference][probes].
@@ -268,9 +270,11 @@ appSettings:
     resources:
       limits:
         cpu: 10m
+        ephemeral-storage: 64Mi
         memory: 128Mi
       requests:
         cpu: 10m
+        ephemeral-storage: 64Mi
         memory: 128Mi
   liveness:
     # -- Number of times to retry the liveness probe for the `fiftyone-app`. [Reference][probes].
@@ -426,9 +430,11 @@ casSettings:
     resources:
       limits:
         cpu: 10m
+        ephemeral-storage: 64Mi
         memory: 128Mi
       requests:
         cpu: 10m
+        ephemeral-storage: 64Mi
         memory: 128Mi
   liveness:
     # -- Number of times to retry the liveness probe for the `teams-cas`. [Reference][probes].
@@ -792,9 +798,11 @@ pluginsSettings:
     resources:
       limits:
         cpu: 10m
+        ephemeral-storage: 64Mi
         memory: 128Mi
       requests:
         cpu: 10m
+        ephemeral-storage: 64Mi
         memory: 128Mi
   liveness:
     # -- Number of times to retry the liveness probe for the `teams-plugins`. [Reference][probes].
@@ -1015,9 +1023,11 @@ teamsAppSettings:
     resources:
       limits:
         cpu: 10m
+        ephemeral-storage: 64Mi
         memory: 128Mi
       requests:
         cpu: 10m
+        ephemeral-storage: 64Mi
         memory: 128Mi
   liveness:
     # -- Number of times to retry the liveness probe for the `teams-app`.  [Reference][probes].

--- a/tests/unit/helm/api-deployment_test.go
+++ b/tests/unit/helm/api-deployment_test.go
@@ -1672,12 +1672,14 @@ func (s *deploymentApiTemplateTest) TestInitContainerResourceRequirements() {
 			func(resourceRequirements corev1.ResourceRequirements) {
 				resourceExpected := corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
-						"cpu":    resource.MustParse("10m"),
-						"memory": resource.MustParse("128Mi"),
+						"cpu":               resource.MustParse("10m"),
+						"ephemeral-storage": resource.MustParse("64Mi"),
+						"memory":            resource.MustParse("128Mi"),
 					},
 					Requests: corev1.ResourceList{
-						"cpu":    resource.MustParse("10m"),
-						"memory": resource.MustParse("128Mi"),
+						"cpu":               resource.MustParse("10m"),
+						"ephemeral-storage": resource.MustParse("64Mi"),
+						"memory":            resource.MustParse("128Mi"),
 					},
 				}
 				s.Equal(resourceExpected, resourceRequirements, "should be equal")
@@ -1687,20 +1689,24 @@ func (s *deploymentApiTemplateTest) TestInitContainerResourceRequirements() {
 		{
 			"overrideResources",
 			map[string]string{
-				"apiSettings.initContainers.resources.limits.cpu":      "1",
-				"apiSettings.initContainers.resources.limits.memory":   "1Gi",
-				"apiSettings.initContainers.resources.requests.cpu":    "500m",
-				"apiSettings.initContainers.resources.requests.memory": "512Mi",
+				"apiSettings.initContainers.resources.limits.cpu":                 "1",
+				"apiSettings.initContainers.resources.limits.ephemeral-storage":   "1Gi",
+				"apiSettings.initContainers.resources.limits.memory":              "1Gi",
+				"apiSettings.initContainers.resources.requests.cpu":               "500m",
+				"apiSettings.initContainers.resources.requests.ephemeral-storage": "512Mi",
+				"apiSettings.initContainers.resources.requests.memory":            "512Mi",
 			},
 			func(resourceRequirements corev1.ResourceRequirements) {
 				resourceExpected := corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
-						"cpu":    resource.MustParse("1"),
-						"memory": resource.MustParse("1Gi"),
+						"cpu":               resource.MustParse("1"),
+						"ephemeral-storage": resource.MustParse("1Gi"),
+						"memory":            resource.MustParse("1Gi"),
 					},
 					Requests: corev1.ResourceList{
-						"cpu":    resource.MustParse("500m"),
-						"memory": resource.MustParse("512Mi"),
+						"cpu":               resource.MustParse("500m"),
+						"ephemeral-storage": resource.MustParse("512Mi"),
+						"memory":            resource.MustParse("512Mi"),
 					},
 				}
 				s.Equal(resourceExpected, resourceRequirements, "should be equal")

--- a/tests/unit/helm/app-deployment_test.go
+++ b/tests/unit/helm/app-deployment_test.go
@@ -1628,12 +1628,14 @@ func (s *deploymentAppTemplateTest) TestInitContainerResourceRequirements() {
 			func(resourceRequirements corev1.ResourceRequirements) {
 				resourceExpected := corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
-						"cpu":    resource.MustParse("10m"),
-						"memory": resource.MustParse("128Mi"),
+						"cpu":               resource.MustParse("10m"),
+						"ephemeral-storage": resource.MustParse("64Mi"),
+						"memory":            resource.MustParse("128Mi"),
 					},
 					Requests: corev1.ResourceList{
-						"cpu":    resource.MustParse("10m"),
-						"memory": resource.MustParse("128Mi"),
+						"cpu":               resource.MustParse("10m"),
+						"ephemeral-storage": resource.MustParse("64Mi"),
+						"memory":            resource.MustParse("128Mi"),
 					},
 				}
 				s.Equal(resourceExpected, resourceRequirements, "should be equal")
@@ -1643,20 +1645,24 @@ func (s *deploymentAppTemplateTest) TestInitContainerResourceRequirements() {
 		{
 			"overrideResources",
 			map[string]string{
-				"appSettings.initContainers.resources.limits.cpu":      "1",
-				"appSettings.initContainers.resources.limits.memory":   "1Gi",
-				"appSettings.initContainers.resources.requests.cpu":    "500m",
-				"appSettings.initContainers.resources.requests.memory": "512Mi",
+				"appSettings.initContainers.resources.limits.cpu":                 "1",
+				"appSettings.initContainers.resources.limits.ephemeral-storage":   "1Gi",
+				"appSettings.initContainers.resources.limits.memory":              "1Gi",
+				"appSettings.initContainers.resources.requests.cpu":               "500m",
+				"appSettings.initContainers.resources.requests.ephemeral-storage": "512Mi",
+				"appSettings.initContainers.resources.requests.memory":            "512Mi",
 			},
 			func(resourceRequirements corev1.ResourceRequirements) {
 				resourceExpected := corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
-						"cpu":    resource.MustParse("1"),
-						"memory": resource.MustParse("1Gi"),
+						"cpu":               resource.MustParse("1"),
+						"ephemeral-storage": resource.MustParse("1Gi"),
+						"memory":            resource.MustParse("1Gi"),
 					},
 					Requests: corev1.ResourceList{
-						"cpu":    resource.MustParse("500m"),
-						"memory": resource.MustParse("512Mi"),
+						"cpu":               resource.MustParse("500m"),
+						"ephemeral-storage": resource.MustParse("512Mi"),
+						"memory":            resource.MustParse("512Mi"),
 					},
 				}
 				s.Equal(resourceExpected, resourceRequirements, "should be equal")

--- a/tests/unit/helm/plugins-deployment_test.go
+++ b/tests/unit/helm/plugins-deployment_test.go
@@ -1979,12 +1979,14 @@ func (s *deploymentPluginsTemplateTest) TestInitContainerResourceRequirements() 
 			func(resourceRequirements corev1.ResourceRequirements) {
 				resourceExpected := corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
-						"cpu":    resource.MustParse("10m"),
-						"memory": resource.MustParse("128Mi"),
+						"cpu":               resource.MustParse("10m"),
+						"ephemeral-storage": resource.MustParse("64Mi"),
+						"memory":            resource.MustParse("128Mi"),
 					},
 					Requests: corev1.ResourceList{
-						"cpu":    resource.MustParse("10m"),
-						"memory": resource.MustParse("128Mi"),
+						"cpu":               resource.MustParse("10m"),
+						"ephemeral-storage": resource.MustParse("64Mi"),
+						"memory":            resource.MustParse("128Mi"),
 					},
 				}
 				s.Equal(resourceExpected, resourceRequirements, "should be equal")
@@ -1994,21 +1996,25 @@ func (s *deploymentPluginsTemplateTest) TestInitContainerResourceRequirements() 
 		{
 			"overrideResources",
 			map[string]string{
-				"pluginsSettings.enabled":                                  "true",
-				"pluginsSettings.initContainers.resources.limits.cpu":      "1",
-				"pluginsSettings.initContainers.resources.limits.memory":   "1Gi",
-				"pluginsSettings.initContainers.resources.requests.cpu":    "500m",
-				"pluginsSettings.initContainers.resources.requests.memory": "512Mi",
+				"pluginsSettings.enabled":                                             "true",
+				"pluginsSettings.initContainers.resources.limits.cpu":                 "1",
+				"pluginsSettings.initContainers.resources.limits.ephemeral-storage":   "1Gi",
+				"pluginsSettings.initContainers.resources.limits.memory":              "1Gi",
+				"pluginsSettings.initContainers.resources.requests.cpu":               "500m",
+				"pluginsSettings.initContainers.resources.requests.ephemeral-storage": "512Mi",
+				"pluginsSettings.initContainers.resources.requests.memory":            "512Mi",
 			},
 			func(resourceRequirements corev1.ResourceRequirements) {
 				resourceExpected := corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
-						"cpu":    resource.MustParse("1"),
-						"memory": resource.MustParse("1Gi"),
+						"cpu":               resource.MustParse("1"),
+						"ephemeral-storage": resource.MustParse("1Gi"),
+						"memory":            resource.MustParse("1Gi"),
 					},
 					Requests: corev1.ResourceList{
-						"cpu":    resource.MustParse("500m"),
-						"memory": resource.MustParse("512Mi"),
+						"cpu":               resource.MustParse("500m"),
+						"ephemeral-storage": resource.MustParse("512Mi"),
+						"memory":            resource.MustParse("512Mi"),
 					},
 				}
 				s.Equal(resourceExpected, resourceRequirements, "should be equal")

--- a/tests/unit/helm/teams-app-deployment_test.go
+++ b/tests/unit/helm/teams-app-deployment_test.go
@@ -1821,12 +1821,14 @@ func (s *deploymentTeamsAppTemplateTest) TestInitContainerResourceRequirements()
 			func(resourceRequirements corev1.ResourceRequirements) {
 				resourceExpected := corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
-						"cpu":    resource.MustParse("10m"),
-						"memory": resource.MustParse("128Mi"),
+						"cpu":               resource.MustParse("10m"),
+						"ephemeral-storage": resource.MustParse("64Mi"),
+						"memory":            resource.MustParse("128Mi"),
 					},
 					Requests: corev1.ResourceList{
-						"cpu":    resource.MustParse("10m"),
-						"memory": resource.MustParse("128Mi"),
+						"cpu":               resource.MustParse("10m"),
+						"ephemeral-storage": resource.MustParse("64Mi"),
+						"memory":            resource.MustParse("128Mi"),
 					},
 				}
 				s.Equal(resourceExpected, resourceRequirements, "should be equal")
@@ -1836,20 +1838,24 @@ func (s *deploymentTeamsAppTemplateTest) TestInitContainerResourceRequirements()
 		{
 			"overrideResources",
 			map[string]string{
-				"teamsAppSettings.initContainers.resources.limits.cpu":      "1",
-				"teamsAppSettings.initContainers.resources.limits.memory":   "1Gi",
-				"teamsAppSettings.initContainers.resources.requests.cpu":    "500m",
-				"teamsAppSettings.initContainers.resources.requests.memory": "512Mi",
+				"teamsAppSettings.initContainers.resources.limits.cpu":                 "1",
+				"teamsAppSettings.initContainers.resources.limits.ephemeral-storage":   "1Gi",
+				"teamsAppSettings.initContainers.resources.limits.memory":              "1Gi",
+				"teamsAppSettings.initContainers.resources.requests.cpu":               "500m",
+				"teamsAppSettings.initContainers.resources.requests.ephemeral-storage": "512Mi",
+				"teamsAppSettings.initContainers.resources.requests.memory":            "512Mi",
 			},
 			func(resourceRequirements corev1.ResourceRequirements) {
 				resourceExpected := corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
-						"cpu":    resource.MustParse("1"),
-						"memory": resource.MustParse("1Gi"),
+						"cpu":               resource.MustParse("1"),
+						"ephemeral-storage": resource.MustParse("1Gi"),
+						"memory":            resource.MustParse("1Gi"),
 					},
 					Requests: corev1.ResourceList{
-						"cpu":    resource.MustParse("500m"),
-						"memory": resource.MustParse("512Mi"),
+						"cpu":               resource.MustParse("500m"),
+						"ephemeral-storage": resource.MustParse("512Mi"),
+						"memory":            resource.MustParse("512Mi"),
 					},
 				}
 				s.Equal(resourceExpected, resourceRequirements, "should be equal")


### PR DESCRIPTION
# Rationale

We set expected resource requests/limits for the initContainer CPU/memory. We should add it for [ephemeral-storage](http://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#setting-requests-and-limits-for-local-ephemeral-storage) as well.


## Changes

Adds `ephemeral-storage` defaults to each `initContainer`
Updates tests accordingly

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
