### PR TITLE
[ephem chart] activity time-tracking env (do not merge)

### DIFF
--- a/helm/fiftyone-teams-app/templates/_helpers.tpl
+++ b/helm/fiftyone-teams-app/templates/_helpers.tpl
@@ -427,6 +427,17 @@ Create a merged list of environment variables for fiftyone-app
     secretKeyRef:
       name: {{ $secretName }}
       key: encryptionKey
+{{- /* Activity Analytics: the workflows plugin's read operator
+       (get_workflow_activity_metrics) reads the activity event store
+       directly, so the operator-executing service needs the store's
+       connection — same secret + database the activity workers use. */}}
+- name: FIFTYONE_ACTIVITY_MONGO_URI
+  valueFrom:
+    secretKeyRef:
+      name: {{ $secretName }}
+      key: mongodbConnectionString
+- name: FIFTYONE_ACTIVITY_MONGO_DB
+  value: {{ .Values.activitySettings.mongo.database | default "fiftyone_activity" | quote }}
 {{- range $key, $val := .Values.appSettings.env }}
 - name: {{ $key }}
   value: {{ $val | quote }}
@@ -543,6 +554,14 @@ Create a merged list of environment variables for fiftyone-teams-plugins
     secretKeyRef:
       name: {{ $secretName }}
       key: encryptionKey
+{{- /* Activity Analytics read path — see the app helper above. */}}
+- name: FIFTYONE_ACTIVITY_MONGO_URI
+  valueFrom:
+    secretKeyRef:
+      name: {{ $secretName }}
+      key: mongodbConnectionString
+- name: FIFTYONE_ACTIVITY_MONGO_DB
+  value: {{ .Values.activitySettings.mongo.database | default "fiftyone_activity" | quote }}
 {{- range $key, $val := .Values.pluginsSettings.env }}
 - name: {{ $key }}
   value: {{ $val | quote }}

--- a/helm/fiftyone-teams-app/templates/activity-redis-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/activity-redis-deployment.yaml
@@ -1,0 +1,64 @@
+{{- /*
+Activity Analytics: an in-cluster Redis for the fiftyone.mq queue (BullMQ).
+The chart's convention is "bring your own datastore via connection string"
+(Mongo is external), but the teams stack ships no Redis today, so for the
+Activity proof we bundle a single, ephemeral Redis. Point workers/producers at
+an external Redis instead by setting activitySettings.redis.url and
+activitySettings.redis.enabled=false.
+*/}}
+{{- if and .Values.activitySettings.enabled .Values.activitySettings.redis.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: activity-redis
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    app.kubernetes.io/name: fiftyone-activity
+    app.kubernetes.io/component: activity-redis
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: fiftyone-activity
+      app.kubernetes.io/component: activity-redis
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: fiftyone-activity
+        app.kubernetes.io/component: activity-redis
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: redis
+          image: {{ .Values.activitySettings.redis.image | default "redis:7" | quote }}
+          ports:
+            - containerPort: 6379
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: activity-redis
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    app.kubernetes.io/name: fiftyone-activity
+    app.kubernetes.io/component: activity-redis
+spec:
+  selector:
+    app.kubernetes.io/name: fiftyone-activity
+    app.kubernetes.io/component: activity-redis
+  ports:
+    - port: 6379
+      targetPort: 6379
+{{- end }}

--- a/helm/fiftyone-teams-app/templates/activity-workers-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/activity-workers-deployment.yaml
@@ -55,6 +55,22 @@ spec:
                   key: mongodbConnectionString
             - name: FIFTYONE_ACTIVITY_MONGO_DB
               value: {{ $a.mongo.database | default "fiftyone_activity" | quote }}
+            {{- /* The snapshot worker reads the FiftyOne (datasets) database —
+                   a DIFFERENT database from the activity store, though the same
+                   Mongo instance — and stamps its org onto the snapshot event,
+                   since the rollups are tenant-scoped. The database name comes
+                   from the same secret every other service reads it from. */}}
+            - name: FIFTYONE_DATABASE_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Values.secret.name }}
+                  key: fiftyoneDatabaseName
+            - name: FIFTYONE_ACTIVITY_ORG_ID
+              value: {{ $a.orgId | default $.Values.appSettings.env.FIFTYONE_ACTIVITY_ORG_ID | quote }}
+            {{- if $a.snapshotIntervalMs }}
+            - name: FIFTYONE_ACTIVITY_SNAPSHOT_INTERVAL_MS
+              value: {{ $a.snapshotIntervalMs | quote }}
+            {{- end }}
           resources:
             {{- toYaml $a.resources | nindent 12 }}
 ---

--- a/helm/fiftyone-teams-app/templates/activity-workers-deployment.yaml
+++ b/helm/fiftyone-teams-app/templates/activity-workers-deployment.yaml
@@ -1,0 +1,63 @@
+{{- /*
+Activity Analytics workers: one published image, N Deployments differing only
+by entrypoint (ingest = queue-depth drain, idempotent; rollup = single-flight
+scheduler). Rendered from the activitySettings.workers map. Mongo comes from
+the shared teams secret (its own fiftyone_activity database); Redis from the
+in-cluster activity-redis (or activitySettings.redis.url).
+*/}}
+{{- if .Values.activitySettings.enabled }}
+{{- $a := .Values.activitySettings }}
+{{- $redisUrl := $a.redis.url | default "redis://activity-redis:6379/0" }}
+{{- range $name, $w := $a.workers }}
+{{- if ne $w.enabled false }}
+{{- $full := printf "activity-%s-worker" $name }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $full }}
+  namespace: {{ $.Values.namespace.name }}
+  labels:
+    app.kubernetes.io/name: fiftyone-activity
+    app.kubernetes.io/component: {{ $full }}
+spec:
+  replicas: {{ $w.replicaCount | default 1 }}
+  {{- if $w.recreate }}
+  strategy:
+    type: Recreate
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: fiftyone-activity
+      app.kubernetes.io/component: {{ $full }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: fiftyone-activity
+        app.kubernetes.io/component: {{ $full }}
+    spec:
+      {{- with $.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ $full }}
+          image: "{{ $a.image.repository }}:{{ $a.image.tag | default $.Chart.AppVersion }}"
+          imagePullPolicy: {{ $a.image.pullPolicy | default "IfNotPresent" }}
+          command:
+            {{- toYaml $w.command | nindent 12 }}
+          env:
+            - name: FIFTYONE_MQ_REDIS_URL
+              value: {{ $redisUrl | quote }}
+            - name: FIFTYONE_ACTIVITY_MONGO_URI
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Values.secret.name }}
+                  key: mongodbConnectionString
+            - name: FIFTYONE_ACTIVITY_MONGO_DB
+              value: {{ $a.mongo.database | default "fiftyone_activity" | quote }}
+          resources:
+            {{- toYaml $a.resources | nindent 12 }}
+---
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -12,6 +12,11 @@ apiSettings:
   deploymentAnnotations: {}
   # Environment Variables are passed to the `teams-api` containers
   env:
+    # -- Activity Analytics: teams-api hosts the domain-event bridge, which
+    # emits activity events onto the queue. Without this the bridge catches
+    # events but cannot enqueue them, so every bridged event is silently
+    # dropped. Points at the bundled in-cluster Redis (same as the workers).
+    FIFTYONE_MQ_REDIS_URL: "redis://activity-redis:6379/0"
     # -- Controls FiftyOne GraphQL verbosity.
     # When "production", debug mode is disabled and the default logging level is "INFO".
     # When "development", debug mode is enabled and the default logging level is "DEBUG".

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -1619,7 +1619,7 @@ activitySettings:
     # -- Pinned worker image published from the fiftyone-activity repo.
     repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-activity
     # -- REQUIRED when enabled: the published image tag (e.g. a commit SHA).
-    tag: "34d519e576f2f9bc2ab3a7f2e22d14a66d2afa22"
+    tag: "a8dc66f553c43a43c5315bc9cb2c7321fb51174d"
     pullPolicy: IfNotPresent
   mongo:
     # -- Activity's own database on the shared Mongo instance.

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -368,13 +368,20 @@ appSettings:
   # (like Minikube). To set resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces (`{}`) after 'resources:'.
   # -- Container resource requests and limits for `fiftyone-app`. [Reference][resources].
+  # ephemeral-storage is set explicitly: the fiftyone-app-torch image is ~5.4GB
+  # compressed / ~15-20GB unpacked, but GKE Autopilot injects a 1Gi default when
+  # unset and bin-packs by request — so the app landed on a full node and was
+  # evicted ("node was low on resource: ephemeral-storage"). 10Gi is Autopilot's
+  # per-workload max (it rejects >10Gi). Harmless on non-Autopilot clusters.
   resources:
-    limits: {}
-    #   cpu: 2
-    #   memory: 6Gi
-    requests: {}
-    #   cpu: 500m
-    #   memory: 512Mi
+    limits:
+      cpu: 2
+      memory: 6Gi
+      ephemeral-storage: 10Gi
+    requests:
+      cpu: 500m
+      memory: 512Mi
+      ephemeral-storage: 10Gi
   service:
     # -- Service annotations for `fiftyone-app`. [Reference][annotations].
     annotations: {}
@@ -1619,7 +1626,9 @@ activitySettings:
     # -- Pinned worker image published from the fiftyone-activity repo.
     repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-activity
     # -- REQUIRED when enabled: the published image tag (e.g. a commit SHA).
-    tag: "e95ba92bde3f59366311c7b8a59d83563a20cb40"
+    # 0.0.7: per-metric rollup isolation (one bad metric, e.g. op_duration_p95
+    # on Mongo <7, no longer aborts the whole scheduled batch).
+    tag: "20402a643be3dfba17b8281de0a42bee81ac558f"
     pullPolicy: IfNotPresent
   mongo:
     # -- Activity's own database on the shared Mongo instance.

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -1595,3 +1595,47 @@ teamsAppSettings:
   volumeMounts: []
   # -- Volumes for `teams-app` pods. [Reference][volumes].
   volumes: []
+
+# -----------------------------------------------------------------------------
+# Activity Analytics (proof / opt-in)
+#
+# Ingest + rollup workers off a single published fiftyone-activity image, plus
+# an in-cluster Redis for the fiftyone.mq queue. Disabled by default. The
+# workers write to the fiftyone_activity database on the SAME Mongo as teams
+# (connection string reused from the shared secret); teams-api reads it back.
+# -----------------------------------------------------------------------------
+activitySettings:
+  # -- Master toggle for the Activity workers + Redis.
+  enabled: false
+  image:
+    # -- Pinned worker image published from the fiftyone-activity repo.
+    repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-activity
+    # -- REQUIRED when enabled: the published image tag (e.g. a commit SHA).
+    tag: ""
+    pullPolicy: IfNotPresent
+  mongo:
+    # -- Activity's own database on the shared Mongo instance.
+    database: fiftyone_activity
+  redis:
+    # -- Bundle an ephemeral in-cluster Redis (set false to use an external one).
+    enabled: true
+    image: redis:7
+    # -- Override to point at an external Redis; default targets the bundled one.
+    url: ""
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  # -- One Deployment per entry; command selects the entrypoint in the image.
+  workers:
+    ingest:
+      command: ["fiftyone-activity-ingest-worker"]
+      replicaCount: 2
+    rollup:
+      command: ["fiftyone-activity-rollup-worker"]
+      replicaCount: 1
+      # Single-flight: it owns the repeatable rollup schedule.
+      recreate: true

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -1628,7 +1628,7 @@ activitySettings:
     # -- REQUIRED when enabled: the published image tag (e.g. a commit SHA).
     # 0.0.9: snapshot worker (state metrics) + per-metric rollup isolation (one bad
     # metric, e.g. op_duration_p95 on Mongo <7, no longer aborts the batch).
-    tag: "67693359765b95f2372b6ee97aeb89b603169b62"
+    tag: "7b0cf27736522e9a5045f7d7cf49445164a7a6c4"
     pullPolicy: IfNotPresent
   mongo:
     # -- Activity's own database on the shared Mongo instance.

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -1631,9 +1631,9 @@ activitySettings:
     # -- Pinned worker image published from the fiftyone-activity repo.
     repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-activity
     # -- REQUIRED when enabled: the published image tag (e.g. a commit SHA).
-    # 0.0.9: snapshot worker (state metrics) + per-metric rollup isolation (one bad
-    # metric, e.g. op_duration_p95 on Mongo <7, no longer aborts the batch).
-    tag: "7bc0657389d05faebc196744e4d7c4644c857dc3"
+    # 0.0.16: browser time-tracking events (sample.*_started/_ended) +
+    # COUNT_DISTINCT + annotation_time/review_time/review_decisions rollups.
+    tag: "57cce235b5e1bb12e02302aa497af424cb372c32"
     pullPolicy: IfNotPresent
   mongo:
     # -- Activity's own database on the shared Mongo instance.

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -1615,7 +1615,7 @@ activitySettings:
     # -- Pinned worker image published from the fiftyone-activity repo.
     repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-activity
     # -- REQUIRED when enabled: the published image tag (e.g. a commit SHA).
-    tag: "15e878fe29c4a28a6fa55d964805efb58388aa9e"
+    tag: "fb9a0fd70c1172cfd4338cc68c8964e824e69a44"
     pullPolicy: IfNotPresent
   mongo:
     # -- Activity's own database on the shared Mongo instance.

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -1615,7 +1615,7 @@ activitySettings:
     # -- Pinned worker image published from the fiftyone-activity repo.
     repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-activity
     # -- REQUIRED when enabled: the published image tag (e.g. a commit SHA).
-    tag: "3aa0cd8a0ee70f71cee33d48afdc3afbdddb61e6"
+    tag: "c1e9fb31243ca67018e297fccb064cb63c26f1db"
     pullPolicy: IfNotPresent
   mongo:
     # -- Activity's own database on the shared Mongo instance.

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -1626,9 +1626,9 @@ activitySettings:
     # -- Pinned worker image published from the fiftyone-activity repo.
     repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-activity
     # -- REQUIRED when enabled: the published image tag (e.g. a commit SHA).
-    # 0.0.7: per-metric rollup isolation (one bad metric, e.g. op_duration_p95
-    # on Mongo <7, no longer aborts the whole scheduled batch).
-    tag: "20402a643be3dfba17b8281de0a42bee81ac558f"
+    # 0.0.9: snapshot worker (state metrics) + per-metric rollup isolation (one bad
+    # metric, e.g. op_duration_p95 on Mongo <7, no longer aborts the batch).
+    tag: "67693359765b95f2372b6ee97aeb89b603169b62"
     pullPolicy: IfNotPresent
   mongo:
     # -- Activity's own database on the shared Mongo instance.
@@ -1646,6 +1646,13 @@ activitySettings:
     limits:
       cpu: 500m
       memory: 512Mi
+  # -- Override the org the snapshot worker stamps its events with; defaults to
+  # appSettings.env.FIFTYONE_ACTIVITY_ORG_ID (rollups are tenant-scoped, so an
+  # org-less snapshot would never surface).
+  orgId: ""
+  # -- Snapshot cadence in ms. Defaults to hourly, matching the HOUR bucket the
+  # state metrics (dataset_count/sample_count/label_density) roll up by.
+  snapshotIntervalMs: ""
   # -- One Deployment per entry; command selects the entrypoint in the image.
   workers:
     ingest:
@@ -1655,4 +1662,10 @@ activitySettings:
       command: ["fiftyone-activity-rollup-worker"]
       replicaCount: 1
       # Single-flight: it owns the repeatable rollup schedule.
+      recreate: true
+    snapshot:
+      command: ["fiftyone-activity-snapshot-worker"]
+      replicaCount: 1
+      # Single-flight: it owns the repeatable snapshot schedule, and a double
+      # snapshot in one bucket would be a duplicate point.
       recreate: true

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -282,6 +282,10 @@ appSettings:
     # (the bundled in-cluster Redis). Emit is fire-and-forget; if unset the
     # review_submitted events simply don't flow.
     FIFTYONE_MQ_REDIS_URL: "redis://activity-redis:6379/0"
+    # -- The org id the activity feed is scoped by (matches user.organization.id).
+    # Single-org deployments set this so the review-submit emit stamps the org
+    # the reader queries. REPLACE with your org id.
+    FIFTYONE_ACTIVITY_ORG_ID: "dev-internal-env"
     # @schema
     # type: ["string", "boolean"]
     # @schema
@@ -1615,7 +1619,7 @@ activitySettings:
     # -- Pinned worker image published from the fiftyone-activity repo.
     repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-activity
     # -- REQUIRED when enabled: the published image tag (e.g. a commit SHA).
-    tag: "c1e9fb31243ca67018e297fccb064cb63c26f1db"
+    tag: "34d519e576f2f9bc2ab3a7f2e22d14a66d2afa22"
     pullPolicy: IfNotPresent
   mongo:
     # -- Activity's own database on the shared Mongo instance.

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -1615,7 +1615,7 @@ activitySettings:
     # -- Pinned worker image published from the fiftyone-activity repo.
     repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-activity
     # -- REQUIRED when enabled: the published image tag (e.g. a commit SHA).
-    tag: "fb9a0fd70c1172cfd4338cc68c8964e824e69a44"
+    tag: "3aa0cd8a0ee70f71cee33d48afdc3afbdddb61e6"
     pullPolicy: IfNotPresent
   mongo:
     # -- Activity's own database on the shared Mongo instance.

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -1619,7 +1619,7 @@ activitySettings:
     # -- Pinned worker image published from the fiftyone-activity repo.
     repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-activity
     # -- REQUIRED when enabled: the published image tag (e.g. a commit SHA).
-    tag: "a8dc66f553c43a43c5315bc9cb2c7321fb51174d"
+    tag: "e95ba92bde3f59366311c7b8a59d83563a20cb40"
     pullPolicy: IfNotPresent
   mongo:
     # -- Activity's own database on the shared Mongo instance.

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -278,6 +278,10 @@ appSettings:
   deploymentAnnotations: {}
   # Environment Variables are passed to the `fiftyone-app` containers
   env:
+    # -- Activity Analytics: where the workflows-plugin emit() enqueues events
+    # (the bundled in-cluster Redis). Emit is fire-and-forget; if unset the
+    # review_submitted events simply don't flow.
+    FIFTYONE_MQ_REDIS_URL: "redis://activity-redis:6379/0"
     # @schema
     # type: ["string", "boolean"]
     # @schema
@@ -1606,12 +1610,12 @@ teamsAppSettings:
 # -----------------------------------------------------------------------------
 activitySettings:
   # -- Master toggle for the Activity workers + Redis.
-  enabled: false
+  enabled: true
   image:
     # -- Pinned worker image published from the fiftyone-activity repo.
     repository: us-central1-docker.pkg.dev/computer-vision-team/dev-docker/fiftyone-activity
     # -- REQUIRED when enabled: the published image tag (e.g. a commit SHA).
-    tag: ""
+    tag: "15e878fe29c4a28a6fa55d964805efb58388aa9e"
     pullPolicy: IfNotPresent
   mongo:
     # -- Activity's own database on the shared Mongo instance.

--- a/helm/fiftyone-teams-app/values.yaml
+++ b/helm/fiftyone-teams-app/values.yaml
@@ -1628,7 +1628,7 @@ activitySettings:
     # -- REQUIRED when enabled: the published image tag (e.g. a commit SHA).
     # 0.0.9: snapshot worker (state metrics) + per-metric rollup isolation (one bad
     # metric, e.g. op_duration_p95 on Mongo <7, no longer aborts the batch).
-    tag: "7b0cf27736522e9a5045f7d7cf49445164a7a6c4"
+    tag: "7bc0657389d05faebc196744e4d7c4644c857dc3"
     pullPolicy: IfNotPresent
   mongo:
     # -- Activity's own database on the shared Mongo instance.


### PR DESCRIPTION
**Not for review or merge** — this PR exists so the `helm-pre-release` job publishes an RC chart for the `lanny/activity-time-tracking` deploy branch (the ephem build-and-deploy pipeline resolves charts from the helm-internal registry by branch-tip SHA, and only the PR workflow publishes them for non-release branches).

Branch = `ritch/activity-e2e` + two changes:
- `activitySettings.image.tag` → `57cce235b5e1bb12e02302aa497af424cb372c32` (fiftyone-activity 0.0.16: browser time-tracking events + COUNT_DISTINCT + time rollups)
- `FIFTYONE_ACTIVITY_MONGO_URI/_DB` on fiftyone-app + teams-plugins (the workflows plugin's `get_workflow_activity_metrics` read operator needs the activity store; same secret/database the workers use)

Context: activity-analytics KB `design/time-tracking-events.md` + voxel51/kb#9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)