### PR TITLE
fix: increase telemetry-sidecar CPU

### DIFF
--- a/docker/common-services.yaml
+++ b/docker/common-services.yaml
@@ -282,10 +282,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: "0.10"
+          cpus: "0.20"
           memory: 512M
         reservations:
-          cpus: "0.10"
+          cpus: "0.20"
           memory: 512M
     restart: always
 

--- a/docker/common-services.yaml
+++ b/docker/common-services.yaml
@@ -234,10 +234,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: "0.10"
+          cpus: "0.20"
           memory: 512M
         reservations:
-          cpus: "0.10"
+          cpus: "0.20"
           memory: 512M
     restart: always
 

--- a/docker/docs/upgrading.md
+++ b/docker/docs/upgrading.md
@@ -112,15 +112,18 @@ plus a `telemetry-redis` service that buffers the streamed metrics and
 logs.
 
 **Resource impact:**
-Each sidecar reserves `0.10` CPUs and `512M` memory, except the
-`teams-plugins` container which reserves 0.20 CPU. (reservation == limit).
-A default deploy (using `compose.yaml` rather than one of its variants) adds
-two sidecars
-(`fiftyone-app` + `teams-api`), so
-expect roughly **+0.2 CPU** and **+1 GiB memory** in additional
-resource usage, plus the bundled `telemetry-redis` service (`0.10` CPU
-/ `256M` memory reservation, `0.25` / `512M` limits) and its
-`telemetry-redis-data` named volume.
+By default the telemetry requires an additional `0.55` CPU and `1.5Gi` of
+resources used by:
+
+- `telemetry-sidecar` container
+  - `teams-api`: 0.1 CPU and 512 Mi memory
+  - `fiftyone-app`: 0.2 CPU and 512 Mi memory
+- Redis container
+  - 0.25 CPU and 512Mi memory
+
+The additional required resources depends of replica count for each
+deployment.
+The optional deployments may also increase this amount.
 
 ##### Host Requirements
 

--- a/docker/docs/upgrading.md
+++ b/docker/docs/upgrading.md
@@ -112,11 +112,12 @@ plus a `telemetry-redis` service that buffers the streamed metrics and
 logs.
 
 **Resource impact:**
-Each sidecar reserves `0.10` CPUs and `512M` memory
-(reservation == limit).
-A default deploy adds four sidecars
-(`fiftyone-app` + `teams-api` + `teams-plugins` + one `teams-do`), so
-expect roughly **+0.4 CPU** and **+2 GiB memory** in additional
+Each sidecar reserves `0.10` CPUs and `512M` memory, except the
+`teams-plugins` container which reserves 0.20 CPU. (reservation == limit).
+A default deploy (using `compose.yaml` rather than one of its variants) adds
+two sidecars
+(`fiftyone-app` + `teams-api`), so
+expect roughly **+0.2 CPU** and **+1 GiB memory** in additional
 resource usage, plus the bundled `telemetry-redis` service (`0.10` CPU
 / `256M` memory reservation, `0.25` / `512M` limits) and its
 `telemetry-redis-data` named volume.

--- a/helm/docs/upgrading.md
+++ b/helm/docs/upgrading.md
@@ -161,7 +161,16 @@ A default deploy adds three sidecars
 so expect roughly **+600m CPU** and **+1.5 GiB memory** in additional
 resource usage, plus the bundled Redis
 (`250m` CPU / `512Mi` memory, request == limit)
-backed by an `emptyDir`.
+By default the telemetry requires an additional `850m` CPU and `2Gi` of resources used by
+
+* `telemetry-sidecar` container
+  * `200m` CPU and `512Mi` memory per each replica of 
+    * `teams-api` x 1
+    * `fiftyone-app` x 2
+* Redis container
+  * `250m` CPU and `512Mi` memory
+
+The additional required resources depends of replica count for each deployment. The optional deployments may also increase this amount.
 Tune via `telemetry.sidecar.resources` and `telemetry.redis.resources`.
 Opt into a `PersistentVolumeClaim` with
 `telemetry.redis.persistence.enabled: true`.

--- a/helm/docs/upgrading.md
+++ b/helm/docs/upgrading.md
@@ -161,16 +161,19 @@ A default deploy adds three sidecars
 so expect roughly **+600m CPU** and **+1.5 GiB memory** in additional
 resource usage, plus the bundled Redis
 (`250m` CPU / `512Mi` memory, request == limit)
-By default the telemetry requires an additional `850m` CPU and `2Gi` of resources used by
+By default the telemetry requires an additional `850m` CPU and `2Gi` of
+resources used by:
 
-* `telemetry-sidecar` container
-  * `200m` CPU and `512Mi` memory per each replica of 
-    * `teams-api` x 1
-    * `fiftyone-app` x 2
-* Redis container
-  * `250m` CPU and `512Mi` memory
+- `telemetry-sidecar` container
+  - `200m` CPU and `512Mi` memory per each replica of
+    - `teams-api` x 1
+    - `fiftyone-app` x 2
+- Redis container
+  - `250m` CPU and `512Mi` memory
 
-The additional required resources depends of replica count for each deployment. The optional deployments may also increase this amount.
+The additional required resources depends of replica count for each
+deployment.
+The optional deployments may also increase this amount.
 Tune via `telemetry.sidecar.resources` and `telemetry.redis.resources`.
 Opt into a `PersistentVolumeClaim` with
 `telemetry.redis.persistence.enabled: true`.

--- a/helm/docs/upgrading.md
+++ b/helm/docs/upgrading.md
@@ -155,12 +155,13 @@ workloads (and as a native sidecar on on-demand delegated-operator
 buffers the streamed metrics and logs.
 
 **Resource impact:**
-Each sidecar requests `100m` CPU and `512Mi` memory (request == limit).
-A default deploy adds four sidecars
-(`teams-api` + `fiftyone-app` + `teams-plugins` + one
-delegated-operator), so expect roughly **+400m CPU** and **+2 GiB
-memory** in additional resource usage, plus the bundled Redis (`250m`
-CPU / `512Mi` memory, request == limit) backed by an `emptyDir`.
+Each sidecar requests `200m` CPU and `512Mi` memory (request == limit).
+A default deploy adds three sidecars
+(`teams-api` + 2 x `fiftyone-app`),
+so expect roughly **+600m CPU** and **+1.5 GiB memory** in additional
+resource usage, plus the bundled Redis
+(`250m` CPU / `512Mi` memory, request == limit)
+backed by an `emptyDir`.
 Tune via `telemetry.sidecar.resources` and `telemetry.redis.resources`.
 Opt into a `PersistentVolumeClaim` with
 `telemetry.redis.persistence.enabled: true`.

--- a/helm/fiftyone-teams-app/README.md
+++ b/helm/fiftyone-teams-app/README.md
@@ -1100,7 +1100,7 @@ If pods show unhealthy states (e.g., `0/1`, `CrashLoopBackOff`, `Pending`):
 | telemetry.sidecar.image.pullPolicy | string | `"Always"` | Instruct when the kubelet should pull (download) the specified image. One of `IfNotPresent`, `Always` or `Never`. [Reference][image-pull-policy]. |
 | telemetry.sidecar.image.repository | string | `"voxel51/telemetry-sidecar"` | Container image for `telemetry-sidecar`. |
 | telemetry.sidecar.image.tag | string | `""` | Image tag for `telemetry-sidecar`. Defaults to `Chart.AppVersion`. |
-| telemetry.sidecar.resources | object | `{"limits":{"cpu":"100m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"512Mi"}}` | Resource requests/limits for each `telemetry-sidecar` container. |
+| telemetry.sidecar.resources | object | `{"limits":{"cpu":"200m","memory":"512Mi"},"requests":{"cpu":"200m","memory":"512Mi"}}` | Resource requests/limits for each `telemetry-sidecar` container. |
 
 <!-- markdownlint-enable MD060 -->
 

--- a/helm/fiftyone-teams-app/values.schema.json
+++ b/helm/fiftyone-teams-app/values.schema.json
@@ -4274,7 +4274,7 @@
                 "limits": {
                   "properties": {
                     "cpu": {
-                      "default": "100m",
+                      "default": "200m",
                       "title": "cpu",
                       "type": "string"
                     },
@@ -4291,7 +4291,7 @@
                 "requests": {
                   "properties": {
                     "cpu": {
-                      "default": "100m",
+                      "default": "200m",
                       "title": "cpu",
                       "type": "string"
                     },

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -1699,10 +1699,10 @@ telemetry:
     # -- Resource requests/limits for each `telemetry-sidecar` container.
     resources:
       requests:
-        cpu: 100m
+        cpu: 200m
         memory: 512Mi
       limits:
-        cpu: 100m
+        cpu: 200m
         memory: 512Mi
   # -- ServiceAccount names (in `namespace.name`) bound to the telemetry
   # pod-logs Role. When empty, the RoleBinding binds the chart's main app


### PR DESCRIPTION
# Rationale

<!-- Explain why you are making this change. Describe the problem. -->
We have observed that some of the `telemetry-sidecar` containers use near their full `100m` cpu limit.

**Credit:** @kevin-dimichel 

<!-- Please check a priority box below, and also assign a priority label
to the PR. Definitions for each priority are on its label.
-->

Review Priority

* [X] high
* [ ] medium
* [ ] low

## Changes

<!-- Describe the changes. -->
* docker compose: bump cpu reservation/limit to 200m for `teams-plugins-telemetry-common`
* helm: bump all telemetry-sidecars to 200m
* update docs accordingly

Checklist

* [X] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->
Local `helm template`

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
