### PR TITLE
docs(docker): remove obsolete FIFTYONE_DATABASE_ADMIN=true install step

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -42,7 +42,6 @@ regarding FiftyOne Enterprise.
   - [1. Copy the template `.env` file](#1-copy-the-template-env-file)
   - [2. Fill out required values in `.env`](#2-fill-out-required-values-in-env)
   - [3. Create a `compose.override.yaml` to override configuration](#3-create-a-composeoverrideyaml-to-override-configuration)
-  - [:package: Official Docker Images](#package-official-docker-images)
 - [:rocket: Step 4: Initial Deployment](#rocket-step-4-initial-deployment)
   - [1. Database admin mode](#1-database-admin-mode)
   - [2. Launch the application](#2-launch-the-application)
@@ -275,7 +274,6 @@ services:
     environment:
       FIFTYONE_DATABASE_ADMIN: false
 ```
-
 
 ### 2. Launch the application
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -42,6 +42,7 @@ regarding FiftyOne Enterprise.
   - [1. Copy the template `.env` file](#1-copy-the-template-env-file)
   - [2. Fill out required values in `.env`](#2-fill-out-required-values-in-env)
   - [3. Create a `compose.override.yaml` to override configuration](#3-create-a-composeoverrideyaml-to-override-configuration)
+  - [:package: Official Docker Images](#package-official-docker-images)
 - [:rocket: Step 4: Initial Deployment](#rocket-step-4-initial-deployment)
   - [1. Database admin mode](#1-database-admin-mode)
   - [2. Launch the application](#2-launch-the-application)
@@ -210,11 +211,6 @@ print(Fernet.generate_key().decode())
 
 ### 3. Create a `compose.override.yaml` to override configuration
 
-```yaml
-services:
-  fiftyone-app:
-    environment:
-      # Add any environment variable overrides here
 Create an overrides file (`compose.override.yaml`) and add overrides there.
 Avoid changing the `yaml` files in this directory and instead use overrides.
 
@@ -225,6 +221,7 @@ services:
   fiftyone-app:
     environment:
       EXAMPLE_VARIABLE: example-value
+```
 
 ### :package: Official Docker Images
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -267,8 +267,6 @@ services:
       FIFTYONE_DATABASE_ADMIN: false
 ```
 
-> `false` is the safe default. Set `true` only when intentionally running a
-> database migration (see [Upgrades](#upgrades)).
 
 ### 2. Launch the application
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -215,7 +215,7 @@ print(Fernet.generate_key().decode())
 services:
   fiftyone-app:
     environment:
-      FIFTYONE_DATABASE_ADMIN: true # Only for first install
+      # Add any environment variable overrides here
 ```
 
 ### :package: Official Docker Images
@@ -253,9 +253,12 @@ services:
 
 ## :rocket: Step 4: Initial Deployment
 
-### 1. Enable Database Admin mode
+### 1. Database admin mode
 
-In `compose.override.yaml`, make sure:
+A fresh install does **not** require database admin mode (as of v2.9+) — a new
+database automatically initializes to the connecting client's version, so no
+migration is needed. Keep `FIFTYONE_DATABASE_ADMIN: false` (the default) in
+`compose.override.yaml`:
 
 ```yaml
 services:
@@ -264,7 +267,8 @@ services:
       FIFTYONE_DATABASE_ADMIN: false
 ```
 
-> This allows the application to create and migrate the database schema.
+> `false` is the safe default. Set `true` only when intentionally running a
+> database migration (see [Upgrades](#upgrades)).
 
 ### 2. Launch the application
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -44,7 +44,7 @@ regarding FiftyOne Enterprise.
   - [3. Create a `compose.override.yaml` to override configuration](#3-create-a-composeoverrideyaml-to-override-configuration)
   - [:package: Official Docker Images](#package-official-docker-images)
 - [:rocket: Step 4: Initial Deployment](#rocket-step-4-initial-deployment)
-  - [1. Enable Database Admin mode](#1-enable-database-admin-mode)
+  - [1. Database admin mode](#1-database-admin-mode)
   - [2. Launch the application](#2-launch-the-application)
 - [:globe_with_meridians: Step 5: Configure SSL & Reverse Proxy (Nginx / Load Balancer)](#globe_with_meridians-step-5-configure-ssl--reverse-proxy-nginx--load-balancer)
   - [:compass: Routing Overview (Path-Based Proxy)](#compass-routing-overview-path-based-proxy)

--- a/docker/README.md
+++ b/docker/README.md
@@ -216,7 +216,16 @@ services:
   fiftyone-app:
     environment:
       # Add any environment variable overrides here
-```
+Create an overrides file (`compose.override.yaml`) and add overrides there.
+Avoid changing the `yaml` files in this directory and instead use overrides.
+
+For example, adding a variable to the `fiftyone-app` service would look like:
+
+```yaml
+services:
+  fiftyone-app:
+    environment:
+      EXAMPLE_VARIABLE: example-value
 
 ### :package: Official Docker Images
 


### PR DESCRIPTION
## Summary

Removes the obsolete install-time `FIFTYONE_DATABASE_ADMIN: true` guidance from the Docker deployment README and fixes the self-contradictory "Enable Database Admin mode" step, bringing Docker in line with Helm's existing v2.9+ treatment. The migration/upgrade safeguard section is left untouched.

## Motivation

Per [AS-578](https://voxel51.atlassian.net/browse/AS-578) and the cs-aloha thread, the "set `FIFTYONE_DATABASE_ADMIN=true` on first install" procedure is obsolete as of v2.9+. It became unnecessary in fiftyone core commit voxel51/fiftyone@44acde9a530beb8dedf606ea6797223011655ae2 (June 2024): a fresh database now initializes to the **connecting client's version**, so there's nothing to migrate and the admin gate never fires on a fresh install. Because this is core `fiftyone` behavior shipped in the **same images** for both Helm and Docker, it applies to both — Helm's docs were already updated, but the Docker README lagged and even contradicted itself (Step 3 said `true # Only for first install`, while Step 4 showed `false`).

## Changes (`docker/README.md`)

- **Step 3** — removed `FIFTYONE_DATABASE_ADMIN: true # Only for first install` from the `compose.override.yaml` example; fresh installs don't need it.
- **Step 4.1** — renamed "Enable Database Admin mode" → "Database admin mode" and rewrote the note. It previously showed `false` under an "enable" heading and claimed `false` *"allows the application to create and migrate the database schema"* (misleading). It now states admin mode isn't required for a fresh install (v2.9+), that `false` is the safe default, and that `true` is only for intentional migrations (links to Upgrades).
- **Upgrades section** — unchanged; the migration safeguard (`false` to prevent auto-migration + the `fiftyone migrate` behavior) is still correct.

## Test plan

- [x] Docs-only change; reviewed rendered diff.
- No fresh-deployment test required: the obsolescence is in shared `fiftyone` core code (deployment-agnostic), confirmed via the commit history above (`44acde9a53`).

Refs: AS-578 · voxel51/fiftyone@44acde9a53

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AS-578]: https://voxel51.atlassian.net/browse/AS-578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ