### PR TITLE
docs: update references from legacy NFS server (`nfs-server`) to new …

### DIFF
--- a/tests/integration/helm/common_test.go
+++ b/tests/integration/helm/common_test.go
@@ -88,7 +88,7 @@ spec:
             storage: {{ .Capacity }}
 `
 	nfsExportPath      = "/ephemeral-integration-tests/plugins"
-	nfsExportServer    = "nfs-server.us-east5-a.c.computer-vision-team.internal"
+	nfsExportServer    = "voxel51-dev-nfs-server.us-east5-a.c.computer-vision-team.internal"
 	pvCapacity         = "100Mi"
 	pvStorageClassName = "\"\""
 	// License File Secret


### PR DESCRIPTION
…NFS server (`voxel51-dev-nfs-server`)

# Rationale

Now that we have a new NFS server, let's update helm integration test to use the new server (so we can decommission the legacy one. 

This should be OK to merge to main.

## Changes

* replace `nfs-server` with `voxel51-dev-nfs-server`

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

n/a ^

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
