### PR TITLE
chore(deps): bump actions/setup-python from 6.2.0 to 6.3.0 (#589)

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -32,7 +32,7 @@ jobs:
           sed -i \
             's%voxel51/aloha-github-workflows/.github/actions/generate-version-file@main%./.github/actions/aloha-github-workflows/.github/actions/generate-version-file%' \
             .github/actions/aloha-github-workflows/.github/actions/asdf-install-and-cache/action.yml
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/setup-python@v6.3.0
       - name: Temporary SQLite/LZMA - Install missing libraries
         run: sudo apt install -y libsqlite3-dev libbz2-dev
       - name: Install asdf & tools

--- a/.github/workflows/test-docker-pulls.yml
+++ b/.github/workflows/test-docker-pulls.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/setup-python@v6.3.0
       - name: Checkout voxel51/aloha-github-workflows
         uses: actions/checkout@v7
         with:

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -34,7 +34,7 @@ jobs:
           sed -i \
             's%voxel51/aloha-github-workflows/.github/actions/generate-version-file@main%./.github/actions/aloha-github-workflows/.github/actions/generate-version-file%' \
             .github/actions/aloha-github-workflows/.github/actions/asdf-install-and-cache/action.yml
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/setup-python@v6.3.0
       - name: Install asdf & tools
         uses: ./.github/actions/aloha-github-workflows/.github/actions/asdf-install-and-cache
       - name: Run unit tests
@@ -66,7 +66,7 @@ jobs:
           sed -i \
             's%voxel51/aloha-github-workflows/.github/actions/generate-version-file@main%./.github/actions/aloha-github-workflows/.github/actions/generate-version-file%' \
             .github/actions/aloha-github-workflows/.github/actions/asdf-install-and-cache/action.yml
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/setup-python@v6.3.0
       - name: Temporary SQLite/LZMA - Install missing libraries
         run: sudo apt install -y libsqlite3-dev libbz2-dev
       - name: Install asdf & tools
@@ -123,7 +123,7 @@ jobs:
           sed -i \
             's%voxel51/aloha-github-workflows/.github/actions/generate-version-file@main%./.github/actions/aloha-github-workflows/.github/actions/generate-version-file%' \
             .github/actions/aloha-github-workflows/.github/actions/asdf-install-and-cache/action.yml
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/setup-python@v6.3.0
       - name: Install asdf & tools
         uses: ./.github/actions/aloha-github-workflows/.github/actions/asdf-install-and-cache
       - name: Authenticate to Google Cloud

--- a/.github/workflows/test-helm.yml
+++ b/.github/workflows/test-helm.yml
@@ -28,7 +28,7 @@ jobs:
           sed -i \
             's%voxel51/aloha-github-workflows/.github/actions/generate-version-file@main%./.github/actions/aloha-github-workflows/.github/actions/generate-version-file%' \
             .github/actions/aloha-github-workflows/.github/actions/asdf-install-and-cache/action.yml
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/setup-python@v6.3.0
       - name: Temporary SQLite/LZMA - Install missing libraries
         run: sudo apt install -y libsqlite3-dev libbz2-dev
       - name: Install asdf & tools

--- a/.github/workflows/test-integration-helm.yml
+++ b/.github/workflows/test-integration-helm.yml
@@ -33,7 +33,7 @@ jobs:
           sed -i \
             's%voxel51/aloha-github-workflows/.github/actions/generate-version-file@main%./.github/actions/aloha-github-workflows/.github/actions/generate-version-file%' \
             .github/actions/aloha-github-workflows/.github/actions/asdf-install-and-cache/action.yml
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/setup-python@v6.3.0
       - name: Temporary SQLite/LZMA - Install missing libraries
         run: sudo apt install -y libsqlite3-dev libbz2-dev
       - name: Install asdf & tools


### PR DESCRIPTION
# Rationale

Cherry pick https://github.com/voxel51/fiftyone-teams-app-deploy/pull/589 into release branch.

Review Priority

* [ ] high
* [x] medium
* [ ] low

## Changes

* dependabot bumps [actions/setup-python](https://github.com/actions/setup-python) from 6.2.0 to 6.3.0.

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

n/a. PR checks passed on main.

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
