### PR TITLE
chore: add new agentic-labeler image to validate-docker-pulls.

### DIFF
--- a/utils/validate-docker-pulls.sh
+++ b/utils/validate-docker-pulls.sh
@@ -19,6 +19,7 @@ set -euo pipefail
 EXPECTED_IMAGES=(
   "docker.io/busybox:stable-glibc" # For initContainers
   "docker.io/redis:7-alpine"       # For telemetry redis (telemetry.enabled defaults to true)
+  "voxel51/agentic-labeler"
   "voxel51/fiftyone-app"
   "voxel51/fiftyone-app-gpt"
   "voxel51/fiftyone-app-torch"


### PR DESCRIPTION
# Rationale

Our public release automations for v2.21.1 failed on pushing the agentic-laber image to Docker Hub.  After creating this new repository within our registry (and setting the repo permissions), the push was successful.  Let's add it to our validate script so it is validated when we release v2.23.0

Review Priority

* [ ] high
* [x] medium
* [ ] low

## Changes

* utils/validate-docker-pulls
  * add "voxel51/agentic-labeler" to array

Checklist

* [x] This PR maintains parity between Docker Compose and Helm

## Testing

Next release.

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
