### PR TITLE
test(unit-helm): remove test TestServiceTelemetrySidecarGpuEnv after …

### DIFF
--- a/tests/unit/helm/delegated-operator-job-configmap_test.go
+++ b/tests/unit/helm/delegated-operator-job-configmap_test.go
@@ -1116,64 +1116,6 @@ func (s *doK8sConfigMapTemplateTest) TestServiceTelemetry() {
 	s.False(ok)
 }
 
-// TestServiceTelemetrySidecarGpuEnv verifies GPU passthrough to the
-// telemetry sidecar on service pods, matching the jobs behavior:
-// a GPU in the merged resources gives the sidecar the NVIDIA_* env vars
-// for read-only metrics, without its own nvidia.com/gpu request.
-func (s *doK8sConfigMapTemplateTest) TestServiceTelemetrySidecarGpuEnv() {
-	testCases := []struct {
-		name      string
-		values    map[string]string
-		expectGpu bool
-	}{
-		{
-			name: "gpuInLimitsExposesEnvToSidecar",
-			values: map[string]string{
-				"telemetry.enabled": "true",
-				"delegatedOperatorJobTemplates.serviceOrchestrators.gpuServices.resources.limits.nvidia\\.com/gpu": "1",
-			},
-			expectGpu: true,
-		},
-		{
-			name: "noGpuOmitsEnvFromSidecar",
-			values: map[string]string{
-				"telemetry.enabled": "true",
-				"delegatedOperatorJobTemplates.serviceOrchestrators.gpuServices.unused": "nil",
-			},
-			expectGpu: false,
-		},
-	}
-
-	for _, testCase := range testCases {
-		testCase := testCase
-		s.Run(testCase.name, func() {
-			subT := s.T()
-			subT.Parallel()
-
-			options := &helm.Options{SetValues: testCase.values}
-			output := helm.RenderTemplate(subT, options, s.chartPath, s.releaseName, s.templates)
-
-			var configMap corev1.ConfigMap
-			helm.UnmarshalK8SYaml(subT, output, &configMap)
-
-			pod := s.renderServicePod(configMap.Data, "gpuServices.yaml", brokerServiceVars())
-
-			sidecar := findContainer(pod.Spec.InitContainers, "telemetry-sidecar")
-			s.Require().NotNil(sidecar, "telemetry-sidecar initContainer not found")
-
-			visibleDevices, hasVisibleDevices := envValue(sidecar.Env, "NVIDIA_VISIBLE_DEVICES")
-			if testCase.expectGpu {
-				s.True(hasVisibleDevices)
-				s.Equal("all", visibleDevices)
-				_, limitsHaveGpu := sidecar.Resources.Limits[corev1.ResourceName("nvidia.com/gpu")]
-				s.False(limitsHaveGpu, "sidecar must not request its own GPU")
-			} else {
-				s.False(hasVisibleDevices)
-			}
-		})
-	}
-}
-
 // TestDefaultGpuServiceOrcAuthSecret pins the chart default: the
 // gpuServiceOrc pod template delivers FIFTYONE_AUTH_SECRET by reference
 // (secretEnv), so its services authenticate to teams-api without a


### PR DESCRIPTION
…#611 removed the `NVIDIA_VISIBLE_DEVICES` env var from the sidecar.

# Rationale

In #611 we removed code that added the `NVIDIA_VISIBLE_DEVICES` environment variable to the sidecar container.  In #597, @yrahal added a test `TestServiceTelemetrySidecarGpuEnv` that inspected the sidecar contained the `NVIDIA_VISIBLE_DEVICES` env var.  This caused our unit tests to fail on #628 like https://github.com/voxel51/fiftyone-teams-app-deploy/actions/runs/30647141949/job/91235307776?pr=628.

Review Priority

* [x] high
* [ ] medium
* [ ] low

## Changes

* unit helm test
  * remove no unnecessary test function

Checklist

* [ ] This PR maintains parity between Docker Compose and Helm

## Testing

See PR Checks.


Locally, tests pass:

```
[helm]$ go test -count=1 -timeout=30s -v -tags unit delegated-operator-job-configmap_test.go common_test.go yaml_helpers.go k8s_helpers.go chartInfo.go
=== RUN   TestDoK8sConfigMapTemplate
=== PAUSE TestDoK8sConfigMapTemplate
=== CONT  TestDoK8sConfigMapTemplate
=== RUN   TestDoK8sConfigMapTemplate/TestData
...
--- PASS: TestDoK8sConfigMapTemplate (1.95s)
    --- PASS: TestDoK8sConfigMapTemplate/TestData (0.06s)
        --- PASS: TestDoK8sConfigMapTemplate/TestData/defaultValues (0.06s)
            --- PASS: TestDoK8sConfigMapTemplate/TestData/defaultValues/defaultValuesCpuEnabled (0.06s)
                --- PASS: TestDoK8sConfigMapTemplate/TestData/defaultValues/defaultValuesCpuEnabled/overrideTemplateValues (0.08s)
                    --- PASS: TestDoK8sConfigMapTemplate/TestData/defaultValues/defaultValuesCpuEnabled/overrideTemplateValues/overrideTemplateAndInstanceValues (0.10s)
                        --- PASS: TestDoK8sConfigMapTemplate/TestData/defaultValues/defaultValuesCpuEnabled/overrideTemplateValues/overrideTemplateAndInstanceValues/overrideTemplateAndInstanceValuesCascading (0.10s)
    --- PASS: TestDoK8sConfigMapTemplate/TestDefaultGpuServiceOrcAuthSecret (0.06s)
    --- PASS: TestDoK8sConfigMapTemplate/TestDisabled (0.00s)
        --- PASS: TestDoK8sConfigMapTemplate/TestDisabled/defaultValues (0.06s)
            --- PASS: TestDoK8sConfigMapTemplate/TestDisabled/defaultValues/defaultValuesConfigMapDisabled (0.06s)
    --- PASS: TestDoK8sConfigMapTemplate/TestMetadataAnnotations (0.00s)
        --- PASS: TestDoK8sConfigMapTemplate/TestMetadataAnnotations/defaultValues (0.06s)
            --- PASS: TestDoK8sConfigMapTemplate/TestMetadataAnnotations/defaultValues/overrideAnnotations (0.06s)
    --- PASS: TestDoK8sConfigMapTemplate/TestMetadataLabels (0.04s)
        --- PASS: TestDoK8sConfigMapTemplate/TestMetadataLabels/defaultValues (0.06s)
            --- PASS: TestDoK8sConfigMapTemplate/TestMetadataLabels/defaultValues/overrideMetadataLabels (0.06s)
    --- PASS: TestDoK8sConfigMapTemplate/TestMetadataName (0.00s)
        --- PASS: TestDoK8sConfigMapTemplate/TestMetadataName/defaultValues (0.06s)
            --- PASS: TestDoK8sConfigMapTemplate/TestMetadataName/defaultValues/overrideName (0.06s)
    --- PASS: TestDoK8sConfigMapTemplate/TestMetadataNamespace (0.00s)
        --- PASS: TestDoK8sConfigMapTemplate/TestMetadataNamespace/defaultValues (0.06s)
            --- PASS: TestDoK8sConfigMapTemplate/TestMetadataNamespace/defaultValues/overrideName (0.06s)
    --- PASS: TestDoK8sConfigMapTemplate/TestServiceData (0.06s)
    --- PASS: TestDoK8sConfigMapTemplate/TestServiceDisabled (0.06s)
    --- PASS: TestDoK8sConfigMapTemplate/TestServiceNodeSelector (0.06s)
    --- PASS: TestDoK8sConfigMapTemplate/TestServiceResources (0.06s)
    --- PASS: TestDoK8sConfigMapTemplate/TestServiceTelemetry (0.13s)
    --- PASS: TestDoK8sConfigMapTemplate/TestServiceWithoutHealthcheck (0.06s)
    --- PASS: TestDoK8sConfigMapTemplate/TestTelemetryDisabledOmitsSidecar (0.06s)
    --- PASS: TestDoK8sConfigMapTemplate/TestTelemetrySidecarNoGpu (0.00s)
        --- PASS: TestDoK8sConfigMapTemplate/TestTelemetrySidecarNoGpu/gpuInLimits (0.06s)
            --- PASS: TestDoK8sConfigMapTemplate/TestTelemetrySidecarNoGpu/gpuInLimits/gpuInRequests (0.06s)
                --- PASS: TestDoK8sConfigMapTemplate/TestTelemetrySidecarNoGpu/gpuInLimits/gpuInRequests/noGpu (0.06s)
    --- PASS: TestDoK8sConfigMapTemplate/TestTelemetrySocketInjection (0.00s)
        --- PASS: TestDoK8sConfigMapTemplate/TestTelemetrySocketInjection/autoInjectsWhenUserHasNoTelemetrySocket (0.06s)
            --- PASS: TestDoK8sConfigMapTemplate/TestTelemetrySocketInjection/autoInjectsWhenUserHasNoTelemetrySocket/doesNotDuplicateWhenUserDeclaresTelemetrySocket (0.06s)
PASS
```

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
