### PR TITLE
docs(docker): add version tag requirement note, fix -d flag typo

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -236,7 +236,8 @@ services:
     image: voxel51/fiftyone-app-torch:v2.17.1
 ```
 
-> ⚠️ Note: Always include a version tag when overriding images (e.g., `:v2.17.1`).
+> [!NOTE]
+> Always include a version tag when overriding images (e.g., `:v2.17.1`).
 > Omitting the tag will result in a **not found** error.
 
 ## :rocket: Step 4: Initial Deployment

--- a/docker/README.md
+++ b/docker/README.md
@@ -236,6 +236,9 @@ services:
     image: voxel51/fiftyone-app-torch:v2.17.1
 ```
 
+> ⚠️ Note: Always include a version tag when overriding images (e.g., `:v2.17.1`).
+> Omitting the tag will result in a **not found** error.
+
 ## :rocket: Step 4: Initial Deployment
 
 ### 1. Enable Database Admin mode

--- a/docker/docs/configuring-delegated-operators.md
+++ b/docker/docs/configuring-delegated-operators.md
@@ -29,7 +29,7 @@ in conjunction with one of the three plugin configurations.
       -f compose.dedicated-plugins.yaml \
       -f compose.delegated-operators.yaml \
       -f compose.override.yaml \
-      up --d
+      up -d
     ```
 
 Optionally, delegated operation run logs may be uploaded to a


### PR DESCRIPTION
# Rationale

<!-- Explain why you are making this change. Describe the problem. -->

1. Magna encountered a `not found` error during their initial deployment because the `compose.override.yaml` image override did not include a version tag. 
2. Additionally, the delegated operators doc contains a `--d` flag typo.

<!-- Please check a priority box below, and also assign a priority label
to the PR. Definitions for each priority are on its label.
-->

Review Priority

* [ ] high
* [ ] medium
* [x] low

## Changes

<!-- Describe the changes. -->
1. Added a note in the Docker README clarifying that a version tag is required when overriding images in `compose.override.yaml`
2. Fixed `--d` to `-d` in `docker/docs/configuring-delegated-operators.md`

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->
Visual review of rendered markdown in GitHub preview.
<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
