### PR TITLE
fix: api log line test flakes race condition

### DIFF
--- a/tests/fixtures/docker/compose.override.mongodb.yaml
+++ b/tests/fixtures/docker/compose.override.mongodb.yaml
@@ -5,6 +5,11 @@ services:
   teams-api:
     depends_on: [mongodb]
     image: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-teams-api:${FIFTYONE_TEAMS_API_VERSION}
+    # Force unbuffered stdout so the startup log line is flushed immediately
+    # rather than sitting in a block buffer. Prevents flaky log assertions in
+    # the integration tests (see checkContainerLogsWithRetries).
+    environment:
+      PYTHONUNBUFFERED: "1"
   teams-app:
     depends_on: [mongodb]
     image: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-teams-app:${FIFTYONE_TEAMS_APP_VERSION}

--- a/tests/integration/compose/common_test.go
+++ b/tests/integration/compose/common_test.go
@@ -42,8 +42,14 @@ func get_logs(t *testing.T, dockerOptions *docker.Options, container string) str
 }
 
 func checkContainerLogsWithRetries(subT *testing.T, dockerOptions *docker.Options, container string, tc string, expected string) {
-	maxRetries := 6
-	retryDelay := 2 * time.Second
+	// Give the log assertion at least as much headroom as validate_endpoint
+	// (10 x 3s = 30s), plus margin. On loaded CI runners the larger compose
+	// stacks (e.g. dedicated plugins) can take longer to emit their startup
+	// line than the previous 6 x 2s (~12s) budget allowed, which caused
+	// non-deterministic failures where an otherwise-healthy container's log
+	// line had not yet surfaced within the window.
+	maxRetries := 15
+	retryDelay := 3 * time.Second
 
 	var log string
 


### PR DESCRIPTION
# Rationale

<!-- Explain why you are making this change. Describe the problem. -->

<!-- Please check a priority box below, and also assign a priority label
to the PR. Definitions for each priority are on its label.
-->
API log line tests are still flaking.

Review Priority

* [x] high
* [ ] medium
* [ ] low

## Changes

<!-- Describe the changes. -->
* sets PYTHONUNBUFFERED=1
* widens the log-assertion retry budget in checkContainerLogsWithRetries

Checklist

* [X] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->
Will see in CI.

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
