### PR TITLE
chore: remove GPU instructions for sidecar

### DIFF
--- a/docker/docs/configuring-telemetry.md
+++ b/docker/docs/configuring-telemetry.md
@@ -122,8 +122,9 @@ docker compose --profile gpu \
         [Scaling teams-do with telemetry](#scaling-teams-do-with-telemetry)
   - `teams-do-gpu-telemetry`
     - Only with `compose.delegated-operators.gpu.yaml` and `--profile gpu`
-    - The sidecar reads GPU metrics via NVML and requires its own GPU
-      reservation.
+    - The paired sidecar for the GPU worker. Collects the same
+      CPU/memory/log metrics as any other sidecar; it does not access
+      the GPU.
 - Environment Variables
   - `FIFTYONE_TELEMETRY_REDIS_URL` environment variable is set on these services
     so the telemetry blueprint and server-sent events endpoints can read from Redis
@@ -225,8 +226,8 @@ All knobs live in your `.env` — see `env.template` for the full list:
 | `TEAMS_API_TARGET_NAME`            | `fiftyone-teams-api`                   | Substring used to locate the teams-api process                                                     |
 | `TEAMS_PLUGINS_TARGET_NAME`        | `hypercorn`                            | Substring used to locate the teams-plugins process                                                 |
 | `TEAMS_DO_TARGET_NAME`             | `fiftyone delegated`                   | Substring used to locate the teams-do process                                                      |
-| `NVIDIA_GPU_COUNT`                 | `1`                                    | GPU reservation for the GPU DO worker + sidecar                                                    |
-| `NVIDIA_VISIBLE_DEVICES`           | `all`                                  | Pass-through to teams-do-gpu / sidecar                                                             |
+| `NVIDIA_GPU_COUNT`                 | `1`                                    | GPU reservation for the GPU DO worker                                                              |
+| `NVIDIA_VISIBLE_DEVICES`           | `all`                                  | Pass-through to teams-do-gpu                                                                       |
 | `NVIDIA_DRIVER_CAPABILITIES`       | `compute,utility`                      | Must include `utility` so NVML is available                                                        |
 
 ## Resource limits

--- a/docker/internal-auth/compose.delegated-operators.gpu.yaml
+++ b/docker/internal-auth/compose.delegated-operators.gpu.yaml
@@ -65,13 +65,7 @@ services:
         reservations:
           cpus: "0.10"
           memory: 512M
-          devices:
-            - driver: nvidia
-              count: ${NVIDIA_GPU_COUNT:-1}
-              capabilities: ["gpu"]
     environment:
-      NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES:-all}
-      NVIDIA_DRIVER_CAPABILITIES: ${NVIDIA_DRIVER_CAPABILITIES:-compute,utility}
       POD_NAME: teams-do-gpu
       POD_NAMESPACE: ${TELEMETRY_NAMESPACE:-docker}
       SERVICE_TYPE: delegated-operator

--- a/docker/legacy-auth/compose.delegated-operators.gpu.yaml
+++ b/docker/legacy-auth/compose.delegated-operators.gpu.yaml
@@ -65,13 +65,7 @@ services:
         reservations:
           cpus: "0.10"
           memory: 512M
-          devices:
-            - driver: nvidia
-              count: ${NVIDIA_GPU_COUNT:-1}
-              capabilities: ["gpu"]
     environment:
-      NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES:-all}
-      NVIDIA_DRIVER_CAPABILITIES: ${NVIDIA_DRIVER_CAPABILITIES:-compute,utility}
       POD_NAME: teams-do-gpu
       POD_NAMESPACE: ${TELEMETRY_NAMESPACE:-docker}
       SERVICE_TYPE: delegated-operator

--- a/helm/fiftyone-teams-app/templates/_telemetry.tpl
+++ b/helm/fiftyone-teams-app/templates/_telemetry.tpl
@@ -90,8 +90,6 @@ Inputs (dict):
   podName          — value for POD_NAME env var (defaults to fieldRef metadata.name)
   executor         — bool, when true emit EXECUTOR_SIDECAR=true and TELEMETRY_SOCKET env
   targetContainer  — when set, emit TARGET_CONTAINER env var (used by job sidecars)
-  sidecarEnv       — optional map of extra env vars to append (e.g. NVIDIA_* so a
-                     sidecar on a GPU node can read NVML/GPU metrics)
 */}}
 {{- define "telemetry.sidecar-env" -}}
 {{- $secretName := .ctx.Values.secret.name -}}
@@ -129,10 +127,6 @@ Inputs (dict):
     secretKeyRef:
       name: {{ $secretName }}
       key: fiftyoneDatabaseName
-{{- range $name, $value := .sidecarEnv }}
-- name: {{ $name }}
-  value: {{ $value | quote }}
-{{- end }}
 {{- end }}
 
 {{/*

--- a/helm/fiftyone-teams-app/templates/delegated-operator-instance-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/delegated-operator-instance-deployment.yaml
@@ -17,16 +17,6 @@
 {{- $defaultDescription := printf "Long running operations delegated to %s" $name }}
 {{- $updateStrategy := merge (dict) ($v.updateStrategy|default dict) ($baseTpl.updateStrategy) }}
 {{- $mergedResources := merge (dict) ($v.resources | default dict) ($baseTpl.resources | default dict) }}
-{{- /* When the executor requests a GPU, expose that same GPU to its telemetry
-       sidecar for read-only metrics. This sets env vars only — the sidecar never
-       requests its own nvidia.com/gpu, so it consumes no GPU quota and the
-       executor keeps the allocated GPU. Honored where the NVIDIA runtime accepts
-       NVIDIA_VISIBLE_DEVICES (most setups; GKE blocks env-based exposure). */}}
-{{- $gpuRequested := or (not (empty (dig "limits" "nvidia.com/gpu" "" $mergedResources))) (not (empty (dig "requests" "nvidia.com/gpu" "" $mergedResources))) }}
-{{- $sidecarEnv := dict }}
-{{- if $gpuRequested }}
-{{- $sidecarEnv = dict "NVIDIA_VISIBLE_DEVICES" "all" "NVIDIA_DRIVER_CAPABILITIES" "compute,utility" }}
-{{- end }}
 {{- $mergedVolumeMounts := $v.volumeMounts | default $baseTpl.volumeMounts | default list }}
 {{- $mergedVolumes := $v.volumes | default $baseTpl.volumes | default list }}
 {{- if $.Values.telemetry.enabled }}
@@ -143,7 +133,7 @@ spec:
             periodSeconds: {{ ($v.startup).periodSeconds | default $baseTpl.startup.periodSeconds }}
             timeoutSeconds: {{ ($v.startup).timeoutSeconds | default $baseTpl.startup.timeoutSeconds }}
         {{- if $.Values.telemetry.enabled }}
-        {{- include "telemetry.sidecar" (dict "ctx" $ "serviceType" "delegated-operator" "targetName" "fiftyone delegated" "executor" true "sidecarEnv" $sidecarEnv) | nindent 8 }}
+        {{- include "telemetry.sidecar" (dict "ctx" $ "serviceType" "delegated-operator" "targetName" "fiftyone delegated" "executor" true) | nindent 8 }}
         {{- end }}
       {{- with (merge (dict) ($v.nodeSelector | default dict) ($baseTpl.nodeSelector)) }}
       nodeSelector:

--- a/helm/fiftyone-teams-app/templates/delegated-operator-job-configmap.yaml
+++ b/helm/fiftyone-teams-app/templates/delegated-operator-job-configmap.yaml
@@ -44,17 +44,6 @@ data:
   {{- $mergedVolumeMounts := $jobConfig.volumeMounts | default $baseTpl.volumeMounts | default list }}
   {{- $mergedVolumes := $jobConfig.volumes | default $baseTpl.volumes | default list }}
 
-  {{- /* When the executor requests a GPU, expose that same GPU to its telemetry
-         sidecar for read-only metrics. This sets env vars only — the sidecar never
-         requests its own nvidia.com/gpu, so it consumes no GPU quota and the
-         executor keeps the allocated GPU. Honored where the NVIDIA runtime accepts
-         NVIDIA_VISIBLE_DEVICES (most setups; GKE blocks env-based exposure). */}}
-  {{- $gpuRequested := or (not (empty (dig "limits" "nvidia.com/gpu" "" $mergedResources))) (not (empty (dig "requests" "nvidia.com/gpu" "" $mergedResources))) }}
-  {{- $sidecarEnv := dict }}
-  {{- if $gpuRequested }}
-  {{- $sidecarEnv = dict "NVIDIA_VISIBLE_DEVICES" "all" "NVIDIA_DRIVER_CAPABILITIES" "compute,utility" }}
-  {{- end }}
-
   {{- if $.Values.telemetry.enabled }}
     {{- $hasSocketVolume := false }}
     {{- range $vol := $mergedVolumes }}
@@ -157,7 +146,7 @@ data:
               {{- end }}
           {{- if $.Values.telemetry.enabled }}
           initContainers:
-            {{- include "telemetry.native-sidecar" (dict "ctx" $ "serviceType" "delegated-operator" "targetName" "fiftyone delegated" "executor" true "targetContainer" "executor" "sidecarEnv" $sidecarEnv) | nindent 12 }}
+            {{- include "telemetry.native-sidecar" (dict "ctx" $ "serviceType" "delegated-operator" "targetName" "fiftyone delegated" "executor" true "targetContainer" "executor") | nindent 12 }}
           {{- end }}
           {{- with $mergedNodeSelector }}
           nodeSelector:

--- a/tests/unit/helm/delegated-operator-instance-deployment_test.go
+++ b/tests/unit/helm/delegated-operator-instance-deployment_test.go
@@ -5806,12 +5806,11 @@ func (s *deploymentDelegatedOperatorInstanceTemplateTest) TestTelemetryDisabledO
 		"telemetry-socket volumeMount should be absent when telemetry is disabled")
 }
 
-// TestTelemetrySidecarGpuEnv verifies that when a delegated-operator executor
-// requests a GPU (via resources.limits or resources.requests), its
-// telemetry-sidecar is given the NVIDIA_* env vars needed to read GPU metrics,
-// without the sidecar requesting its own nvidia.com/gpu allocation. When no GPU
-// is requested, the sidecar receives no NVIDIA_* env vars.
-func (s *deploymentDelegatedOperatorInstanceTemplateTest) TestTelemetrySidecarGpuEnv() {
+// TestTelemetrySidecarNoGpu verifies that the delegated-operator
+// telemetry-sidecar never receives GPU access — no NVIDIA_* env vars and no
+// nvidia.com/gpu resource request — even when the executor itself requests a
+// GPU. GPU metrics are collected by the executor process, not the sidecar.
+func (s *deploymentDelegatedOperatorInstanceTemplateTest) TestTelemetrySidecarNoGpu() {
 	const gpuResource = "nvidia.com/gpu"
 
 	// gpuKey escapes the dot in nvidia.com/gpu so helm --set treats the whole
@@ -5822,35 +5821,31 @@ func (s *deploymentDelegatedOperatorInstanceTemplateTest) TestTelemetrySidecarGp
 	}
 
 	testCases := []struct {
-		name      string
-		values    map[string]string
-		expectGpu bool
+		name   string
+		values map[string]string
 	}{
 		{
-			name: "gpuInLimitsExposesEnvToSidecar",
+			name: "gpuInLimits",
 			values: map[string]string{
 				"telemetry.enabled": "true",
 				"delegatedOperatorDeployments.deployments.teamsDoCpuDefault.enabled": "true",
 				gpuKey("limits"): "1",
 			},
-			expectGpu: true,
 		},
 		{
-			name: "gpuInRequestsExposesEnvToSidecar",
+			name: "gpuInRequests",
 			values: map[string]string{
 				"telemetry.enabled": "true",
 				"delegatedOperatorDeployments.deployments.teamsDoCpuDefault.enabled": "true",
 				gpuKey("requests"): "1",
 			},
-			expectGpu: true,
 		},
 		{
-			name: "noGpuOmitsEnvFromSidecar",
+			name: "noGpu",
 			values: map[string]string{
 				"telemetry.enabled": "true",
 				"delegatedOperatorDeployments.deployments.teamsDoCpuDefault.enabled": "true",
 			},
-			expectGpu: false,
 		},
 	}
 
@@ -5872,24 +5867,15 @@ func (s *deploymentDelegatedOperatorInstanceTemplateTest) TestTelemetrySidecarGp
 			sidecar := findContainer(deployment.Spec.Template.Spec.Containers, "telemetry-sidecar")
 			s.Require().NotNil(sidecar, "telemetry-sidecar container not found")
 
-			visibleDevices, hasVisibleDevices := envValue(sidecar.Env, "NVIDIA_VISIBLE_DEVICES")
-			driverCaps, hasDriverCaps := envValue(sidecar.Env, "NVIDIA_DRIVER_CAPABILITIES")
+			_, hasVisibleDevices := envValue(sidecar.Env, "NVIDIA_VISIBLE_DEVICES")
+			_, hasDriverCaps := envValue(sidecar.Env, "NVIDIA_DRIVER_CAPABILITIES")
+			s.False(hasVisibleDevices, "sidecar must not have NVIDIA_VISIBLE_DEVICES")
+			s.False(hasDriverCaps, "sidecar must not have NVIDIA_DRIVER_CAPABILITIES")
 
-			if tc.expectGpu {
-				s.True(hasVisibleDevices, "sidecar should have NVIDIA_VISIBLE_DEVICES")
-				s.Equal("all", visibleDevices, "NVIDIA_VISIBLE_DEVICES value mismatch")
-				s.True(hasDriverCaps, "sidecar should have NVIDIA_DRIVER_CAPABILITIES")
-				s.Equal("compute,utility", driverCaps, "NVIDIA_DRIVER_CAPABILITIES value mismatch")
-
-				// The sidecar reads the executor's GPU; it must not request its own.
-				_, limitsHasGpu := sidecar.Resources.Limits[corev1.ResourceName(gpuResource)]
-				_, requestsHasGpu := sidecar.Resources.Requests[corev1.ResourceName(gpuResource)]
-				s.False(limitsHasGpu, "sidecar must not request nvidia.com/gpu in limits")
-				s.False(requestsHasGpu, "sidecar must not request nvidia.com/gpu in requests")
-			} else {
-				s.False(hasVisibleDevices, "sidecar should not have NVIDIA_VISIBLE_DEVICES when no GPU requested")
-				s.False(hasDriverCaps, "sidecar should not have NVIDIA_DRIVER_CAPABILITIES when no GPU requested")
-			}
+			_, limitsHasGpu := sidecar.Resources.Limits[corev1.ResourceName(gpuResource)]
+			_, requestsHasGpu := sidecar.Resources.Requests[corev1.ResourceName(gpuResource)]
+			s.False(limitsHasGpu, "sidecar must not request nvidia.com/gpu in limits")
+			s.False(requestsHasGpu, "sidecar must not request nvidia.com/gpu in requests")
 		})
 	}
 }

--- a/tests/unit/helm/delegated-operator-instance-deployment_test.go
+++ b/tests/unit/helm/delegated-operator-instance-deployment_test.go
@@ -5821,8 +5821,10 @@ func (s *deploymentDelegatedOperatorInstanceTemplateTest) TestTelemetrySidecarNo
 	}
 
 	testCases := []struct {
-		name   string
-		values map[string]string
+		name          string
+		values        map[string]string
+		gpuInLimits   bool
+		gpuInRequests bool
 	}{
 		{
 			name: "gpuInLimits",
@@ -5831,6 +5833,7 @@ func (s *deploymentDelegatedOperatorInstanceTemplateTest) TestTelemetrySidecarNo
 				"delegatedOperatorDeployments.deployments.teamsDoCpuDefault.enabled": "true",
 				gpuKey("limits"): "1",
 			},
+			gpuInLimits: true,
 		},
 		{
 			name: "gpuInRequests",
@@ -5839,6 +5842,7 @@ func (s *deploymentDelegatedOperatorInstanceTemplateTest) TestTelemetrySidecarNo
 				"delegatedOperatorDeployments.deployments.teamsDoCpuDefault.enabled": "true",
 				gpuKey("requests"): "1",
 			},
+			gpuInRequests: true,
 		},
 		{
 			name: "noGpu",
@@ -5863,6 +5867,14 @@ func (s *deploymentDelegatedOperatorInstanceTemplateTest) TestTelemetrySidecarNo
 
 			var deployment appsv1.Deployment
 			helm.UnmarshalK8SYaml(subT, docs[1], &deployment)
+
+			// The configured GPU must reach the primary executor container.
+			main := findContainer(deployment.Spec.Template.Spec.Containers, "teams-do-cpu-default")
+			s.Require().NotNil(main, "main DO container not found")
+			_, mainLimitsGpu := main.Resources.Limits[corev1.ResourceName(gpuResource)]
+			_, mainRequestsGpu := main.Resources.Requests[corev1.ResourceName(gpuResource)]
+			s.Equal(tc.gpuInLimits, mainLimitsGpu, "primary executor nvidia.com/gpu limits mismatch")
+			s.Equal(tc.gpuInRequests, mainRequestsGpu, "primary executor nvidia.com/gpu requests mismatch")
 
 			sidecar := findContainer(deployment.Spec.Template.Spec.Containers, "telemetry-sidecar")
 			s.Require().NotNil(sidecar, "telemetry-sidecar container not found")

--- a/tests/unit/helm/delegated-operator-job-configmap_test.go
+++ b/tests/unit/helm/delegated-operator-job-configmap_test.go
@@ -799,8 +799,10 @@ func (s *doK8sConfigMapTemplateTest) TestTelemetrySidecarNoGpu() {
 	}
 
 	testCases := []struct {
-		name   string
-		values map[string]string
+		name          string
+		values        map[string]string
+		gpuInLimits   bool
+		gpuInRequests bool
 	}{
 		{
 			name: "gpuInLimits",
@@ -809,6 +811,7 @@ func (s *doK8sConfigMapTemplateTest) TestTelemetrySidecarNoGpu() {
 				"delegatedOperatorJobTemplates.jobs.cpuDefault.unused": "nil",
 				gpuKey("limits"): "1",
 			},
+			gpuInLimits: true,
 		},
 		{
 			name: "gpuInRequests",
@@ -817,6 +820,7 @@ func (s *doK8sConfigMapTemplateTest) TestTelemetrySidecarNoGpu() {
 				"delegatedOperatorJobTemplates.jobs.cpuDefault.unused": "nil",
 				gpuKey("requests"): "1",
 			},
+			gpuInRequests: true,
 		},
 		{
 			name: "noGpu",
@@ -840,6 +844,14 @@ func (s *doK8sConfigMapTemplateTest) TestTelemetrySidecarNoGpu() {
 			helm.UnmarshalK8SYaml(subT, output, &configMap)
 
 			job := s.renderJob(configMap.Data, jobKey)
+
+			// The configured GPU must reach the primary executor container.
+			s.Require().NotEmpty(job.Spec.Template.Spec.Containers, "expected at least one container")
+			main := job.Spec.Template.Spec.Containers[0]
+			_, mainLimitsGpu := main.Resources.Limits[corev1.ResourceName(gpuResource)]
+			_, mainRequestsGpu := main.Resources.Requests[corev1.ResourceName(gpuResource)]
+			s.Equal(testCase.gpuInLimits, mainLimitsGpu, "primary executor nvidia.com/gpu limits mismatch")
+			s.Equal(testCase.gpuInRequests, mainRequestsGpu, "primary executor nvidia.com/gpu requests mismatch")
 
 			// The native-sidecar runs as an initContainer (restartPolicy: Always).
 			sidecar := findContainer(job.Spec.Template.Spec.InitContainers, "telemetry-sidecar")

--- a/tests/unit/helm/delegated-operator-job-configmap_test.go
+++ b/tests/unit/helm/delegated-operator-job-configmap_test.go
@@ -783,12 +783,11 @@ func (s *doK8sConfigMapTemplateTest) TestTelemetryDisabledOmitsSidecar() {
 		"telemetry-socket volumeMount should be absent when telemetry is disabled")
 }
 
-// TestTelemetrySidecarGpuEnv verifies that when a delegated-operator job's
-// executor requests a GPU (via resources.limits or resources.requests), its
-// telemetry native-sidecar is given the NVIDIA_* env vars needed to read GPU
-// metrics, without the sidecar requesting its own nvidia.com/gpu allocation.
-// When no GPU is requested, the sidecar receives no NVIDIA_* env vars.
-func (s *doK8sConfigMapTemplateTest) TestTelemetrySidecarGpuEnv() {
+// TestTelemetrySidecarNoGpu verifies that the delegated-operator job's
+// telemetry native-sidecar never receives GPU access — no NVIDIA_* env vars and
+// no nvidia.com/gpu resource request — even when the executor itself requests a
+// GPU. GPU metrics are collected by the executor process, not the sidecar.
+func (s *doK8sConfigMapTemplateTest) TestTelemetrySidecarNoGpu() {
 	const gpuResource = "nvidia.com/gpu"
 	jobKey := "cpuDefault.yaml"
 
@@ -800,35 +799,31 @@ func (s *doK8sConfigMapTemplateTest) TestTelemetrySidecarGpuEnv() {
 	}
 
 	testCases := []struct {
-		name      string
-		values    map[string]string
-		expectGpu bool
+		name   string
+		values map[string]string
 	}{
 		{
-			name: "gpuInLimitsExposesEnvToSidecar",
+			name: "gpuInLimits",
 			values: map[string]string{
 				"telemetry.enabled": "true",
 				"delegatedOperatorJobTemplates.jobs.cpuDefault.unused": "nil",
 				gpuKey("limits"): "1",
 			},
-			expectGpu: true,
 		},
 		{
-			name: "gpuInRequestsExposesEnvToSidecar",
+			name: "gpuInRequests",
 			values: map[string]string{
 				"telemetry.enabled": "true",
 				"delegatedOperatorJobTemplates.jobs.cpuDefault.unused": "nil",
 				gpuKey("requests"): "1",
 			},
-			expectGpu: true,
 		},
 		{
-			name: "noGpuOmitsEnvFromSidecar",
+			name: "noGpu",
 			values: map[string]string{
 				"telemetry.enabled": "true",
 				"delegatedOperatorJobTemplates.jobs.cpuDefault.unused": "nil",
 			},
-			expectGpu: false,
 		},
 	}
 
@@ -850,24 +845,15 @@ func (s *doK8sConfigMapTemplateTest) TestTelemetrySidecarGpuEnv() {
 			sidecar := findContainer(job.Spec.Template.Spec.InitContainers, "telemetry-sidecar")
 			s.Require().NotNil(sidecar, "telemetry-sidecar initContainer not found")
 
-			visibleDevices, hasVisibleDevices := envValue(sidecar.Env, "NVIDIA_VISIBLE_DEVICES")
-			driverCaps, hasDriverCaps := envValue(sidecar.Env, "NVIDIA_DRIVER_CAPABILITIES")
+			_, hasVisibleDevices := envValue(sidecar.Env, "NVIDIA_VISIBLE_DEVICES")
+			_, hasDriverCaps := envValue(sidecar.Env, "NVIDIA_DRIVER_CAPABILITIES")
+			s.False(hasVisibleDevices, "sidecar must not have NVIDIA_VISIBLE_DEVICES")
+			s.False(hasDriverCaps, "sidecar must not have NVIDIA_DRIVER_CAPABILITIES")
 
-			if testCase.expectGpu {
-				s.True(hasVisibleDevices, "sidecar should have NVIDIA_VISIBLE_DEVICES")
-				s.Equal("all", visibleDevices, "NVIDIA_VISIBLE_DEVICES value mismatch")
-				s.True(hasDriverCaps, "sidecar should have NVIDIA_DRIVER_CAPABILITIES")
-				s.Equal("compute,utility", driverCaps, "NVIDIA_DRIVER_CAPABILITIES value mismatch")
-
-				// The sidecar reads the executor's GPU; it must not request its own.
-				_, limitsHasGpu := sidecar.Resources.Limits[corev1.ResourceName(gpuResource)]
-				_, requestsHasGpu := sidecar.Resources.Requests[corev1.ResourceName(gpuResource)]
-				s.False(limitsHasGpu, "sidecar must not request nvidia.com/gpu in limits")
-				s.False(requestsHasGpu, "sidecar must not request nvidia.com/gpu in requests")
-			} else {
-				s.False(hasVisibleDevices, "sidecar should not have NVIDIA_VISIBLE_DEVICES when no GPU requested")
-				s.False(hasDriverCaps, "sidecar should not have NVIDIA_DRIVER_CAPABILITIES when no GPU requested")
-			}
+			_, limitsHasGpu := sidecar.Resources.Limits[corev1.ResourceName(gpuResource)]
+			_, requestsHasGpu := sidecar.Resources.Requests[corev1.ResourceName(gpuResource)]
+			s.False(limitsHasGpu, "sidecar must not request nvidia.com/gpu in limits")
+			s.False(requestsHasGpu, "sidecar must not request nvidia.com/gpu in requests")
 		})
 	}
 }


### PR DESCRIPTION
# Rationale

- due to problems with accessing the GPU metrics from the sidecar in Kubernetes, moving the collection to the executor itself 
- requires https://github.com/voxel51/fiftyone-teams/pull/3325

Review Priority

* [ ] high
* [ ] medium
* [x] low

## Changes

- remove GPU sidecar instructions

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
