### PR TITLE
Sid/remove k8s install

### DIFF
--- a/docs/orchestrators/configuring-kubernetes-orchestrator.md
+++ b/docs/orchestrators/configuring-kubernetes-orchestrator.md
@@ -15,7 +15,6 @@
 <!-- toc -->
 
 - [Introduction](#introduction)
-- [Prerequisites](#prerequisites)
 - [Kubernetes Credentials](#kubernetes-credentials)
 - [Create Job Template](#create-job-template)
 - [Container Image](#container-image)

--- a/docs/orchestrators/configuring-kubernetes-orchestrator.md
+++ b/docs/orchestrators/configuring-kubernetes-orchestrator.md
@@ -45,13 +45,6 @@ for execution, on-demand. Jobs are submitted as Kubernetes
 [Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/job/)
 using a Jinja2 template that you provide.
 
-## Prerequisites
-
-Your FiftyOne API deployment must have the `kubernetes` Python package
-installed. This is not included by default, so you will need to add it as an
-extra dependency. See the
-[Custom Plugins Images docs](../custom-plugins.md#custom-plugins-images).
-
 ## Kubernetes Credentials
 
 The orchestrator can authenticate to Kubernetes in two ways:

--- a/helm/docs/configuring-delegated-operators.md
+++ b/helm/docs/configuring-delegated-operators.md
@@ -45,13 +45,6 @@ to create on-demand delegated operators utilizing
 `delegatedOperatorJobTemplates` enables you to create multiple job
 templates that FiftyOne Enterprise can use to create Kubernetes jobs.
 
-> [!NOTE]
-> Using `delegatedOperatorJobTemplates` and on-demand kubernetes orchestration
-> requires that you install the `kubernetes` python client into your
-> `teams-api` image.
-> See
-> [the kubernetes orchestrator docs](../../docs/orchestrators/configuring-kubernetes-orchestrator.md)
-
 FiftyOne Enterprise 2.14+ pre-populates a `teams-do-cpu-default`
 delegated operator `Deployment` by default.
 Configuring the delegated operator has


### PR DESCRIPTION
# Rationale

the kubernetes package now comes installed by default on the teams-api image. removing the notes/mentions in the docs that say they need to install it to set up on-demand orcs

<!-- Please check a priority box below, and also assign a priority label
to the PR. Definitions for each priority are on its label.
-->

Review Priority

* [ ] high
* [x] medium
* [ ] low

## Changes

<!-- Describe the changes. -->

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
