### PR TITLE
chore: fix helm.fiftyone.ai table [AS-1454]

### DIFF
--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -712,6 +712,7 @@ If pods show unhealthy states (e.g., `0/1`, `CrashLoopBackOff`, `Pending`):
 ## Values
 
 <!-- markdownlint-disable MD060 -->
+
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | apiSettings.affinity | object | `{}` | Affinity and anti-affinity for `teams-api`. [Reference][affinity]. |
@@ -1084,6 +1085,7 @@ If pods show unhealthy states (e.g., `0/1`, `CrashLoopBackOff`, `Pending`):
 | teamsAppSettings.updateStrategy | object | `{"type":"RollingUpdate"}` | Control how `teams-app` pods are redeployed during an upgrade. [Reference][upgrade-strategies] |
 | teamsAppSettings.volumeMounts | list | `[]` | Volume mounts for `teams-app` pods. [Reference][volumes]. |
 | teamsAppSettings.volumes | list | `[]` | Volumes for `teams-app` pods. [Reference][volumes]. |
+
 <!-- markdownlint-enable MD060 -->
 
 <!-- Reference Links -->

--- a/helm/fiftyone-teams-app/README.md.gotmpl
+++ b/helm/fiftyone-teams-app/README.md.gotmpl
@@ -718,7 +718,9 @@ If pods show unhealthy states (e.g., `0/1`, `CrashLoopBackOff`, `Pending`):
 ## Values
 
 <!-- markdownlint-disable MD060 -->
+
 {{ template "chart.valuesTable" . }}
+
 <!-- markdownlint-enable MD060 -->
 
 <!-- Reference Links -->


### PR DESCRIPTION
# Rationale

Allen reported that the table in [https://helm.fiftyone.ai/](https://helm.fiftyone.ai/) was broken. I traced it to [this commit](https://github.com/voxel51/fiftyone-teams-app-deploy/commit/c7e1682e9073b9c2fa17f2564294d9d0d55bcde8).  I don't know the motivation behind it.  But something in it may be causing the page rendering issue.

This might fix it? If not, we have a backlog item to look into it further

Review Priority

* [ ] high
* [x] medium
* [ ] low

## Changes

* Add white space for markdown comment

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

n/a ^ This is a helm only change.

## Testing

n/a.  The next release will publish.  We will see if it renders the table correctly after that.

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
