### PR TITLE
Update values.yaml to include comment about CAS db name

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -80,6 +80,8 @@ appSettings:
 casSettings:
   env:
     FIFTYONE_AUTH_MODE: legacy
+    # Set the name of the Mongo database for CAS if not using the default `cas`
+    # CAS_DATABASE_NAME: your-cas-name
 
 # delegatedOperatorExecutorSettings:
 #   enabled: true


### PR DESCRIPTION
# Rationale

<!-- Explain why you are making this change. Describe the problem. -->

A customer didn't know that CAS had a separate DB or how to configure that name, this adds comment to values.yaml at at least call it out in one additional location

<!-- Describe the changes. -->

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

This brings us closer to docker compose parity which calls it out in the .env: https://github.com/voxel51/fiftyone-teams-app-deploy/blob/17c11828f3e3d02cc7eb32543d26ba3e61ebfe77/docker/internal-auth/env.template#L64

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
