### PR TITLE
test(integration/docker): remove service log matches because they are ... [AS-1530]

### DIFF
--- a/tests/integration/compose/docker-compose-internal-auth_test.go
+++ b/tests/integration/compose/docker-compose-internal-auth_test.go
@@ -93,21 +93,21 @@ func (s *commonServicesInternalAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "http://127.0.0.1:8000/health",
 					responsePayload:  `{"status":{"teams":"available"}}`,
 					httpResponseCode: 200,
-					log:              "FiftyOne Teams API starting up",
+					log:              "",
 				},
 				{
 					name:             "teams-app",
 					url:              "http://127.0.0.1:3000/api/hello",
 					responsePayload:  `{"status":"available"}`,
 					httpResponseCode: 200,
-					log:              " ✓ Ready in",
+					log:              "",
 				},
 				{
 					name:             "teams-cas",
 					url:              "http://127.0.0.1:3030/cas/api",
 					responsePayload:  `{"status":"available"}`,
 					httpResponseCode: 200,
-					log:              "FiftyOne CAS starting up",
+					log:              "",
 				},
 				// ordering this last to avoid test flakes where testing for log before the container is running
 				{
@@ -115,7 +115,7 @@ func (s *commonServicesInternalAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "",
 					responsePayload:  "",
 					httpResponseCode: 200,
-					log:              "Running on http://0.0.0.0:5151",
+					log:              "",
 				},
 			},
 		},
@@ -130,21 +130,21 @@ func (s *commonServicesInternalAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "http://127.0.0.1:8000/health",
 					responsePayload:  `{"status":{"teams":"available"}}`,
 					httpResponseCode: 200,
-					log:              "FiftyOne Teams API starting up",
+					log:              "",
 				},
 				{
 					name:             "teams-app",
 					url:              "http://127.0.0.1:3000/api/hello",
 					responsePayload:  `{"status":"available"}`,
 					httpResponseCode: 200,
-					log:              " ✓ Ready in",
+					log:              "",
 				},
 				{
 					name:             "teams-cas",
 					url:              "http://127.0.0.1:3030/cas/api",
 					responsePayload:  `{"status":"available"}`,
 					httpResponseCode: 200,
-					log:              "FiftyOne CAS starting up",
+					log:              "",
 				},
 				// ordering this last to avoid test flakes where testing for log before the container is running
 				{
@@ -152,7 +152,7 @@ func (s *commonServicesInternalAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "",
 					responsePayload:  "",
 					httpResponseCode: 200,
-					log:              "Running on http://0.0.0.0:5151",
+					log:              "",
 				},
 			},
 		},
@@ -167,21 +167,21 @@ func (s *commonServicesInternalAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "http://127.0.0.1:8000/health",
 					responsePayload:  `{"status":{"teams":"available"}}`,
 					httpResponseCode: 200,
-					log:              "FiftyOne Teams API starting up",
+					log:              "",
 				},
 				{
 					name:             "teams-app",
 					url:              "http://127.0.0.1:3000/api/hello",
 					responsePayload:  `{"status":"available"}`,
 					httpResponseCode: 200,
-					log:              " ✓ Ready in",
+					log:              "",
 				},
 				{
 					name:             "teams-cas",
 					url:              "http://127.0.0.1:3030/cas/api",
 					responsePayload:  `{"status":"available"}`,
 					httpResponseCode: 200,
-					log:              "FiftyOne CAS starting up",
+					log:              "",
 				},
 				// ordering this last to avoid test flakes where testing for log before the container is running
 				{
@@ -189,14 +189,14 @@ func (s *commonServicesInternalAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "",
 					responsePayload:  "",
 					httpResponseCode: 0,
-					log:              "Running on http://0.0.0.0:5151",
+					log:              "",
 				},
 				{
 					name:             "teams-plugins",
 					url:              "",
 					responsePayload:  "",
 					httpResponseCode: 0,
-					log:              "Running on http://0.0.0.0:5151", // same as fiftyone-app since plugins uses or is based on the fiftyone-app image
+					log:              "", // same as fiftyone-app since plugins uses or is based on the fiftyone-app image
 				},
 			},
 		},
@@ -211,21 +211,21 @@ func (s *commonServicesInternalAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "http://127.0.0.1:8000/health",
 					responsePayload:  `{"status":{"teams":"available"}}`,
 					httpResponseCode: 200,
-					log:              "FiftyOne Teams API starting up",
+					log:              "",
 				},
 				{
 					name:             "teams-app",
 					url:              "http://127.0.0.1:3000/api/hello",
 					responsePayload:  `{"status":"available"}`,
 					httpResponseCode: 200,
-					log:              " ✓ Ready in",
+					log:              "",
 				},
 				{
 					name:             "teams-cas",
 					url:              "http://127.0.0.1:3030/cas/api",
 					responsePayload:  `{"status":"available"}`,
 					httpResponseCode: 200,
-					log:              "FiftyOne CAS starting up",
+					log:              "",
 				},
 				// ordering this last to avoid test flakes where testing for log before the container is running
 				{
@@ -233,7 +233,7 @@ func (s *commonServicesInternalAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "",
 					responsePayload:  "",
 					httpResponseCode: 0,
-					log:              "Running on http://0.0.0.0:5151",
+					log:              "",
 				},
 				{
 					name:             "teams-do",

--- a/tests/integration/compose/docker-compose-legacy-auth_test.go
+++ b/tests/integration/compose/docker-compose-legacy-auth_test.go
@@ -93,21 +93,21 @@ func (s *commonServicesLegacyAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "http://127.0.0.1:8000/health",
 					responsePayload:  `{"status":{"teams":"available"}}`,
 					httpResponseCode: 200,
-					log:              "FiftyOne Teams API starting up",
+					log:              "",
 				},
 				{
 					name:             "teams-app",
 					url:              "http://127.0.0.1:3000/api/hello",
 					responsePayload:  `{"status":"available"}`,
 					httpResponseCode: 200,
-					log:              " ✓ Ready in",
+					log:              "",
 				},
 				{
 					name:             "teams-cas",
 					url:              "http://127.0.0.1:3030/cas/api",
 					responsePayload:  `{"status":"available"}`,
 					httpResponseCode: 200,
-					log:              "FiftyOne CAS starting up",
+					log:              "",
 				},
 				// ordering this last to avoid test flakes where testing for log before the container is running
 				{
@@ -115,7 +115,7 @@ func (s *commonServicesLegacyAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "",
 					responsePayload:  "",
 					httpResponseCode: 200,
-					log:              "Running on http://0.0.0.0:5151",
+					log:              "",
 				},
 			},
 		},
@@ -130,21 +130,21 @@ func (s *commonServicesLegacyAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "http://127.0.0.1:8000/health",
 					responsePayload:  `{"status":{"teams":"available"}}`,
 					httpResponseCode: 200,
-					log:              "FiftyOne Teams API starting up",
+					log:              "",
 				},
 				{
 					name:             "teams-app",
 					url:              "http://127.0.0.1:3000/api/hello",
 					responsePayload:  `{"status":"available"}`,
 					httpResponseCode: 200,
-					log:              " ✓ Ready in",
+					log:              "",
 				},
 				{
 					name:             "teams-cas",
 					url:              "http://127.0.0.1:3030/cas/api",
 					responsePayload:  `{"status":"available"}`,
 					httpResponseCode: 200,
-					log:              "FiftyOne CAS starting up",
+					log:              "",
 				},
 				// ordering this last to avoid test flakes where testing for log before the container is running
 				{
@@ -152,7 +152,7 @@ func (s *commonServicesLegacyAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "",
 					responsePayload:  "",
 					httpResponseCode: 200,
-					log:              "Running on http://0.0.0.0:5151",
+					log:              "",
 				},
 			},
 		},
@@ -167,21 +167,21 @@ func (s *commonServicesLegacyAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "http://127.0.0.1:8000/health",
 					responsePayload:  `{"status":{"teams":"available"}}`,
 					httpResponseCode: 200,
-					log:              "FiftyOne Teams API starting up",
+					log:              "",
 				},
 				{
 					name:             "teams-app",
 					url:              "http://127.0.0.1:3000/api/hello",
 					responsePayload:  `{"status":"available"}`,
 					httpResponseCode: 200,
-					log:              " ✓ Ready in",
+					log:              "",
 				},
 				{
 					name:             "teams-cas",
 					url:              "http://127.0.0.1:3030/cas/api",
 					responsePayload:  `{"status":"available"}`,
 					httpResponseCode: 200,
-					log:              "FiftyOne CAS starting up",
+					log:              "",
 				},
 				// ordering this last to avoid test flakes where testing for log before the container is running
 				{
@@ -189,14 +189,14 @@ func (s *commonServicesLegacyAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "",
 					responsePayload:  "",
 					httpResponseCode: 0,
-					log:              "Running on http://0.0.0.0:5151",
+					log:              "",
 				},
 				{
 					name:             "teams-plugins",
 					url:              "",
 					responsePayload:  "",
 					httpResponseCode: 0,
-					log:              "Running on http://0.0.0.0:5151", // same as fiftyone-app since plugins uses or is based on the fiftyone-app image
+					log:              "", // same as fiftyone-app since plugins uses or is based on the fiftyone-app image
 				},
 			},
 		},
@@ -211,21 +211,21 @@ func (s *commonServicesLegacyAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "http://127.0.0.1:8000/health",
 					responsePayload:  `{"status":{"teams":"available"}}`,
 					httpResponseCode: 200,
-					log:              "FiftyOne Teams API starting up",
+					log:              "",
 				},
 				{
 					name:             "teams-app",
 					url:              "http://127.0.0.1:3000/api/hello",
 					responsePayload:  `{"status":"available"}`,
 					httpResponseCode: 200,
-					log:              " ✓ Ready in",
+					log:              "",
 				},
 				{
 					name:             "teams-cas",
 					url:              "http://127.0.0.1:3030/cas/api",
 					responsePayload:  `{"status":"available"}`,
 					httpResponseCode: 200,
-					log:              "FiftyOne CAS starting up",
+					log:              "",
 				},
 				// ordering this last to avoid test flakes where testing for log before the container is running
 				{
@@ -233,7 +233,7 @@ func (s *commonServicesLegacyAuthDockerComposeUpTest) TestDockerComposeUp() {
 					url:              "",
 					responsePayload:  "",
 					httpResponseCode: 0,
-					log:              "Running on http://0.0.0.0:5151",
+					log:              "",
 				},
 				{
 					name:             "teams-do",


### PR DESCRIPTION
… inconsistent during CI.

# Rationale
Starting a few releases ago, the Docker compose integration tests started to fail on our log match message. We do not see this problem with the helm integration tests.

Alan and I talked about this a few times over and agreed to remove them from the composed temporarily to unblock the releases. We may re-add them later if we find that they provide value.

This is currently blocking the v2.22.0 release

https://voxel51.atlassian.net/browse/AS-1530

<!-- Please check a priority box below, and also assign a priority label
to the PR. Definitions for each priority are on its label.
-->

Review Priority

* [x] high
* [ ] medium
* [ ] low

## Changes

* docker
  * integration
    * remove log match strings

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

Running tests, locally pass

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
