### PR TITLE
Kevin/fix skaffold

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -9,5 +9,5 @@ pre-commit 4.6.0
 python 3.14.4
 shellcheck 0.11.0
 shfmt 3.13.1
-skaffold 2.18.3
+skaffold 2.19.0
 yq 4.53.2

--- a/helm/local-self-signed-example/mongodb-community-operator-crds/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
+++ b/helm/local-self-signed-example/mongodb-community-operator-crds/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
@@ -1,10 +1,10 @@
 ---
+# from https://github.com/mongodb/mongodb-kubernetes/blob/master/helm_chart/crds/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    helm.sh/resource-policy: keep
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.18.0
     service.binding: path={.metadata.name}-{.spec.users[0].db}-{.spec.users[0].name},objectType=Secret
     service.binding/connectionString: path={.metadata.name}-{.spec.users[0].db}-{.spec.users[0].name},objectType=Secret,sourceKey=connectionString.standardSrv
     service.binding/password: path={.metadata.name}-{.spec.users[0].db}-{.spec.users[0].name},objectType=Secret,sourceKey=password
@@ -58,7 +58,8 @@ spec:
               description: MongoDBCommunitySpec defines the desired state of MongoDB
               properties:
                 additionalConnectionStringConfig:
-                  description: Additional options to be appended to the connection string. These options apply to the entire resource and to each user.
+                  description: Additional options to be appended to the connection string. These
+                    options apply to the entire resource and to each user.
                   nullable: true
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
@@ -74,7 +75,8 @@ spec:
                   description: AgentConfiguration sets options for the MongoDB automation agent
                   properties:
                     auditLogRotate:
-                      description: AuditLogRotate if enabled, will enable AuditLogRotate for all processes.
+                      description: AuditLogRotate if enabled, will enable AuditLogRotate for all
+                        processes.
                       properties:
                         includeAuditLogsWithMongoDBLogs:
                           description: |-
@@ -171,12 +173,14 @@ spec:
                   properties:
                     processes:
                       items:
-                        description: OverrideProcess contains fields that we can override on the AutomationConfig processes.
+                        description: OverrideProcess contains fields that we can override on the
+                          AutomationConfig processes.
                         properties:
                           disabled:
                             type: boolean
                           logRotate:
-                            description: CrdLogRotate is the crd definition of LogRotate including fields in strings while the agent supports them as float64
+                            description: CrdLogRotate is the crd definition of LogRotate including fields in
+                              strings while the agent supports them as float64
                             properties:
                               includeAuditLogsWithMongoDBLogs:
                                 description: |-
@@ -231,6 +235,9 @@ spec:
                           x-kubernetes-preserve-unknown-fields: true
                       type: object
                   type: object
+                clusterDomain:
+                  format: hostname
+                  type: string
                 featureCompatibilityVersion:
                   description: |-
                     FeatureCompatibilityVersion configures the feature compatibility version that will
@@ -264,7 +271,8 @@ spec:
                       description: Name of a Secret containing a HTTP Basic Auth Password.
                       properties:
                         key:
-                          description: Key is the key in the secret storing this password. Defaults to "password"
+                          description: Key is the key in the secret storing this password. Defaults to
+                            "password"
                           type: string
                         name:
                           description: Name is the name of the secret storing this user's password
@@ -281,7 +289,8 @@ spec:
                         Prometheus endpoint.
                       properties:
                         key:
-                          description: Key is the key in the secret storing this password. Defaults to "password"
+                          description: Key is the key in the secret storing this password. Defaults to
+                            "password"
                           type: string
                         name:
                           description: Name is the name of the secret storing this user's password
@@ -310,7 +319,8 @@ spec:
                     type: object
                   type: array
                 security:
-                  description: Security configures security features, such as TLS, and authentication settings for a deployment
+                  description: Security configures security features, such as TLS, and
+                    authentication settings for a deployment
                   properties:
                     authentication:
                       properties:
@@ -329,14 +339,13 @@ spec:
                                 This field is effectively required, but due to backwards compatibility is
                                 allowed to be empty. Instances of this type with an empty value here are
                                 almost certainly wrong.
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         agentMode:
-                          description: AgentMode contains the authentication mode used by the automation agent.
+                          description: AgentMode contains the authentication mode used by the automation
+                            agent.
                           enum:
                             - SCRAM
                             - SCRAM-SHA-256
@@ -348,7 +357,8 @@ spec:
                           nullable: true
                           type: boolean
                         modes:
-                          description: Modes is an array specifying which authentication methods should be enabled.
+                          description: Modes is an array specifying which authentication methods should be
+                            enabled.
                           items:
                             enum:
                               - SCRAM
@@ -361,7 +371,8 @@ spec:
                         - modes
                       type: object
                     roles:
-                      description: User-specified custom MongoDB roles that should be configured in the deployment.
+                      description: User-specified custom MongoDB roles that should be configured in
+                        the deployment.
                       items:
                         description: CustomRole defines a custom MongoDB role.
                         properties:
@@ -391,7 +402,8 @@ spec:
                           privileges:
                             description: The privileges to grant the role.
                             items:
-                              description: Privilege defines the actions a role is allowed to perform on a given resource.
+                              description: Privilege defines the actions a role is allowed to perform on a
+                                given resource.
                               properties:
                                 actions:
                                   items:
@@ -442,7 +454,8 @@ spec:
                         type: object
                       type: array
                     tls:
-                      description: TLS configuration for both client-server and server-server communication
+                      description: TLS configuration for both client-server and server-server
+                        communication
                       properties:
                         caCertificateSecretRef:
                           description: |-
@@ -456,9 +469,7 @@ spec:
                                 This field is effectively required, but due to backwards compatibility is
                                 allowed to be empty. Instances of this type with an empty value here are
                                 almost certainly wrong.
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -475,9 +486,7 @@ spec:
                                 This field is effectively required, but due to backwards compatibility is
                                 allowed to be empty. Instances of this type with an empty value here are
                                 almost certainly wrong.
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -496,16 +505,15 @@ spec:
                                 This field is effectively required, but due to backwards compatibility is
                                 allowed to be empty. Instances of this type with an empty value here are
                                 almost certainly wrong.
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         enabled:
                           type: boolean
                         optional:
-                          description: Optional configures if TLS should be required or optional for connections
+                          description: Optional configures if TLS should be required or optional for
+                            connections
                           type: boolean
                       required:
                         - enabled
@@ -517,7 +525,8 @@ spec:
                     that should be merged into the operator created one.
                   properties:
                     metadata:
-                      description: StatefulSetMetadataWrapper is a wrapper around Labels and Annotations
+                      description: StatefulSetMetadataWrapper is a wrapper around Labels and
+                        Annotations
                       properties:
                         annotations:
                           additionalProperties:
@@ -535,12 +544,14 @@ spec:
                     - spec
                   type: object
                 type:
-                  description: Type defines which type of MongoDB deployment the resource should create
+                  description: Type defines which type of MongoDB deployment the resource should
+                    create
                   enum:
                     - ReplicaSet
                   type: string
                 users:
-                  description: Users specifies the MongoDB users that should be configured in your deployment
+                  description: Users specifies the MongoDB users that should be configured in your
+                    deployment
                   items:
                     properties:
                       additionalConnectionStringConfig:
@@ -550,13 +561,22 @@ spec:
                         nullable: true
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
+                      connectionStringSecretAnnotations:
+                        additionalProperties:
+                          type: string
+                        description: ConnectionStringSecretAnnotations is the annotations of the secret
+                          object created by the operator which exposes the
+                          connection strings for the user.
+                        type: object
                       connectionStringSecretName:
                         description: |-
                           ConnectionStringSecretName is the name of the secret object created by the operator which exposes the connection strings for the user.
                           If provided, this secret must be different for each user in a deployment.
                         type: string
                       connectionStringSecretNamespace:
-                        description: ConnectionStringSecretNamespace is the namespace of the secret object created by the operator which exposes the connection strings for the user.
+                        description: ConnectionStringSecretNamespace is the namespace of the secret
+                          object created by the operator which exposes the
+                          connection strings for the user.
                         type: string
                       db:
                         default: admin
@@ -566,10 +586,12 @@ spec:
                         description: Name is the username of the user
                         type: string
                       passwordSecretRef:
-                        description: PasswordSecretRef is a reference to the secret containing this user's password
+                        description: PasswordSecretRef is a reference to the secret containing this
+                          user's password
                         properties:
                           key:
-                            description: Key is the key in the secret storing this password. Defaults to "password"
+                            description: Key is the key in the secret storing this password. Defaults to
+                              "password"
                             type: string
                           name:
                             description: Name is the name of the secret storing this user's password

--- a/skaffold-cert-manager.yaml
+++ b/skaffold-cert-manager.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: skaffold/v4beta9
+apiVersion: skaffold/v4beta14
 kind: Config
 metadata:
   name: cert-manager-crds
@@ -15,7 +15,7 @@ deploy:
   kubectl: {}
 
 ---
-apiVersion: skaffold/v4beta9
+apiVersion: skaffold/v4beta14
 kind: Config
 metadata:
   name: cert-manager-self-signed-cluster-issuer
@@ -33,7 +33,7 @@ deploy:
   kubectl: {}
 
 ---
-apiVersion: skaffold/v4beta9
+apiVersion: skaffold/v4beta14
 kind: Config
 metadata:
   name: cert-manager

--- a/skaffold-mongodb.yaml
+++ b/skaffold-mongodb.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: skaffold/v4beta9
+apiVersion: skaffold/v4beta14
 kind: Config
 metadata:
   name: mongodb-community-operator-crds
@@ -13,7 +13,7 @@ deploy:
   kubectl: {}
 
 ---
-apiVersion: skaffold/v4beta9
+apiVersion: skaffold/v4beta14
 kind: Config
 metadata:
   name: mongodb-community-operator-namespace
@@ -25,7 +25,7 @@ deploy:
   kubectl: {}
 
 ---
-apiVersion: skaffold/v4beta9
+apiVersion: skaffold/v4beta14
 kind: Config
 metadata:
   name: mongodb-community-operator-secrets
@@ -40,7 +40,7 @@ requires:
   - configs:
       - mongodb-community-operator-namespace
 ---
-apiVersion: skaffold/v4beta9
+apiVersion: skaffold/v4beta14
 kind: Config
 metadata:
   name: mongodb

--- a/skaffold-voxel51-license.yaml
+++ b/skaffold-voxel51-license.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: skaffold/v4beta9
+apiVersion: skaffold/v4beta14
 kind: Config
 metadata:
   name: license

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: skaffold/v4beta9
+apiVersion: skaffold/v4beta14
 kind: Config
 metadata:
   name: fiftyone-teams


### PR DESCRIPTION
# Rationale

For https://github.com/voxel51/fiftyone-teams-app-deploy/pull/558 I used the "wrong" base branch.  It should have the `kacey-bump-versions-2.18.0` not the `bump-versions-2.18.0` branch. 

Let's try this again....

The PR checks in https://github.com/voxel51/fiftyone-teams-app-deploy/pull/557 are failing https://github.com/voxel51/fiftyone-teams-app-deploy/actions/runs/25063667641/job/73424717210?pr=557

> Helm release mongodb not installed. Installing...
deploying "mongodb": Failed to install Helm plugin: Installing plugin from local directory (development mode)
Error: plugin is installed but unusable: failed to load plugin "/home/runner/.local/share/helm/plugins/skaffold-render243929300": invalid plugin `version` "0.1": must be valid semver
make: *** [Makefile:268: test-integration-helm-ci] Error 1

Let's fix them.

Review Priority

* [x] high
* [ ] medium
* [ ] low

## Changes

* upgrade skaffold to latest
  * use latest apiVersion for latest skaffold version
* upgrade mongodb community crd  

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

With these changes, I can successfully start the app locally via skaffold. Prior to these changes, I was seeing the same issue as in the failed PR check on #557 

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
