### PR TITLE
chore(deps): bump the go_modules group across 1 directory with 2 updates

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -121,7 +121,7 @@ require (
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
-	golang.org/x/crypto v0.51.0 // indirect
+	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -300,8 +300,8 @@ golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
-golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
+golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
+golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6 h1:y5zboxd6LQAqYIhHnB48p0ByQ/GnQx2BE33L8BOHQkI=
 golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6/go.mod h1:U6Lno4MTRCDY+Ba7aCcauB9T60gsv5s4ralQzP72ZoQ=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=


### PR DESCRIPTION
# Rationale

Supersedes https://github.com/voxel51/fiftyone-teams-app-deploy/pull/601 cherry-picking the commit to the release branch and resolving the merge conflicts.

Review Priority

* [ ] high
* [ ] medium
* [x] low

## Changes

```shell
git cherry-pick 09c848c6b5b3322c1d7fe7985fb06a5c438fad9a
cd tests/
# resolve merge conflicts in go.mod
go mod init
go mod tidy
git add go.mod go.sum
git cherry-pick --continue
make test-unit-compose
make test-unit-helm
git push
```

Bumps the go_modules group with 1 update in the /tests directory: [golang.org/x/crypto](https://github.com/golang/crypto).

Updates `golang.org/x/crypto` from 0.45.0 to 0.52.0
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/golang/crypto/commit/a1c0d9929856c8aba2b31f079340f00578eda803"><code>a1c0d99</code></a> go.mod: update golang.org/x dependencies</li>
<li><a href="https://github.com/golang/crypto/commit/3c7c86938f4541c333d506f719388d9c42d4763d"><code>3c7c869</code></a> ssh: fix deadlock on unexpected channel responses</li>
<li><a href="https://github.com/golang/crypto/commit/533fb3f7e4a5ae23f69d1837cd851d35ff5b76ce"><code>533fb3f</code></a> ssh: fix source-address critical option bypass</li>
<li><a href="https://github.com/golang/crypto/commit/abbc44d451a6f9236a2bbd26cbcd4d0fec473da3"><code>abbc44d</code></a> ssh: fix incorrect operator order</li>
<li><a href="https://github.com/golang/crypto/commit/e052873987615dc96fe67607a9a6adb76311344f"><code>e052873</code></a> ssh: fix infinite loop on large channel writes due to integer overflow</li>
<li><a href="https://github.com/golang/crypto/commit/b61cf853a89d82cad68da5e12a6beca2116f8456"><code>b61cf85</code></a> ssh: enforce user presence verification for security keys</li>
<li><a href="https://github.com/golang/crypto/commit/9c2cd33e8d96a96133fd6ff732510ebba539c2bd"><code>9c2cd33</code></a> ssh: enforce strict limits on DSA key parameters</li>
<li><a href="https://github.com/golang/crypto/commit/890731877d85f71cfdc9554e7a27fec4684fc4c4"><code>8907318</code></a> ssh: reject RSA keys with excessively large moduli</li>
<li><a href="https://github.com/golang/crypto/commit/ffd87b4878fa98ca2908ec534e1a410bf095a35e"><code>ffd87b4</code></a> ssh: fix panic when authority callbacks are nil</li>
<li><a href="https://github.com/golang/crypto/commit/4e7a7384ecbc8d519f6f4c11b36fa9d761fc8946"><code>4e7a738</code></a> ssh: fix deadlock on unexpected global responses</li>
<li>Additional commits viewable in <a href="https://github.com/golang/crypto/compare/v0.45.0...v0.52.0">compare view</a></li>
</ul>
</details>
<br />

Updates `golang.org/x/net` from 0.47.0 to 0.54.0
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/golang/net/commit/b138e06246cb323f2f380c2b7f7dd91f581dd56b"><code>b138e06</code></a> go.mod: update golang.org/x dependencies</li>
<li><a href="https://github.com/golang/net/commit/689f70a42abd350f3a1aaa70b0d13eb9543d927a"><code>689f70a</code></a> quic: fix wrong final size being used for RESET_STREAM frame</li>
<li><a href="https://github.com/golang/net/commit/208f306b2f0fd008b388bee2c2644be279778e94"><code>208f306</code></a> http3: increase handshake timeout</li>
<li><a href="https://github.com/golang/net/commit/49810da71b9026da9e0d028a6ad8c7730c52d9c4"><code>49810da</code></a> http2: enable net/http wrapping when go &gt;= 1.27</li>
<li><a href="https://github.com/golang/net/commit/5e11a5ab891c117eda83b4304d60dd13286c1c76"><code>5e11a5a</code></a> quic: fix data race in streamForFrame</li>
<li><a href="https://github.com/golang/net/commit/8c63081cd380ea768db5651941614b73472160ff"><code>8c63081</code></a> http2: use empty Transport rather than DefaultTransport in http2wrap</li>
<li><a href="https://github.com/golang/net/commit/fc7b466ca49cb204039630533ece4fc557eb35cd"><code>fc7b466</code></a> http2: add http2wrap test</li>
<li><a href="https://github.com/golang/net/commit/15c2cb1875fd727313dc4de909b3ee149422fbe2"><code>15c2cb1</code></a> http2: avoid overflowing 32-bit int when http2wrap enabled</li>
<li><a href="https://github.com/golang/net/commit/64651885c2f2d745d77af2d7af2edbf568c179af"><code>6465188</code></a> http2: add wrapped Server</li>
<li><a href="https://github.com/golang/net/commit/72f419a894cb0597dd5b6bcf119086bf2af41231"><code>72f419a</code></a> http2: add wrapped ClientConn</li>
<li>Additional commits viewable in <a href="https://github.com/golang/net/compare/v0.47.0...v0.54.0">compare view</a></li>
</ul>
</details>
<br />

## Testing

locall runs of compose and helm unit tests passed:

```
[fiftyone-teams-app-deploy]$ make test-unit-compose
ok  	github.com/voxel51/fiftyone-teams-app-deploy/unit/compose	2.808s
[fiftyone-teams-app-deploy]$ make test-unit-helm
...
PASS
ok  	github.com/voxel51/fiftyone-teams-app-deploy/unit/helm	17.143s
[fiftyone-teams-app-deploy]$
```
