### PR TITLE
docs(docker): update deployment guide based on customer deployment feedback

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -157,14 +157,12 @@ mv license.key "${LOCAL_LICENSE_FILE_DIR}/license"
 > Docker Compose reads `.env` natively. Sourcing it can cause issues with
 > values containing special characters (e.g., MongoDB URIs with `@`, `?`, `=`)
 > and may require quoting that is otherwise unnecessary.
-
 > [!IMPORTANT]
 > The license file directory must be accessible to the Docker containers at
 > runtime. Ensure the path is within a directory that is volume-mounted into
 > the containers (e.g., `/opt/data/licenses/`). The license file should have
 > read permissions (`chmod 644`). If the file is stored outside the
 > container's mount path, services will fail to start without a clear error.
-
 > [!TIP]
 > When rotating the license, to ensure that the new license values are
 > picked up immediately, you may need to restart the `teams-cas` and `teams-api`

--- a/docker/README.md
+++ b/docker/README.md
@@ -144,25 +144,18 @@ and dataset sizes.
 
 1. Set `LOCAL_LICENSE_FILE_DIR` in your `.env`
 2. Place the license file there and rename it to `license`
+3. Ensure the license directory is volume-mounted into the containers
+   (e.g., `/opt/data/licenses/`)
+4. Set read permissions on the license file: `chmod 644 license`
 
 ```bash
 # Set this to match the LOCAL_LICENSE_FILE_DIR value in your .env file
 LOCAL_LICENSE_FILE_DIR="/path/to/your/licenses"
 mkdir -p "${LOCAL_LICENSE_FILE_DIR}"
 mv license.key "${LOCAL_LICENSE_FILE_DIR}/license"
+chmod 644 "${LOCAL_LICENSE_FILE_DIR}/license"
 ```
 
-> [!WARNING]
-> **Do not `source` (`. .env`) the `.env` file in your shell.**
-> Docker Compose reads `.env` natively. Sourcing it can cause issues with
-> values containing special characters (e.g., MongoDB URIs with `@`, `?`, `=`)
-> and may require quoting that is otherwise unnecessary.
-> [!IMPORTANT]
-> The license file directory must be accessible to the Docker containers at
-> runtime. Ensure the path is within a directory that is volume-mounted into
-> the containers (e.g., `/opt/data/licenses/`). The license file should have
-> read permissions (`chmod 644`). If the file is stored outside the
-> container's mount path, services will fail to start without a clear error.
 > [!TIP]
 > When rotating the license, to ensure that the new license values are
 > picked up immediately, you may need to restart the `teams-cas` and `teams-api`
@@ -270,13 +263,6 @@ services:
       FIFTYONE_DATABASE_ADMIN: false
 ```
 
-> [!IMPORTANT]
-> This is required **only for the very first deployment** to create the
-> database schema. After initial deployment is verified and all containers
-> are healthy, set `FIFTYONE_DATABASE_ADMIN` to `false` and restart. It
-> should remain `false` for normal operation, including during version
-> upgrades. Leaving it `true` risks unintended automatic database
-> migrations on container restarts.
 
 ### 2. Launch the application
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -251,13 +251,11 @@ services:
 
 > [!NOTE]
 > Default images and versions for all services are defined in
-> `common-services.yaml` and will be used automatically. You only need to
-> specify images in `compose.override.yaml` if you want to customize — for
-> example, switching `fiftyone-app` to the `-torch` or `-gpt` variant, or
-> pinning a specific version. The override can be extended to other services
-> for additional customization as needed. Always include a version tag when
-> overriding images (e.g., `:v2.17.1`). Omitting the tag will result in a
-> **not found** error.
+> `common-services.yaml`. To override an image or version, 
+> set the value in `compose.override.yaml`. For
+> example, instead of using the `fiftyone-app` image, you may instead the `fiftyone-app-gpt` image.
+> Always include a version tag when overriding images (e.g., `:vX.Y.Z`).
+> Omitting the tag will result in a **not found** error.
 
 ## :rocket: Step 4: Initial Deployment
 
@@ -269,7 +267,7 @@ In `compose.override.yaml`, make sure:
 services:
   fiftyone-app:
     environment:
-      FIFTYONE_DATABASE_ADMIN: true # Only for first install
+      FIFTYONE_DATABASE_ADMIN: false
 ```
 
 > [!IMPORTANT]
@@ -298,16 +296,6 @@ docker compose \
   up -d
 ```
 
-> [!IMPORTANT]
-> `compose.yaml` must be included as the base file when using
-> `compose.delegated-operators.yaml`. While `compose.delegated-operators.yaml`
-> does reference `teams-do-common` from `../common-services.yaml`, it only
-> defines the `teams-do` service and does NOT include the core services
-> (`fiftyone-app`, `teams-api`, `teams-app`, `teams-cas`). Therefore you must
-> include `compose.yaml` as the base file to provide those core services.
-> Contrast this with `compose.plugins.yaml` and `compose.dedicated-plugins.yaml`
-> (which replace `compose.yaml`). Without `compose.yaml`, containers will
-> start but fail to communicate with each other.
 
 This will start the following containers:
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -302,10 +302,13 @@ docker compose \
 
 > [!IMPORTANT]
 > `compose.yaml` must be included as the base file when using
-> `compose.delegated-operators.yaml`. Unlike `compose.dedicated-plugins.yaml`
-> or `compose.plugins.yaml` (which replace `compose.yaml`),
-> `compose.delegated-operators.yaml` is an overlay and does not reference
-> `common-services.yaml` on its own. Without `compose.yaml`, containers will
+> `compose.delegated-operators.yaml`. While `compose.delegated-operators.yaml`
+> does reference `teams-do-common` from `../common-services.yaml`, it only
+> defines the `teams-do` service and does NOT include the core services
+> (`fiftyone-app`, `teams-api`, `teams-app`, `teams-cas`). Therefore you must
+> include `compose.yaml` as the base file to provide those core services.
+> Contrast this with `compose.plugins.yaml` and `compose.dedicated-plugins.yaml`
+> (which replace `compose.yaml`). Without `compose.yaml`, containers will
 > start but fail to communicate with each other.
 
 This will start the following containers:

--- a/docker/README.md
+++ b/docker/README.md
@@ -146,12 +146,27 @@ and dataset sizes.
 2. Place the license file there and rename it to `license`
 
 ```bash
-. .env
+# Set this to match the LOCAL_LICENSE_FILE_DIR value in your .env file
+LOCAL_LICENSE_FILE_DIR="/path/to/your/licenses"
 mkdir -p "${LOCAL_LICENSE_FILE_DIR}"
 mv license.key "${LOCAL_LICENSE_FILE_DIR}/license"
 ```
 
-> [!TIP] When rotating the license, to ensure that the new license values are
+> [!WARNING]
+> **Do not `source` (`. .env`) the `.env` file in your shell.**
+> Docker Compose reads `.env` natively. Sourcing it can cause issues with
+> values containing special characters (e.g., MongoDB URIs with `@`, `?`, `=`)
+> and may require quoting that is otherwise unnecessary.
+
+> [!IMPORTANT]
+> The license file directory must be accessible to the Docker containers at
+> runtime. Ensure the path is within a directory that is volume-mounted into
+> the containers (e.g., `/opt/data/licenses/`). The license file should have
+> read permissions (`chmod 644`). If the file is stored outside the
+> container's mount path, services will fail to start without a clear error.
+
+> [!TIP]
+> When rotating the license, to ensure that the new license values are
 > picked up immediately, you may need to restart the `teams-cas` and `teams-api`
 > services.
 
@@ -237,8 +252,14 @@ services:
 ```
 
 > [!NOTE]
-> Always include a version tag when overriding images (e.g., `:v2.17.1`).
-> Omitting the tag will result in a **not found** error.
+> Default images and versions for all services are defined in
+> `common-services.yaml` and will be used automatically. You only need to
+> specify images in `compose.override.yaml` if you want to customize — for
+> example, switching `fiftyone-app` to the `-torch` or `-gpt` variant, or
+> pinning a specific version. The override can be extended to other services
+> for additional customization as needed. Always include a version tag when
+> overriding images (e.g., `:v2.17.1`). Omitting the tag will result in a
+> **not found** error.
 
 ## :rocket: Step 4: Initial Deployment
 
@@ -250,10 +271,16 @@ In `compose.override.yaml`, make sure:
 services:
   fiftyone-app:
     environment:
-      FIFTYONE_DATABASE_ADMIN: true
+      FIFTYONE_DATABASE_ADMIN: true # Only for first install
 ```
 
-> This allows the application to create and migrate the database schema.
+> [!IMPORTANT]
+> This is required **only for the very first deployment** to create the
+> database schema. After initial deployment is verified and all containers
+> are healthy, set `FIFTYONE_DATABASE_ADMIN` to `false` and restart. It
+> should remain `false` for normal operation, including during version
+> upgrades. Leaving it `true` risks unintended automatic database
+> migrations on container restarts.
 
 ### 2. Launch the application
 
@@ -267,10 +294,19 @@ docker compose commands
 
 ```shell
 docker compose \
+  -f compose.yaml \
   -f compose.delegated-operators.yaml \
   -f compose.override.yaml \
   up -d
 ```
+
+> [!IMPORTANT]
+> `compose.yaml` must be included as the base file when using
+> `compose.delegated-operators.yaml`. Unlike `compose.dedicated-plugins.yaml`
+> or `compose.plugins.yaml` (which replace `compose.yaml`),
+> `compose.delegated-operators.yaml` is an overlay and does not reference
+> `common-services.yaml` on its own. Without `compose.yaml`, containers will
+> start but fail to communicate with each other.
 
 This will start the following containers:
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -262,7 +262,7 @@ services:
     environment:
       FIFTYONE_DATABASE_ADMIN: false
 ```
-
+> This allows the application to create and migrate the database schema.
 
 ### 2. Launch the application
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -244,8 +244,8 @@ services:
 
 > [!NOTE]
 > Default images and versions for all services are defined in
-> `common-services.yaml`. To override an image or version, 
-> set the value in `compose.override.yaml`. For example, instead of using 
+> `common-services.yaml`. To override an image or version,
+> set the value in `compose.override.yaml`. For example, instead of using
 > the `fiftyone-app` image, you may instead the `fiftyone-app-gpt` image.
 > Always include a version tag when overriding images (e.g., `:vX.Y.Z`).
 > Omitting the tag will result in a **not found** error.

--- a/docker/README.md
+++ b/docker/README.md
@@ -245,8 +245,8 @@ services:
 > [!NOTE]
 > Default images and versions for all services are defined in
 > `common-services.yaml`. To override an image or version, 
-> set the value in `compose.override.yaml`. For
-> example, instead of using the `fiftyone-app` image, you may instead the `fiftyone-app-gpt` image.
+> set the value in `compose.override.yaml`. For example, instead of using 
+> the `fiftyone-app` image, you may instead the `fiftyone-app-gpt` image.
 > Always include a version tag when overriding images (e.g., `:vX.Y.Z`).
 > Omitting the tag will result in a **not found** error.
 
@@ -262,6 +262,7 @@ services:
     environment:
       FIFTYONE_DATABASE_ADMIN: false
 ```
+
 > This allows the application to create and migrate the database schema.
 
 ### 2. Launch the application
@@ -281,7 +282,6 @@ docker compose \
   -f compose.override.yaml \
   up -d
 ```
-
 
 This will start the following containers:
 


### PR DESCRIPTION
# Rationale

During a customer deployment (Magna), several documentation gaps caused
debugging friction — containers starting but failing to communicate,
quoting issues from sourcing `.env`, unclear license file mount
requirements, and missing guidance on `FIFTYONE_DATABASE_ADMIN` lifecycle.

These changes address each issue encountered during the live deployment sessions.

<!-- Please check a priority box below, and also assign a priority label
to the PR. Definitions for each priority are on its label.
-->

Review Priority

* [ ] high
* [x] medium
* [ ] low

## Changes

1. **Fixed missing `compose.yaml` in delegated operators launch command** — 
   `compose.delegated-operators.yaml` is an overlay, not a replacement. 
   Without `compose.yaml` as the base file, containers start but cannot 
   communicate. Added `compose.yaml` to the command and an IMPORTANT callout 
   explaining the distinction.
2. **Removed `.env` sourcing instruction** — Step 1 previously instructed 
   users to `. .env`, which caused quoting issues with secrets containing 
   special characters. Replaced with manual variable assignment and added 
   a WARNING callout.
3. **Added license file mount path guidance** — clarified that the license 
   directory must be volume-mounted into containers with `chmod 644` permissions.
4. **Clarified image override is optional** — defaults come from 
   `common-services.yaml`. Override is only needed for customization 
   (e.g., `-torch`, `-gpt` variants). Combined with existing version tag note.
5. **Added `FIFTYONE_DATABASE_ADMIN` lifecycle guidance** — `true` only 
   for the very first deployment, then `false` permanently including 
   during upgrades.
6. **Fixed `[!TIP]` formatting** — pre-existing issue where the tag was 
   on the same line as text, preventing GitHub from rendering the callout.

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

## Testing

Visual review of rendered markdown in GitHub preview

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
