### PR TITLE
chore(helm): AS-711 remove support for old kubernetes versions

### DIFF
--- a/helm/fiftyone-teams-app/Chart.yaml
+++ b/helm/fiftyone-teams-app/Chart.yaml
@@ -9,4 +9,4 @@ type: application
 version: 2.9.0
 appVersion: "v2.9.0"
 icon: https://voxel51.com/images/logo/voxel51-logo-horz-color-600dpi.png
-kubeVersion: ">=1.18-0"
+kubeVersion: ">=1.30-0"

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -122,7 +122,7 @@ Helm and Kubectl must be installed and configured on your machine.
 
 The following kubernetes/kubectl versions are required:
 
-Kubernetes: `>=1.18-0`
+Kubernetes: `>=1.30-0`
 
 However, it is recommended to use a
 [supported kubernetes version](https://kubernetes.io/releases/).

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -658,7 +658,7 @@ follow
 | imagePullSecrets | list | `[]` | Container image registry keys. [Reference][image-pull-secrets]. |
 | ingress.annotations | object | `{}` | Ingress annotations. [Reference][annotations]. |
 | ingress.api | object | `{"path":"/*","pathType":"ImplementationSpecific"}` | The ingress rule values for teams-api, when `apiSettings.dnsName` is not empty. [Reference][ingress-rules]. |
-| ingress.className | string | `""` | Name of the ingress class.  When empty, a default Ingress class should be defined. When not empty and Kubernetes version is >1.18.0, this value will be the Ingress class name. [Reference][ingress-default-ingress-class] |
+| ingress.className | string | `""` | Name of the ingress class.  When empty, a default Ingress class should be defined. When not empty, this value will be the Ingress class name. [Reference][ingress-default-ingress-class] |
 | ingress.enabled | bool | `true` | Controls whether to create the ingress. When `false`, uses a pre-existing ingress. [Reference][ingress]. |
 | ingress.labels | object | `{}` | Additional labels for the ingress. [Reference][labels-and-selectors]. |
 | ingress.paths | list | `[{"path":"/cas","pathType":"Prefix","serviceName":"teams-cas","servicePort":80},{"path":"/*","pathType":"ImplementationSpecific","serviceName":"teams-app","servicePort":80}]` | Additional ingress rules for the host `teamsAppSettings.dnsName` for the chart managed ingress (when `ingress.enabled: true`). [Reference][ingress-rules]. |

--- a/helm/fiftyone-teams-app/templates/NOTES.txt
+++ b/helm/fiftyone-teams-app/templates/NOTES.txt
@@ -5,11 +5,5 @@
         https://helm.fiftyone.ai for details.
 {{ end }}
 
-{{- if (semverCompare "<1.28-0" .Capabilities.KubeVersion.GitVersion) }}
-[WARN]  You are running an older version of kubernetes!
-        Currently supported versions of Kubernetes are described at the following link:
-        https://kubernetes.io/releases/
-{{ end }}
-
 Visit the following URL to access your FiftyOne Enterprise application:
   http{{ if $.Values.ingress.tlsEnabled }}s{{ end }}://{{ .Values.teamsAppSettings.dnsName }}

--- a/helm/fiftyone-teams-app/templates/ingress.yaml
+++ b/helm/fiftyone-teams-app/templates/ingress.yaml
@@ -1,15 +1,11 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "fiftyone-teams-app.fullname" . -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+{{- if .Values.ingress.className }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
   {{- end }}
 {{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
-{{- else -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -21,7 +17,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
   defaultBackend:
@@ -45,53 +41,32 @@ spec:
           {{- if and .Values.ingress.paths (gt (len .Values.ingress.paths) 1) }}
           {{- range .Values.ingress.paths }}
           - path: {{ .path }}
-            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: {{ .pathType }}
-            {{- end }}
             backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ .serviceName }}
                 port:
                   number: {{ .servicePort }}
-              {{- else }}
-              serviceName: {{ .serviceName }}
-              servicePort: {{ .servicePort }}
-              {{- end }}
           {{- end }}
           {{- else }}
           - path: {{ .Values.ingress.teamsApp.path }}
-            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: {{ .Values.ingress.teamsApp.pathType }}
-            {{- end }}
             backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ include "teams-app.name" . }}
                 port:
                   number: {{ .Values.teamsAppSettings.service.port }}
-              {{- else }}
-              serviceName: {{ include "teams-app.name" . }}
-              servicePort: {{ .Values.teamsAppSettings.service.port }}
-              {{- end }}
           {{- end }}
     {{- if .Values.apiSettings.dnsName }}
     - host: {{ .Values.apiSettings.dnsName | quote }}
       http:
         paths:
           - path: {{ .Values.ingress.api.path }}
-            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: {{ .Values.ingress.api.pathType }}
-            {{- end }}
             backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ include "teams-api.name" . }}
                 port:
                   number: {{ .Values.apiSettings.service.port }}
-              {{- else }}
-              serviceName: {{ include "teams-api.name" . }}
-              servicePort: {{ .Values.apiSettings.service.port }}
-              {{- end }}
     {{- end }}
 {{- end }}

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -649,7 +649,7 @@ ingress:
     pathType: ImplementationSpecific
 
   # -- Name of the ingress class.  When empty, a default Ingress class should be defined.
-  # When not empty and Kubernetes version is >1.18.0, this value will be the Ingress class name.
+  # When not empty, this value will be the Ingress class name.
   # [Reference][ingress-default-ingress-class]
   className: ""
   # -- Controls whether to create the ingress. When `false`, uses a pre-existing ingress.

--- a/tests/unit/helm/ingress_test.go
+++ b/tests/unit/helm/ingress_test.go
@@ -124,8 +124,6 @@ func (s *ingressTemplateTest) TestApiVersion() {
 	}
 }
 
-// TODO: Unit Test with different k8s versions
-// Given kubernetes version > 1.18-0, when ingress.className is not "" and `ingress.annotations` does not have key `"kubernetes.io/ingress.class"`, then set values.ingress.annotations `"kubernetes.io/ingress.class": {{ .Values.ingress.className }}`
 func (s *ingressTemplateTest) TestMetadataAnnotations() {
 	testCases := []struct {
 		name     string
@@ -317,8 +315,6 @@ func (s *ingressTemplateTest) TestMetadataNamespace() {
 	}
 }
 
-// TODO: Unit Test with different k8s versions
-// Given kubernetes version <1.18-0, when ingress.className is set, then `spec` should not contain `ingressClassName`
 func (s *ingressTemplateTest) TestIngressClassName() {
 	testCases := []struct {
 		name     string
@@ -437,8 +433,6 @@ func (s *ingressTemplateTest) TestTls() {
 	}
 }
 
-// TODO: Resume here.  Add test cases to cover all of the variants of the rules
-// TODO: Test k8s versions when 1.18-0 and 1.19-0
 func (s *ingressTemplateTest) TestRules() {
 	testCases := []struct {
 		name     string


### PR DESCRIPTION
# Rationale

As discussed, any Kubernetes version older than 1.30.0 is EOL and no longer supported by kubernetes. Cloud providers may support as far back as 1.27. For example, [Google supports 1.27](https://cloud.google.com/kubernetes-engine/docs/release-schedule).

In my opinion, taking a stance that we support non-EOL kubernetes versions seems like a decent stance to take. I am open to discussions on the PR!

## Changes

Moves our minimum version from 1.18 to 1.30 in accordance with the [kubernetes release lifecycle](https://kubernetes.io/releases/).

> [!NOTE]
> We will need to make a corresponding `voxel51/fiftyone` PR as well to update deprecation.voxel51.com.

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

Docs only PR

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
