### PR TITLE
docs(multimodal): add fiftyone-app memory sizing guidance

### DIFF
--- a/docker/docs/configuring-multimodal.md
+++ b/docker/docs/configuring-multimodal.md
@@ -112,11 +112,11 @@ projection Parquet/Iceberg tables to compute the grid and its sidebar
 filters. This is a **memory** requirement on `fiftyone-app`, separate from
 the `teams-do` scratch space above.
 
-As of v2.22.0, `fiftyone-app` limits each DuckDB query to the memory
-available to the container automatically — there is no DuckDB memory setting
-to configure. `fiftyone-app` serves requests with multiple Hypercorn
-workers, and each worker runs its own DuckDB connection, so the container's
-memory is divided among them. The approximate per-query ceiling is:
+`fiftyone-app` limits each DuckDB query to the memory available to the
+container automatically — there is no DuckDB memory setting to configure.
+`fiftyone-app` serves requests with multiple Hypercorn workers, and each
+worker runs its own DuckDB connection, so the container's memory is divided
+among them. The approximate per-query ceiling is:
 
 ```text
 ceiling ≈ (fiftyone-app memory limit × 0.8) ÷ number of Hypercorn workers
@@ -132,10 +132,9 @@ each query only ~0.8Gi. Whether that's enough depends entirely on your
 datasets and projections; as a concrete example, 4 workers on a 500m CPU /
 1.5Gi container — only ~0.3Gi per query — proved far too small for wide
 projections. Set `HYPERCORN_WORKERS` in the service's `environment:` block
-to lower the worker count and give each query more headroom; any
-`HYPERCORN_*` variable is passed straight through to Hypercorn. Fewer
-workers also reduces the app's overall request concurrency, so balance it
-against your traffic.
+to lower the worker count and give each query more headroom. Fewer workers
+also reduce the app's overall request concurrency, so balance it against
+your traffic.
 
 ### Recommended Starting Point
 
@@ -150,8 +149,8 @@ services:
 ```
 
 This gives ≈1.6Gi per DuckDB query (`4Gi × 0.8 ÷ 2`). If your widest
-projections (many `*_mean`/`*_max` columns) return empty sidebar filters,
-raise `fiftyone-app` memory or lower `HYPERCORN_WORKERS` further.
+projections (many columns) return empty sidebar filters, raise
+`fiftyone-app` memory or lower `HYPERCORN_WORKERS` further.
 
 ## Pinning Projection Processing With `FIFTYONE_PROJECTION_DELEGATION_TARGET`
 

--- a/docker/docs/configuring-multimodal.md
+++ b/docker/docs/configuring-multimodal.md
@@ -22,6 +22,8 @@
 - [Delegated Operator Scratch Space Requirements](#delegated-operator-scratch-space-requirements)
   - [Why Multimodal Needs Extra Scratch Space](#why-multimodal-needs-extra-scratch-space)
   - [Sizing Guidance](#sizing-guidance)
+- [`fiftyone-app` Memory Sizing](#fiftyone-app-memory-sizing)
+  - [Recommended Starting Point](#recommended-starting-point)
 - [Pinning Projection Processing With `FIFTYONE_PROJECTION_DELEGATION_TARGET`](#pinning-projection-processing-with-fiftyone_projection_delegation_target)
   - [Behavior When Set](#behavior-when-set)
   - [Naming Your `teams-do` Worker](#naming-your-teams-do-worker)
@@ -44,6 +46,8 @@ Running multimodal datasets requires:
    processes multimodal data.
 1. Enough scratch disk space on `teams-do` (delegated operator) containers
    for projection compaction to succeed.
+1. Enough memory on `fiftyone-app` to serve multimodal grid queries, which
+   run DuckDB in-process.
 1. Optionally, `FIFTYONE_PROJECTION_DELEGATION_TARGET` to pin projection
    processing to a specific `teams-do` worker instead of relying on
    automatic selection.
@@ -100,6 +104,54 @@ raise here; the practical requirement is simply:
   named volume) with enough capacity for the above — a read-only root
   filesystem with no `/tmp` mount will make compaction fail outright, not
   just run low on space.
+
+## `fiftyone-app` Memory Sizing
+
+Serving a multimodal grid runs DuckDB inside `fiftyone-app` — it reads the
+projection Parquet/Iceberg tables to compute the grid and its sidebar
+filters. This is a **memory** requirement on `fiftyone-app`, separate from
+the `teams-do` scratch space above.
+
+As of v2.22.0, `fiftyone-app` limits each DuckDB query to the memory
+available to the container automatically — there is no DuckDB memory setting
+to configure. `fiftyone-app` serves requests with multiple Hypercorn
+workers, and each worker runs its own DuckDB connection, so the container's
+memory is divided among them. The approximate per-query ceiling is:
+
+```text
+ceiling ≈ (fiftyone-app memory limit × 0.8) ÷ number of Hypercorn workers
+```
+
+Disk spill is disabled, so a query that needs more than its ceiling returns
+an empty filter widget (logged as an out-of-memory) rather than crashing
+the container.
+
+The worker count defaults to **4** (an `ENV` baked into the `fiftyone-app`
+image, so it's the runtime default). At that default a 4Gi container leaves
+each query only ~0.8Gi. Whether that's enough depends entirely on your
+datasets and projections; as a concrete example, 4 workers on a 500m CPU /
+1.5Gi container — only ~0.3Gi per query — proved far too small for wide
+projections. Set `HYPERCORN_WORKERS` in the service's `environment:` block
+to lower the worker count and give each query more headroom; any
+`HYPERCORN_*` variable is passed straight through to Hypercorn. Fewer
+workers also reduces the app's overall request concurrency, so balance it
+against your traffic.
+
+### Recommended Starting Point
+
+```yaml
+services:
+  fiftyone-app:
+    mem_limit: 4g
+    cpus: "1"
+    environment:
+      VFF_MULTIMODAL: 1
+      HYPERCORN_WORKERS: 2
+```
+
+This gives ≈1.6Gi per DuckDB query (`4Gi × 0.8 ÷ 2`). If your widest
+projections (many `*_mean`/`*_max` columns) return empty sidebar filters,
+raise `fiftyone-app` memory or lower `HYPERCORN_WORKERS` further.
 
 ## Pinning Projection Processing With `FIFTYONE_PROJECTION_DELEGATION_TARGET`
 

--- a/docker/docs/upgrading.md
+++ b/docker/docs/upgrading.md
@@ -115,6 +115,8 @@ Multimodal datasets require:
   `teams-do` workers, `teams-app`, and `teams-plugins`.
 - Sufficient host disk space for `teams-do` containers to stage projection
   compaction files in `/tmp`.
+- Enough memory on `fiftyone-app` to serve multimodal grid queries, which
+  run DuckDB in-process; size it and `HYPERCORN_WORKERS` accordingly.
 - Optionally, `FIFTYONE_PROJECTION_DELEGATION_TARGET` on `teams-api` to pin
   projection processing to a specific `teams-do` worker.
 

--- a/helm/docs/configuring-multimodal.md
+++ b/helm/docs/configuring-multimodal.md
@@ -151,11 +151,11 @@ projection Parquet/Iceberg tables to compute the grid and its sidebar
 filters. This is a **memory** requirement on `fiftyone-app`, separate from
 the delegated-operator scratch space above.
 
-As of v2.22.0, `fiftyone-app` limits each DuckDB query to the memory
-available to the pod automatically — there is no DuckDB memory setting to
-configure. `fiftyone-app` serves requests with multiple Hypercorn workers,
-and each worker runs its own DuckDB connection, so the pod's memory is
-divided among them. The approximate per-query ceiling is:
+`fiftyone-app` limits each DuckDB query to the memory available to the pod
+automatically — there is no DuckDB memory setting to configure.
+`fiftyone-app` serves requests with multiple Hypercorn workers, and each
+worker runs its own DuckDB connection, so the pod's memory is divided among
+them. The approximate per-query ceiling is:
 
 ```text
 ceiling ≈ (fiftyone-app memory limit × 0.8) ÷ number of Hypercorn workers
@@ -171,8 +171,7 @@ query only ~0.8Gi. Whether that's enough depends entirely on your datasets
 and projections; as a concrete example, 4 workers on a 500m CPU / 1.5Gi pod
 — only ~0.3Gi per query — proved far too small for wide projections. Set
 `HYPERCORN_WORKERS` in the app's environment to lower the worker count and
-give each query more headroom; any `HYPERCORN_*` variable is passed
-straight through to Hypercorn. Fewer workers also reduces the app's overall
+give each query more headroom. Fewer workers also reduce the app's overall
 request concurrency, so balance it against your traffic.
 
 ### Recommended Starting Point
@@ -192,10 +191,9 @@ appSettings:
 ```
 
 This gives ≈1.6Gi per DuckDB query (`4Gi × 0.8 ÷ 2`). If your widest
-projections (many `*_mean`/`*_max` columns) return empty sidebar filters,
-raise `fiftyone-app` memory or lower `HYPERCORN_WORKERS` further. Keep
-`requests` equal to `limits` so the scheduler reserves what DuckDB will
-actually use.
+projections (many columns) return empty sidebar filters, raise
+`fiftyone-app` memory or lower `HYPERCORN_WORKERS` further. Keep `requests`
+equal to `limits` so the scheduler reserves what DuckDB will actually use.
 
 ## Pinning Projection Processing With `FIFTYONE_PROJECTION_DELEGATION_TARGET`
 

--- a/helm/docs/configuring-multimodal.md
+++ b/helm/docs/configuring-multimodal.md
@@ -23,6 +23,8 @@
   - [Why Multimodal Needs Extra Scratch Space](#why-multimodal-needs-extra-scratch-space)
   - [Minimum Recommended Sizing](#minimum-recommended-sizing)
   - [Example Storage Configuration](#example-storage-configuration)
+- [`fiftyone-app` Memory Sizing](#fiftyone-app-memory-sizing)
+  - [Recommended Starting Point](#recommended-starting-point)
 - [Pinning Projection Processing With `FIFTYONE_PROJECTION_DELEGATION_TARGET`](#pinning-projection-processing-with-fiftyone_projection_delegation_target)
   - [Behavior When Set](#behavior-when-set)
   - [Example Delegation Target Configuration](#example-delegation-target-configuration)
@@ -38,13 +40,15 @@ A background delegated-operator pipeline (`run_projections` followed by
 `compact_projections`) continuously ingests new data and periodically
 compacts it into larger, size-bounded files.
 
-Running multimodal datasets requires three pieces of configuration beyond a
+Running multimodal datasets requires the following configuration beyond a
 standard install:
 
 1. The `VFF_MULTIMODAL` feature flag, set on every workload that serves or
    processes multimodal data.
 1. Enough ephemeral/scratch storage on delegated-operator workloads for
    projection compaction to succeed.
+1. Enough memory on `fiftyone-app` to serve multimodal grid queries, which
+   run DuckDB in-process.
 1. Optionally, `FIFTYONE_PROJECTION_DELEGATION_TARGET` to pin projection
    processing to a specific orchestrator instead of relying on automatic
    selection.
@@ -139,6 +143,59 @@ processing.
 > writable filesystem and draws directly from the pod's `ephemeral-storage`
 > limit with no separate cap — you only need the explicit `tmpdir` volume
 > and `sizeLimit` when the root filesystem is read-only.
+
+## `fiftyone-app` Memory Sizing
+
+Serving a multimodal grid runs DuckDB inside `fiftyone-app` — it reads the
+projection Parquet/Iceberg tables to compute the grid and its sidebar
+filters. This is a **memory** requirement on `fiftyone-app`, separate from
+the delegated-operator scratch space above.
+
+As of v2.22.0, `fiftyone-app` limits each DuckDB query to the memory
+available to the pod automatically — there is no DuckDB memory setting to
+configure. `fiftyone-app` serves requests with multiple Hypercorn workers,
+and each worker runs its own DuckDB connection, so the pod's memory is
+divided among them. The approximate per-query ceiling is:
+
+```text
+ceiling ≈ (fiftyone-app memory limit × 0.8) ÷ number of Hypercorn workers
+```
+
+Disk spill is disabled, so a query that needs more than its ceiling returns
+an empty filter widget (logged as an out-of-memory) rather than crashing
+the pod.
+
+The worker count defaults to **4** (an `ENV` baked into the `fiftyone-app`
+image, so it's the runtime default). At that default a 4Gi pod leaves each
+query only ~0.8Gi. Whether that's enough depends entirely on your datasets
+and projections; as a concrete example, 4 workers on a 500m CPU / 1.5Gi pod
+— only ~0.3Gi per query — proved far too small for wide projections. Set
+`HYPERCORN_WORKERS` in the app's environment to lower the worker count and
+give each query more headroom; any `HYPERCORN_*` variable is passed
+straight through to Hypercorn. Fewer workers also reduces the app's overall
+request concurrency, so balance it against your traffic.
+
+### Recommended Starting Point
+
+```yaml
+appSettings:
+  env:
+    VFF_MULTIMODAL: 1
+    HYPERCORN_WORKERS: 2
+  resources:
+    limits:
+      cpu: 1
+      memory: 4Gi
+    requests:
+      cpu: 1
+      memory: 4Gi
+```
+
+This gives ≈1.6Gi per DuckDB query (`4Gi × 0.8 ÷ 2`). If your widest
+projections (many `*_mean`/`*_max` columns) return empty sidebar filters,
+raise `fiftyone-app` memory or lower `HYPERCORN_WORKERS` further. Keep
+`requests` equal to `limits` so the scheduler reserves what DuckDB will
+actually use.
 
 ## Pinning Projection Processing With `FIFTYONE_PROJECTION_DELEGATION_TARGET`
 

--- a/helm/docs/upgrading.md
+++ b/helm/docs/upgrading.md
@@ -158,6 +158,8 @@ Multimodal datasets require:
 - Sufficient `ephemeral-storage` and `/tmp` scratch space on
   delegated-operator workloads for projection compaction to complete
   successfully.
+- Enough memory on `fiftyone-app` to serve multimodal grid queries, which
+  run DuckDB in-process; size it and `HYPERCORN_WORKERS` accordingly.
 - Optionally, `FIFTYONE_PROJECTION_DELEGATION_TARGET` on `teams-api` to pin
   projection processing to a specific orchestrator.
 


### PR DESCRIPTION
# Rationale

Serving a multimodal grid runs DuckDB in-process on `fiftyone-app` to read the projection Parquet/Iceberg tables. As of v2.22.0 each query is capped to the pod/container memory and split across the Hypercorn workers, with disk spill disabled — so an undersized `fiftyone-app` silently degrades to empty filter widgets rather than crashing. This is a memory dimension the existing multimodal docs (which cover delegated-operator scratch disk) don't yet address, and it's easy to get wrong: the image defaults to 4 Hypercorn workers, so the per-query budget is a quarter of the pod's memory. Stacked on #605.

Review Priority

* [ ] high
* [x] medium
* [ ] low

## Changes

Adds a `fiftyone-app` Memory Sizing section to both the Helm and Docker `configuring-multimodal.md` guides, plus a one-line pointer in each `upgrading.md` multimodal summary. Each section documents the per-query memory ceiling (`(fiftyone-app memory limit × 0.8) ÷ Hypercorn workers`), the spill-disabled → empty-widget behavior, the image default of `HYPERCORN_WORKERS=4` and how to override it, and a recommended starting point (4Gi / 1 CPU / 2 workers) with config for each deployment method.

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

## Testing

Formula, the `0.8` fraction, the per-connection split across `HYPERCORN_WORKERS`, spill-disabled behavior, and the `HYPERCORN_WORKERS=4` image default were all verified against the source (`fiftyone-teams` #3240 and the deployment Dockerfiles/`entrypoint.sh`). Repo `pre-commit` hooks pass on all four files, including `markdownlint` and the `markdown-toc` generator (TOC entries match with no rewrite).
