### PR TITLE
chore(values): AS-728 update the FIFTYONE_APP_INSTALL_FIFTYONE_OVERRI…

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -66,9 +66,9 @@ secret:
 #       `teams-plugins` deployment
 #     # See https://github.com/voxel51/fiftyone-teams-app-deploy/tree/main/helm/fiftyone-teams-app#fiftyone-enterprise-plugins
 #     FIFTYONE_PLUGINS_DIR: /opt/plugins
-#     # Set FIFTYONE_TEAMS_VERSION_OVERRIDE to override the `Install FiftyOne`
+#     # Set FIFTYONE_APP_INSTALL_FIFTYONE_OVERRIDE to override the `Install FiftyOne`
 #     # bash command in the `Settings > Install FiftyOne` modal
-#     FIFTYONE_TEAMS_VERSION_OVERRIDE: pip install --index-url https://privatepypi.internal.org fiftyone==2.9.0
+#     FIFTYONE_APP_INSTALL_FIFTYONE_OVERRIDE: pip install --index-url https://privatepypi.internal.org fiftyone==2.9.0
 
 appSettings:
   env:


### PR DESCRIPTION
…DE env var

# Rationale

We had a typo env var in our example `values.yaml` file. The `FIFTYONE_APP_INSTALL_FIFTYONE_OVERRIDE` is actually what overrides the `pip install` string, the `FIFTYONE_TEAMS_VERSION_OVERRIDE` is shown in the footer.

## Changes

<!-- Describe the changes. -->

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

## Testing

Docs only.

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
