### PR TITLE
chore: kubernetes 1.30 EOL`ed on June 28

### DIFF
--- a/helm/fiftyone-teams-app/Chart.yaml
+++ b/helm/fiftyone-teams-app/Chart.yaml
@@ -9,4 +9,4 @@ type: application
 version: 2.10.1
 appVersion: "v2.10.1"
 icon: https://voxel51.com/images/logo/voxel51-logo-horz-color-600dpi.png
-kubeVersion: ">=1.30-0"
+kubeVersion: ">=1.31-0"

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -122,7 +122,7 @@ Helm and Kubectl must be installed and configured on your machine.
 
 The following kubernetes/kubectl versions are required:
 
-Kubernetes: `>=1.30-0`
+Kubernetes: `>=1.31-0`
 
 However, it is recommended to use a
 [supported kubernetes version](https://kubernetes.io/releases/).


### PR DESCRIPTION
# Rationale

Support for 1.30 ended in June - Ever Forward!

## Changes

<!-- Describe the changes. -->

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
