### PR TITLE
fix(telemetry): set kernel user to match workload user for logs

### DIFF
--- a/docker/common-services.yaml
+++ b/docker/common-services.yaml
@@ -217,10 +217,12 @@ services:
   fiftyone-app-telemetry-common:
     image: voxel51/telemetry-sidecar:v2.19.0
     pid: "service:fiftyone-app"
+    # Matches the workload image's USER 1000:1000 so the kernel's
+    # ptrace_may_access() check on /proc/<workload-pid>/fd/1 reads passes via the
+    # same-UID fast path to allow for log tailing
+    user: "1000:1000"
     cap_drop:
       - ALL
-    cap_add:
-      - DAC_READ_SEARCH  # required for reading log files in target container
     security_opt:
       - no-new-privileges:true
     environment:
@@ -242,10 +244,9 @@ services:
   teams-api-telemetry-common:
     image: voxel51/telemetry-sidecar:v2.19.0
     pid: "service:teams-api"
+    user: "1000:1000"
     cap_drop:
       - ALL
-    cap_add:
-      - DAC_READ_SEARCH  # required for reading log files in target container
     security_opt:
       - no-new-privileges:true
     environment:
@@ -267,10 +268,9 @@ services:
   teams-plugins-telemetry-common:
     image: voxel51/telemetry-sidecar:v2.19.0
     pid: "service:teams-plugins"
+    user: "1000:1000"
     cap_drop:
       - ALL
-    cap_add:
-      - DAC_READ_SEARCH  # required for reading log files in target container
     security_opt:
       - no-new-privileges:true
     environment:
@@ -292,10 +292,10 @@ services:
   teams-do-telemetry-common:
     image: voxel51/telemetry-sidecar:v2.19.0
     pid: "service:teams-do"
+    user: "1000:1000"
     cap_drop:
       - ALL
     cap_add:
-      - DAC_READ_SEARCH  # required for reading log files in target container
       - SYS_PTRACE  # allows for additional profiling metrics (sampled stacks via py-spy)
     security_opt:
       - no-new-privileges:true

--- a/tests/integration/compose/docker-compose-internal-auth_test.go
+++ b/tests/integration/compose/docker-compose-internal-auth_test.go
@@ -171,11 +171,7 @@ func (s *commonServicesInternalAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "http://127.0.0.1:8000/health",
 					responsePayload:  `{"status":{"teams":"available"}}`,
 					httpResponseCode: 200,
-					// Sanic's "Starting worker" only fires in multi-worker mode; the test
-					// env runs single-worker, so we assert on Sanic's INFO-level "Goin'
-					// Fast" startup line instead — works regardless of worker count or log
-					// level (INFO is the default).
-					log: "Goin' Fast",
+					log:              "Goin' Fast",
 				},
 				{
 					name:             "teams-app",
@@ -219,11 +215,7 @@ func (s *commonServicesInternalAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "http://127.0.0.1:8000/health",
 					responsePayload:  `{"status":{"teams":"available"}}`,
 					httpResponseCode: 200,
-					// Sanic's "Starting worker" only fires in multi-worker mode; the test
-					// env runs single-worker, so we assert on Sanic's INFO-level "Goin'
-					// Fast" startup line instead — works regardless of worker count or log
-					// level (INFO is the default).
-					log: "Goin' Fast",
+					log:              "Goin' Fast",
 				},
 				{
 					name:             "teams-app",

--- a/tests/integration/compose/docker-compose-internal-auth_test.go
+++ b/tests/integration/compose/docker-compose-internal-auth_test.go
@@ -93,7 +93,7 @@ func (s *commonServicesInternalAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "http://127.0.0.1:8000/health",
 					responsePayload:  `{"status":{"teams":"available"}}`,
 					httpResponseCode: 200,
-					log:              "Starting worker",
+					log:              "Goin' Fast",
 				},
 				{
 					name:             "teams-app",
@@ -130,7 +130,11 @@ func (s *commonServicesInternalAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "http://127.0.0.1:8000/health",
 					responsePayload:  `{"status":{"teams":"available"}}`,
 					httpResponseCode: 200,
-					log:              "Starting worker",
+					// Sanic's "Starting worker" only fires in multi-worker mode; the test
+					// env runs single-worker, so we assert on Sanic's INFO-level "Goin'
+					// Fast" startup line instead — works regardless of worker count or log
+					// level (INFO is the default).
+					log: "Goin' Fast",
 				},
 				{
 					name:             "teams-app",
@@ -167,7 +171,11 @@ func (s *commonServicesInternalAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "http://127.0.0.1:8000/health",
 					responsePayload:  `{"status":{"teams":"available"}}`,
 					httpResponseCode: 200,
-					log:              "Starting worker",
+					// Sanic's "Starting worker" only fires in multi-worker mode; the test
+					// env runs single-worker, so we assert on Sanic's INFO-level "Goin'
+					// Fast" startup line instead — works regardless of worker count or log
+					// level (INFO is the default).
+					log: "Goin' Fast",
 				},
 				{
 					name:             "teams-app",
@@ -211,7 +219,11 @@ func (s *commonServicesInternalAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "http://127.0.0.1:8000/health",
 					responsePayload:  `{"status":{"teams":"available"}}`,
 					httpResponseCode: 200,
-					log:              "Starting worker",
+					// Sanic's "Starting worker" only fires in multi-worker mode; the test
+					// env runs single-worker, so we assert on Sanic's INFO-level "Goin'
+					// Fast" startup line instead — works regardless of worker count or log
+					// level (INFO is the default).
+					log: "Goin' Fast",
 				},
 				{
 					name:             "teams-app",

--- a/tests/integration/compose/docker-compose-legacy-auth_test.go
+++ b/tests/integration/compose/docker-compose-legacy-auth_test.go
@@ -130,11 +130,7 @@ func (s *commonServicesLegacyAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "http://127.0.0.1:8000/health",
 					responsePayload:  `{"status":{"teams":"available"}}`,
 					httpResponseCode: 200,
-					// Sanic's "Starting worker" only fires in multi-worker mode; the test
-					// env runs single-worker, so we assert on Sanic's INFO-level "Goin'
-					// Fast" startup line instead — works regardless of worker count or log
-					// level (INFO is the default).
-					log: "Goin' Fast",
+					log:              "Goin' Fast",
 				},
 				{
 					name:             "teams-app",
@@ -171,11 +167,7 @@ func (s *commonServicesLegacyAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "http://127.0.0.1:8000/health",
 					responsePayload:  `{"status":{"teams":"available"}}`,
 					httpResponseCode: 200,
-					// Sanic's "Starting worker" only fires in multi-worker mode; the test
-					// env runs single-worker, so we assert on Sanic's INFO-level "Goin'
-					// Fast" startup line instead — works regardless of worker count or log
-					// level (INFO is the default).
-					log: "Goin' Fast",
+					log:              "Goin' Fast",
 				},
 				{
 					name:             "teams-app",
@@ -219,11 +211,7 @@ func (s *commonServicesLegacyAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "http://127.0.0.1:8000/health",
 					responsePayload:  `{"status":{"teams":"available"}}`,
 					httpResponseCode: 200,
-					// Sanic's "Starting worker" only fires in multi-worker mode; the test
-					// env runs single-worker, so we assert on Sanic's INFO-level "Goin'
-					// Fast" startup line instead — works regardless of worker count or log
-					// level (INFO is the default).
-					log: "Goin' Fast",
+					log:              "Goin' Fast",
 				},
 				{
 					name:             "teams-app",

--- a/tests/integration/compose/docker-compose-legacy-auth_test.go
+++ b/tests/integration/compose/docker-compose-legacy-auth_test.go
@@ -93,7 +93,7 @@ func (s *commonServicesLegacyAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "http://127.0.0.1:8000/health",
 					responsePayload:  `{"status":{"teams":"available"}}`,
 					httpResponseCode: 200,
-					log:              "Starting worker",
+					log:              "Goin' Fast",
 				},
 				{
 					name:             "teams-app",
@@ -130,7 +130,11 @@ func (s *commonServicesLegacyAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "http://127.0.0.1:8000/health",
 					responsePayload:  `{"status":{"teams":"available"}}`,
 					httpResponseCode: 200,
-					log:              "Starting worker",
+					// Sanic's "Starting worker" only fires in multi-worker mode; the test
+					// env runs single-worker, so we assert on Sanic's INFO-level "Goin'
+					// Fast" startup line instead — works regardless of worker count or log
+					// level (INFO is the default).
+					log: "Goin' Fast",
 				},
 				{
 					name:             "teams-app",
@@ -167,7 +171,11 @@ func (s *commonServicesLegacyAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "http://127.0.0.1:8000/health",
 					responsePayload:  `{"status":{"teams":"available"}}`,
 					httpResponseCode: 200,
-					log:              "Starting worker",
+					// Sanic's "Starting worker" only fires in multi-worker mode; the test
+					// env runs single-worker, so we assert on Sanic's INFO-level "Goin'
+					// Fast" startup line instead — works regardless of worker count or log
+					// level (INFO is the default).
+					log: "Goin' Fast",
 				},
 				{
 					name:             "teams-app",
@@ -211,7 +219,11 @@ func (s *commonServicesLegacyAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "http://127.0.0.1:8000/health",
 					responsePayload:  `{"status":{"teams":"available"}}`,
 					httpResponseCode: 200,
-					log:              "Starting worker",
+					// Sanic's "Starting worker" only fires in multi-worker mode; the test
+					// env runs single-worker, so we assert on Sanic's INFO-level "Goin'
+					// Fast" startup line instead — works regardless of worker count or log
+					// level (INFO is the default).
+					log: "Goin' Fast",
 				},
 				{
 					name:             "teams-app",


### PR DESCRIPTION
# Rationale

- set user so sidecar can access logs without elevated permissions

Review Priority

* [ ] high
* [ ] medium
* [ ] low

## Changes

<!-- Describe the changes. -->

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
