### PR TITLE
docs(helm): tutorialize helm/README.md to match docker/README.md

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,6 +77,7 @@ repos:
           - '-'
           - -i
           - docker/README.md
+          - helm/docs/gke-deployment-guide.md
           - helm/docs/post-install-recommended-configuration.md
           - helm/fiftyone-teams-app/README.md.gotmpl
           - helm/README.md

--- a/helm/README.md
+++ b/helm/README.md
@@ -33,8 +33,6 @@ FiftyOne Enterprise.
 
 - [:green_book: Prerequisites Skills and Knowledge](#green_book-prerequisites-skills-and-knowledge)
 - [:white_check_mark: Technical Requirements](#white_check_mark-technical-requirements)
-  - [Kubernetes Cluster And Kubectl](#kubernetes-cluster-and-kubectl)
-  - [Helm](#helm)
 - [:clock10: Estimated Completion Time](#clock10-estimated-completion-time)
 - [:floppy_disk: Sizing](#floppy_disk-sizing)
 - [:wrench: Step 1: Set Up MongoDB Database](#wrench-step-1-set-up-mongodb-database)
@@ -76,9 +74,9 @@ for the full list.
 The following technical requirements are required for a successful and
 properly secured deployment of FiftyOne Enterprise.
 
-1. [Kubernetes Cluster And Kubectl](#kubernetes-cluster-and-kubectl)
+1. Kubernetes Cluster and Kubectl
 
-1. [Helm](#helm)
+1. Helm
 
 1. A MongoDB Database that meets FiftyOne's
    [version constraints](https://docs.voxel51.com/user_guide/config.html#using-a-different-mongodb-version).
@@ -93,8 +91,6 @@ properly secured deployment of FiftyOne Enterprise.
    and
    [API high-availability](./fiftyone-teams-app/README.md#highly-available-fiftyone-teams-api-deployments)
 
-### Kubernetes Cluster And Kubectl
-
 A kubernetes cluster and `kubectl` installation are required.
 The following kubernetes/kubectl versions are required:
 
@@ -105,8 +101,6 @@ However, it is recommended to use a
 Please refer to the
 [kubernetes installation documentation](https://kubernetes.io/docs/tasks/tools/)
 for steps on installing kubernetes and kubectl.
-
-### Helm
 
 Helm version >= 3.14 is required.
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -222,6 +222,8 @@ Edit your `values.yaml` file (see the example
 - `casSettings.env.FIFTYONE_AUTH_MODE` — the mode chosen in
   [Step 3](#file_folder-step-3-choose-authentication-mode)
 - `teamsAppSettings.dnsName` — your ingress hostname
+- `namespace.name` — set to match your target namespace (e.g.
+  `your-namespace-here`); see the note below
 
 If you are using the Voxel51 Docker Hub registry to pull container images,
 create an image pull secret and reference it in `imagePullSecrets`:
@@ -281,7 +283,7 @@ spec:
 ```
 
 ```shell
-kubectl apply -f teams-plugins-pv-pvc.yaml
+kubectl apply -f teams-plugins-pv-pvc.yaml --namespace your-namespace-here
 ```
 
 For NFS export configuration and cloud-provider alternatives (Google
@@ -385,7 +387,9 @@ helm upgrade fiftyone-teams-app voxel51/fiftyone-teams-app \
 > (Voxel51 is not affiliated with the author of this plugin):
 >
 > ```shell
-> helm diff --context 1 upgrade fiftyone-teams-app voxel51/fiftyone-teams-app -f values.yaml
+> helm diff --context 1 upgrade fiftyone-teams-app voxel51/fiftyone-teams-app \
+>   --namespace your-namespace-here \
+>   -f values.yaml
 > ```
 
 Confirm all pods are running, including `teams-plugins` (from
@@ -452,22 +456,25 @@ docs.
 
 ## Step 11: Initial CAS Setup
 
+In the steps below, `<DNS_NAME>` is the ingress hostname you set for
+`teamsAppSettings.dnsName` in [Step 4](#gear-step-4-configure-valuesyaml).
+
 1. Navigate to the CAS Super Admin UI at
-   `https://<ENVIRONMENT>.fiftyone.ai/cas/configurations`.
+   `https://<DNS_NAME>/cas/configurations`.
 1. In the **API Key** field (upper right corner), enter the value of
    `secret.fiftyone.fiftyoneAuthSecret` (from your `values.yaml`).
 
 ### Add First Admin User
 
 1. Navigate to the **Admins** tab at
-   `https://<ENVIRONMENT>.fiftyone.ai/cas/admins`.
+   `https://<DNS_NAME>/cas/admins`.
 1. Select **Add admin**.
 1. Provide **Name** and **Email**.
 1. Select **Add**.
 
 ### Enable Auto Join
 
-1. Navigate to `https://<ENVIRONMENT>.fiftyone.ai/cas/providers`.
+1. Navigate to `https://<DNS_NAME>/cas/providers`.
 1. Select **+ Edit**.
 1. Select **Allow auto join**.
 1. Select **Save**.
@@ -476,7 +483,7 @@ docs.
 
 Verify the deployment's IdP setup by logging in as a regular user.
 
-1. In a browser, open `https://<ENVIRONMENT>.fiftyone.ai`.
+1. In a browser, open `https://<DNS_NAME>`.
 1. Log in with the user credentials of the admin you created in the CAS
    Super Admin UI.
 1. Confirm you are redirected to the FiftyOne Enterprise home page.

--- a/helm/README.md
+++ b/helm/README.md
@@ -3,296 +3,492 @@
 <div align="center">
 <p align="center">
 
-<img alt="Voxel51 Logo" src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img alt="Voxel51 Logo" src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px">
+&nbsp;
 <img alt="Voxel51 FiftyOne" src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
 
 </p>
 </div>
 <!-- markdownlint-enable no-inline-html line-length -->
 
+---
+
+# FiftyOne Enterprise: Helm Deployment Guide
+
+FiftyOne Enterprise is the enterprise version of the open source
+[FiftyOne](https://github.com/voxel51/fiftyone) project.
+
+The FiftyOne Enterprise Helm chart is the recommended way to install and
+configure FiftyOne Enterprise on Kubernetes.
+
+This guide walks you through the steps for installing FiftyOne Enterprise
+using Helm. It also includes advanced configuration and upgrade
+considerations. This page assumes general knowledge of FiftyOne Enterprise
+and how to use it. Please contact Voxel51 for more information regarding
+FiftyOne Enterprise.
+
+## Table of Contents
+
 <!-- toc -->
 
-- [FiftyOne Enterprise Helm Resources](#fiftyone-enterprise-helm-resources)
-  - [Installing FiftyOne Enterprise](#installing-fiftyone-enterprise)
-    - [Example with `values.yaml`](#example-with-valuesyaml)
-    - [A Full Deployment Example on GKE](#a-full-deployment-example-on-gke)
-      - [Download the Example Configuration Files](#download-the-example-configuration-files)
-      - [Create the Necessary Helm Repos](#create-the-necessary-helm-repos)
-    - [Install and Configure cert-manager](#install-and-configure-cert-manager)
-      - [Create a ClusterIssuer](#create-a-clusterissuer)
-      - [Install and Configure MongoDB](#install-and-configure-mongodb)
-      - [Obtain a Global Static IP Address and Configure a DNS Entry](#obtain-a-global-static-ip-address-and-configure-a-dns-entry)
-      - [Set up http to https Forwarding](#set-up-http-to-https-forwarding)
-      - [Install FiftyOne Enterprise App](#install-fiftyone-enterprise-app)
-      - [Installation Complete](#installation-complete)
-  - [Recommended Next Steps](#recommended-next-steps)
+- [:open_file_folder: Directory Contents](#open_file_folder-directory-contents)
+- [:green_book: Prerequisites Skills and Knowledge](#green_book-prerequisites-skills-and-knowledge)
+- [:white_check_mark: Technical Requirements](#white_check_mark-technical-requirements)
+- [:clock10: Estimated Completion Time](#clock10-estimated-completion-time)
+- [:floppy_disk: Sizing](#floppy_disk-sizing)
+- [:wrench: Step 1: Set Up MongoDB Database](#wrench-step-1-set-up-mongodb-database)
+- [:closed_lock_with_key: Step 2: Prepare License File](#closed_lock_with_key-step-2-prepare-license-file)
+- [:file_folder: Step 3: Choose Authentication Mode](#file_folder-step-3-choose-authentication-mode)
+- [:gear: Step 4: Configure `values.yaml`](#gear-step-4-configure-valuesyaml)
+  - [Enable Dedicated Plugins (required)](#enable-dedicated-plugins-required)
+  - [Configure Delegated Operators (required)](#configure-delegated-operators-required)
+- [:rocket: Step 5: Initial Deployment](#rocket-step-5-initial-deployment)
+- [:globe_with_meridians: Step 6: Configure Ingress & TLS](#globe_with_meridians-step-6-configure-ingress--tls)
+  - [:compass: Routing Overview (Path-Based Ingress)](#compass-routing-overview-path-based-ingress)
+  - [:memo: Notes](#memo-notes)
+- [:page_facing_up: Step 7: Configure Delegated Operation Logs](#page_facing_up-step-7-configure-delegated-operation-logs)
+- [Step 8: Identity Provider (IdP) and Authentication (CAS)](#step-8-identity-provider-idp-and-authentication-cas)
+- [Step 9: Initial CAS Setup](#step-9-initial-cas-setup)
+  - [Add First Admin User](#add-first-admin-user)
+  - [Enable Auto Join](#enable-auto-join)
+- [Step 10: Test End User Login](#step-10-test-end-user-login)
+- [:books: Full Worked Example](#books-full-worked-example)
+- [Recommended Enhancements](#recommended-enhancements)
+- [Upgrades](#upgrades)
+- [Known Issues](#known-issues)
+- [Advanced Configuration](#advanced-configuration)
+- [Validating](#validating)
+- [Health Checks and Monitoring](#health-checks-and-monitoring)
+- [Values](#values)
 
 <!-- tocstop -->
 
----
+## :open_file_folder: Directory Contents
 
-# FiftyOne Enterprise Helm Resources
-
-This directory contains resources and information related to Helm deployments
+This directory contains resources and information related to Helm deployments.
 
 - Directories
-  - `docs` contains additional documentation for
-    - Exposing the teams-api
-    - Plugin storage
-  - `fiftyone-teams-app` contains the helm chart voxel51/fiftyone-teams-app.
-    For the chart documentation, see the fiftyone-teams-app/README.md file.
-  - `gke-example` contains additional kubernetes resources
-    to install FiftyOne Enterprise on Google Kubernetes Engine (GKE).
-    See
-    [A Full Deployment Example on GKE](#a-full-deployment-example-on-gke).
+  - `docs` contains additional documentation, including cloud-specific
+    deployment guides and configuration references.
+  - `fiftyone-teams-app` contains the Helm chart `voxel51/fiftyone-teams-app`.
+    For the full chart documentation (prerequisites, sizing, advanced
+    configuration, and the complete values reference), see
+    [`fiftyone-teams-app/README.md`](./fiftyone-teams-app/README.md).
+  - `gke-example` contains example Kubernetes resources used in the
+    [GKE Deployment Guide](./docs/gke-deployment-guide.md).
+  - `local-self-signed-example` contains resources for a local, self-signed
+    development setup.
 - Files
-  - `values.yaml` is example of overrides for the chart's defaults for a deployment
+  - `values.yaml` is an example of overrides for the chart's defaults for a
+    deployment.
 
-## Installing FiftyOne Enterprise
+## :green_book: Prerequisites Skills and Knowledge
 
-### Example with `values.yaml`
+A successful, properly secured deployment of FiftyOne Enterprise requires
+knowledge of Kubernetes, Helm, MongoDB, DNS, and TLS/SSL certificate
+management. See the chart's
+[Prerequisites Skills and Knowledge](./fiftyone-teams-app/README.md#prerequisites-skills-and-knowledge)
+for the full list.
 
-There are some value overrides that you must make for a successful deployment.
-To highlight some of these, see an example
-[`/values.yaml`](https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/values.yaml)
-in this directory.
+## :white_check_mark: Technical Requirements
 
-1. Edit the `./values.yaml` file
-1. Deploy FiftyOne Enterprise with `helm install`
-    - For new installations, run
+See the chart's
+[Technical Requirements](./fiftyone-teams-app/README.md#technical-requirements)
+for the full list of required tooling and versions (Kubernetes, `kubectl`,
+Helm, MongoDB, DNS, TLS/SSL, and optionally NFS/`ReadWriteMany` storage).
 
-        ```shell
-        helm repo add voxel51 https://helm.fiftyone.ai
-        helm repo update voxel51
-        helm install fiftyone-teams-app voxel51/fiftyone-teams-app -f ./values.yaml
-        ```
+## :clock10: Estimated Completion Time
 
-    - For upgrades, run
+The estimated time to deploy FiftyOne Enterprise is approximately 2 hours.
+See the chart's
+[Estimated Completion Time](./fiftyone-teams-app/README.md#estimated-completion-time)
+section for details.
 
-        ```shell
-        helm repo update voxel51
-        helm upgrade fiftyone-teams-app voxel51/fiftyone-teams-app -f ./values.yaml
-        ```
+## :floppy_disk: Sizing
 
-        > **NOTE**: Prior to running helm upgrade you may
-        > view the changes Helm would apply by using
-        > [helm diff](https://github.com/databus23/helm-diff)
-        > helm plugin.
-        > Voxel51 is not affiliated with the author of this plugin.
-        >
-        > For example:
-        >
-        > ```shell
-        > helm diff --context 1 upgrade fiftyone-teams-app voxel51/fiftyone-teams-app -f values.yaml
-        > ```
+See the chart's
+[Sizing](./fiftyone-teams-app/README.md#sizing)
+recommendations for MongoDB, `fiftyone-app`, `teams-api`, `teams-app`,
+`teams-cas`, dedicated plugins, and delegated operator pods.
 
-### A Full Deployment Example on GKE
+## :wrench: Step 1: Set Up MongoDB Database
 
-The following instructions represent a full Google Kubernetes Engine [GKE]
-deployment using these helm charts
+Before deploying FiftyOne Enterprise, you must have a running MongoDB database.
+FiftyOne Enterprise supports:
 
-- [jetstack/cert-manager](https://github.com/cert-manager/cert-manager)
-  - For Let's Encrypt SSL certificates
-- [mongodb/community-operator](https://github.com/mongodb/helm-charts/tree/main/charts/community-operator)
-  - for MongoDB
-- voxel51/fiftyone-teams-app
+- **MongoDB Atlas** (managed cloud)
+- **MongoDB Community Edition** (self-hosted, open source)
+- **MongoDB Enterprise** (self-hosted, commercial)
 
-These instructions assume you have
+Ensure your MongoDB version meets FiftyOne's
+[version constraints](https://docs.voxel51.com/user_guide/config.html#using-a-different-mongodb-version).
+MongoDB 8.0+ is recommended.
 
-- These tools installed and operating
-  - [kubectl](https://kubernetes.io/docs/tasks/tools/)
-  - [Helm](https://helm.sh/docs/intro/install/)
-- An existing
-  [GKE Cluster available](https://cloud.google.com/kubernetes-engine/docs/concepts/kubernetes-engine-overview)
-- Received Docker Hub credentials from Voxel51
-  - Have `voxel51-docker.json` file in the current directory
-    - If `voxel51-docker.json` is not in the current directory,
-      please update the command line accordingly.
-- Your license file from the Voxel51 Customer Success Team
-  - If you have not received this information, please contact your
-    Voxel51 Support Team via your agreed-upon mechanism (Slack, email, etc.)
+Once your database is running, record your MongoDB connection URI.
+You will need it in
+[Step 4](#gear-step-4-configure-valuesyaml)
+to set `secret.fiftyone.mongodbConnectionString` in your `values.yaml`.
+The URI follows this format:
 
-> **NOTE**: Anytime a license file secret is updated, you
-> must restart the `teams-cas` and `teams-api` services.
-> You may delete the pods, or run
+```text
+mongodb://username:password@mongodb-example.fiftyone.ai:27017/?authSource=admin
+```
+
+## :closed_lock_with_key: Step 2: Prepare License File
+
+> Required for **v2.0+**
+
+Use the license file provided by the Voxel51 Customer Success Team to create
+a license secret:
+
+```shell
+kubectl create namespace your-namespace-here
+kubectl --namespace your-namespace-here create secret generic fiftyone-license \
+  --from-file=license=./your-license-file
+```
+
+Set the name of this secret in your `values.yaml`'s `fiftyoneLicenseSecrets`
+list (see the example [`values.yaml`](./values.yaml)).
+
+> [!TIP]
+> When rotating the license, to ensure that the new license values are
+> picked up immediately, restart the `teams-cas` and `teams-api` deployments:
 >
 > ```shell
 > kubectl rollout restart deploy \
->   -n your-namespace \
+>   -n your-namespace-here \
 >   teams-cas \
 >   teams-api
 > ```
 
-#### Download the Example Configuration Files
+## :file_folder: Step 3: Choose Authentication Mode
 
-Download the example configuration files from the
-[voxel51/fiftyone-teams-app-deploy](https://github.com/voxel51/fiftyone-teams-app-deploy/tree/main/helm/gke-example)
-GitHub repository.
+FiftyOne Enterprise supports two authentication modes.
+Choose the one that matches your deployment:
 
-For example
+| Mode       | Use when                                                                   | `values.yaml` setting                          |
+| ---------- | -------------------------------------------------------------------------- | ---------------------------------------------- |
+| `internal` | Deployment is Air-gapped or Identity Provider is **OpenID Connect (OIDC)** | `casSettings.env.FIFTYONE_AUTH_MODE: internal` |
+| `legacy`   | Identity Provider is **SAML**                                              | `casSettings.env.FIFTYONE_AUTH_MODE: legacy`   |
 
-```shell
-curl -o values.yaml \
-  https://raw.githubusercontent.com/voxel51/fiftyone-teams-app-deploy/main/helm/gke-example/values.yaml
-curl -o cluster-issuer.yaml \
-  https://raw.githubusercontent.com/voxel51/fiftyone-teams-app-deploy/main/helm/gke-example/cluster-issuer.yaml
-curl -o frontend-config.yaml \
-  https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/gke-example/frontend-config.yaml
-```
+> [!NOTE]
+> The example [`values.yaml`](./values.yaml) ships with
+> `casSettings.env.FIFTYONE_AUTH_MODE: legacy` by default. Update it if your
+> Identity Provider uses OIDC.
 
-Update the `values.yaml` file with
+You can refer to the following docs to set up your Identity Provider with
+FiftyOne:
 
-- In `secret.fiftyone`
-  - MongoDB
-    - Set `mongodbConnectionString` containing your MongoDB username and password
-  - Set `cookieSecret`
-  - Set `encryptionKey`
-  - Set `fiftyoneAuthSecret`
-- In `teamsAppSettings.dnsName`
-  - Set ingress `host` values
+- [Pluggable authentication docs](https://docs.voxel51.com/enterprise/pluggable_auth.html#pluggable-authentication)
+  includes information on configuring CAS.
+- To set up authentication for internal mode: refer to the
+  [Getting Started with Internal Mode documentation](https://docs.voxel51.com/enterprise/pluggable_auth.html#getting-started-with-internal-mode).
 
-Assuming you follow these directions your MongoDB host will be
-`fiftyone-teams-mongodb.fiftyone-teams-mongodb.svc.cluster.local`.
-<!-- Please modify this hostname if you modify these instructions. -->
+## :gear: Step 4: Configure `values.yaml`
 
-#### Create the Necessary Helm Repos
+Edit your `values.yaml` file (see the example
+[`values.yaml`](./values.yaml) in this directory) to set:
 
-Add the Helm repositories
+- `fiftyoneLicenseSecrets` — the name of the secret created in
+  [Step 2](#closed_lock_with_key-step-2-prepare-license-file)
+- `secret.fiftyone.mongodbConnectionString` — the MongoDB connection URI from
+  [Step 1](#wrench-step-1-set-up-mongodb-database)
+- `secret.fiftyone.cookieSecret` — a randomly generated string
+  (`openssl rand -hex 32`)
+- `secret.fiftyone.encryptionKey` — used to encrypt storage credentials; see
+  [Storage Credentials and `FIFTYONE_ENCRYPTION_KEY`](./fiftyone-teams-app/README.md#storage-credentials-and-fiftyone_encryption_key)
+  for how to generate it
+- `secret.fiftyone.fiftyoneAuthSecret` — a randomly generated shared secret
+  used for CAS
+- `casSettings.env.FIFTYONE_AUTH_MODE` — the mode chosen in
+  [Step 3](#file_folder-step-3-choose-authentication-mode)
+- `teamsAppSettings.dnsName` — your ingress hostname
 
-```shell
-helm repo add mongodb https://mongodb.github.io/helm-charts
-helm repo add jetstack https://charts.jetstack.io
-helm repo add voxel51 https://helm.fiftyone.ai
-helm repo update
-```
-
-### Install and Configure cert-manager
-
-If you are using a GKE Autopilot cluster, please review the information
-[provided by cert-manager](https://github.com/cert-manager/cert-manager/issues/3717#issuecomment-919299192)
-and adjust your installation accordingly.
+If you are using the Voxel51 Docker Hub registry to pull container images,
+create an image pull secret and reference it in `imagePullSecrets`:
 
 ```shell
-kubectl create namespace cert-manager
-kubectl config set-context --current --namespace cert-manager
-helm install cert-manager jetstack/cert-manager --set installCRDs=true
-```
-
-You can use the cert-manager instructions to
-[verify the cert-manager Installation](https://cert-manager.io/v1.4-docs/installation/verify/).
-
-#### Create a ClusterIssuer
-
-`ClusterIssuers` are Kubernetes resources that represent certificate authorities
-that are able to generate signed certificates by honoring certificate signing requests.
-You must create either an `Issuer` in each namespace or a `ClusterIssuer`
-as part of your cert-manager configuration.
-Voxel51 has provided an example `ClusterIssuer` configuration (downloaded
-[earlier](#download-the-example-configuration-files)
-in this guide).
-
-```shell
-kubectl apply -f ./cluster-issuer.yaml
-```
-
-#### Install and Configure MongoDB
-
-These
-[instructions](https://github.com/mongodb/helm-charts/tree/main/charts/community-operator#deploying-a-mongodb-replica-set)
-can be used to deploy a MongoDB replicaset in your GKE cluster.
-
-Wait until the MongoDB pods are in the `Ready` state before
-beginning the "Install FiftyOne Enterprise App" instructions.
-
-While waiting,
-[configure a DNS entry](#obtain-a-global-static-ip-address-and-configure-a-dns-entry).
-
-To determine the state of the `fiftyone-teams-mongodb` pods, run
-
-```shell
-kubectl get pods
-```
-
-#### Obtain a Global Static IP Address and Configure a DNS Entry
-
-Reserve a global static IP address for use in your cluster:
-
-```shell
-gcloud compute addresses create \
-  fiftyone-teams-static-ip --global --ip-version IPV4
-gcloud compute addresses describe \
-  fiftyone-teams-static-ip --global
-```
-
-Record the IP address and either create a DNS entry or contact your Voxel51
-support team to have them create an appropriate `fiftyone.ai` DNS entry for you.
-
-#### Set up http to https Forwarding
-
-```shell
-kubectl apply -f frontend-config.yaml
-```
-
-For more information, see
-[HTTP to HTTPS redirects](https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-configuration#https_redirect).
-
-#### Install FiftyOne Enterprise App
-
-```shell
-kubectl create namespace fiftyone-teams
-kubectl config set-context --current --namespace fiftyone-teams
-kubectl create secret generic regcred \
+kubectl --namespace your-namespace-here create secret generic regcred \
   --from-file=.dockerconfigjson=./voxel51-docker.json \
   --type kubernetes.io/dockerconfigjson
+```
+
+> [!NOTE]
+> This chart uses `namespace.name` from your `values.yaml` to set the
+> namespace for all chart resources. The Helm `--namespace` flag alone does
+> **not** control where resources are created — see the chart's
+> [Usage](./fiftyone-teams-app/README.md#usage) section for the full
+> `namespace.name` configuration note.
+
+For the full list of available settings, see
+[Values](./fiftyone-teams-app/README.md#values).
+
+### Enable Dedicated Plugins (required)
+
+Dedicated plugins and delegated operators (below) share a common plugin
+directory backed by a Kubernetes PersistentVolume (PV) and
+PersistentVolumeClaim (PVC). If you do not already have shared storage
+configured, see
+[Adding Shared Storage for FiftyOne Enterprise Plugins](./docs/plugins-storage.md)
+before continuing.
+
+Add the following to your `values.yaml` to run plugins in a dedicated
+`teams-plugins` pod, isolated from `fiftyone-app`:
+
+```yaml
+pluginsSettings:
+  enabled: true
+  env:
+    FIFTYONE_PLUGINS_DIR: /opt/plugins
+
+# teams-api also requires access to the plugins directory
+apiSettings:
+  env:
+    FIFTYONE_PLUGINS_DIR: /opt/plugins
+```
+
+For full configuration options, see
+[Configuring Plugins](./docs/configuring-plugins.md).
+
+### Configure Delegated Operators (required)
+
+Delegated operators allow long-running or compute-heavy tasks (computing
+embeddings, model evaluation, dataset import, annotation workflows) to be
+scheduled from the FiftyOne UI and executed in the background. Choose the
+mode that fits your workload:
+
+| Mode                    | Use when                                                                                | Configuration                                   |
+| ----------------------- | --------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| **Always-On Workers**   | Steady or unpredictable delegated-operation volume; workers should be ready immediately | `delegatedOperatorDeployments` in `values.yaml` |
+| **On-Demand Executors** | Infrequent or GPU-heavy jobs; avoid paying for idle workers                             | Kubernetes Jobs spun up per run                 |
+
+For **Always-On Workers**, add the following to your `values.yaml`:
+
+```yaml
+delegatedOperatorDeployments:
+  deployments:
+    teamsDoCpuDefault:
+      enabled: true
+      env:
+        FIFTYONE_PLUGINS_DIR: /opt/plugins
+      volumes:
+        - name: plugins-vol
+          persistentVolumeClaim:
+            claimName: plugins-pvc
+            readOnly: true
+      volumeMounts:
+        - name: plugins-vol
+          mountPath: /opt/plugins
+```
+
+For **On-Demand Executors**, see
+[Configuring On-Demand Orchestrator](../docs/configuring-on-demand-orchestrator.md)
+for setup instructions.
+
+For full always-on delegated operator configuration options, see
+[Configuring Delegated Operators](./docs/configuring-delegated-operators.md).
+
+## :rocket: Step 5: Initial Deployment
+
+Add the Voxel51 Helm repository and install FiftyOne Enterprise:
+
+```shell
+helm repo add voxel51 https://helm.fiftyone.ai
+helm repo update voxel51
 helm install fiftyone-teams-app voxel51/fiftyone-teams-app \
-  --values ./values.yaml
+  --namespace your-namespace-here \
+  -f ./values.yaml
 ```
 
-Issuing SSL Certificates can take up to 15 minutes.
-Be patient while Let's Encrypt and GKE negotiate.
-
-You can verify that your SSL certificates have been
-properly issued with the following curl command:
+For upgrades, run:
 
 ```shell
-curl -I https://replace.this.dns.name
+helm repo update voxel51
+helm upgrade fiftyone-teams-app voxel51/fiftyone-teams-app \
+  --namespace your-namespace-here \
+  -f ./values.yaml
 ```
 
-Your SSL certificates have been correctly issued when
-you see `HTTP/2 200` at the top of the response.
-If, however, you encounter a
-`SSL certificate problem: unable to get local issuer certificate`
-message you should delete the certificate and allow it to recreate.
+> [!TIP]
+> Prior to running `helm upgrade`, you may view the changes Helm would apply
+> using the [helm diff](https://github.com/databus23/helm-diff) plugin
+> (Voxel51 is not affiliated with the author of this plugin):
+>
+> ```shell
+> helm diff --context 1 upgrade fiftyone-teams-app voxel51/fiftyone-teams-app -f values.yaml
+> ```
+
+Confirm all pods are running, including `teams-plugins` and your chosen
+delegated operator workers, both configured in
+[Step 4](#gear-step-4-configure-valuesyaml):
 
 ```shell
-kubectl delete secret fiftyone-teams-cert-secret
+kubectl get pods --namespace your-namespace-here
 ```
 
-Further instructions for debugging ACME certificates are on the
-[cert-manager docs site](https://cert-manager.io/docs/faq/acme/).
+## :globe_with_meridians: Step 6: Configure Ingress & TLS
 
-Once your installation is complete, browse to
-`/settings/cloud_storage_credentials`
-and add your storage credentials to access sample data.
+Next, configure an **Ingress controller** and **TLS termination** in front of
+your FiftyOne Enterprise services — for example, using
+[cert-manager](https://cert-manager.io/) with your cloud provider's ingress
+controller or load balancer.
 
-#### Installation Complete
+### :compass: Routing Overview (Path-Based Ingress)
 
-Congratulations! You should now be able to access your
-FiftyOne Enterprise installation at the DNS address you created
-[earlier](#obtain-a-global-static-ip-address-and-configure-a-dns-entry).
+| Path                 | Proxied To  | Description                          |
+| -------------------- | ----------- | ------------------------------------ |
+| `/`                  | `teams-app` | Main web UI                          |
+| `/cas`               | `teams-cas` | Central Authentication Service (CAS) |
+| `/cloud_credentials` | `teams-api` | Cloud credentials API endpoint       |
+| `/graphql/v1`        | `teams-api` | GraphQL API endpoint                 |
+| `/rpc`               | `teams-api` | RPC API endpoint                     |
+| `/file`              | `teams-api` | File import handling                 |
+| `/_pymongo`          | `teams-api` | MongoDB requests via SDK             |
+| `/health`            | `teams-api` | Health check endpoint                |
 
-## Recommended Next Steps
+### :memo: Notes
 
-The base `helm install` above starts FiftyOne Enterprise with
-**built-in only plugins** and **no delegated operator workers**.
-While sufficient to get started, we recommend enabling
-the following features for a production-ready deployment:
+- FiftyOne Enterprise supports routing traffic through proxy servers. Please
+  refer to the
+  [proxy configuration documentation](./docs/configuring-proxies.md) for
+  information on how to configure proxies.
+- To expose the `teams-api` for host-based routing, see
+  [Exposing the `teams-api`](./docs/expose-teams-api.md).
+- For a complete, cloud-specific worked example of ingress/TLS setup, see the
+  [GKE Deployment Guide](./docs/gke-deployment-guide.md) or the
+  [AWS Deployment Guide](./docs/aws-deployment-guide.md).
 
-| Step | What it enables |
+## :page_facing_up: Step 7: Configure Delegated Operation Logs
+
+Add the log path for delegated operation runs to your `values.yaml`:
+
+```yaml
+delegatedOperatorDeployments:
+  deployments:
+    teamsDoCpuDefault:
+      env:
+        FIFTYONE_DELEGATED_OPERATION_LOG_PATH: "gs://your-bucket/logs"
+```
+
+Logs are stored in the format:
+
+```text
+/mnt/shared/logs/do_logs/<YYYY>/<MM>/<DD>/<RUN_ID>.log
+```
+
+This is useful for auditing, debugging, or monitoring delegated operator
+executions in shared storage or cloud buckets.
+
+## Step 8: Identity Provider (IdP) and Authentication (CAS)
+
+FiftyOne Enterprise uses a Central Authentication Service (CAS), introduced
+in v1.6, for centralized login, roles, and user management. You chose your
+authentication mode in
+[Step 3](#file_folder-step-3-choose-authentication-mode).
+
+The CAS service requires the following in your `values.yaml`:
+
+- `secret.fiftyone.fiftyoneAuthSecret` (set in
+  [Step 4](#gear-step-4-configure-valuesyaml))
+- When using path-based routing, an ingress rule for `/cas` routed to
+  `teams-cas` (see
+  [Step 6](#globe_with_meridians-step-6-configure-ingress--tls))
+
+For more detail, see the chart's
+[Central Authentication Service](./fiftyone-teams-app/README.md#central-authentication-service)
+documentation and the
+[Pluggable Authentication](https://docs.voxel51.com/enterprise/pluggable_auth.html)
+docs.
+
+## Step 9: Initial CAS Setup
+
+1. Navigate to the CAS Super Admin UI at
+   `https://<ENVIRONMENT>.fiftyone.ai/cas/configurations`.
+1. In the **API Key** field (upper right corner), enter the value of
+   `secret.fiftyone.fiftyoneAuthSecret` (from your `values.yaml`).
+
+### Add First Admin User
+
+1. Navigate to the **Admins** tab at
+   `https://<ENVIRONMENT>.fiftyone.ai/cas/admins`.
+1. Select **Add admin**.
+1. Provide **Name** and **Email**.
+1. Select **Add**.
+
+### Enable Auto Join
+
+1. Navigate to `https://<ENVIRONMENT>.fiftyone.ai/cas/providers`.
+1. Select **+ Edit**.
+1. Select **Allow auto join**.
+1. Select **Save**.
+
+## Step 10: Test End User Login
+
+Verify the deployment's IdP setup by logging in as a regular user.
+
+1. In a browser, open `https://<ENVIRONMENT>.fiftyone.ai`.
+1. Log in with the user credentials of the admin you created in the CAS
+   Super Admin UI.
+1. Confirm you are redirected to the FiftyOne Enterprise home page.
+
+## :books: Full Worked Example
+
+The generic steps above apply to any Kubernetes cluster. For a complete,
+cloud-specific walkthrough that combines all of the steps above, see:
+
+- [GKE Deployment Guide](./docs/gke-deployment-guide.md)
+- [AWS Deployment Guide](./docs/aws-deployment-guide.md)
+
+## Recommended Enhancements
+
+With dedicated plugins and delegated operators configured in
+[Step 4](#gear-step-4-configure-valuesyaml), consider these additional
+enhancements for a production-ready deployment:
+
+| Enhancement | What it enables |
 | --- | --- |
-| **Dedicated Plugins** | Install and run custom plugins in an isolated `teams-plugins` pod, keeping plugin workloads separate from the main app |
-| **Delegated Operators** | Schedule compute-heavy tasks — embeddings, model evaluation, dataset import, annotation — from the UI and run them on dedicated background workers |
-| **On-Demand Orchestrator** | *(Optional)* Spin up Kubernetes pods on demand per job instead of maintaining always-on workers; more cost-efficient for infrequent or GPU-heavy workloads |
+| **GPU-Scheduled Workers** | *(Optional)* Schedule delegated operator pods on GPU-enabled nodes for compute-heavy tasks like embeddings or model evaluation |
+| **Multiple Orchestrators** | *(Optional)* Register separate CPU- and GPU-targeted delegated operator orchestrators for mixed workloads |
+| **Custom Job Priorities** | *(Advanced)* Use Kubernetes PriorityClasses with on-demand delegated operator Jobs |
 
 For step-by-step configuration instructions, see
 [Recommended Post-Installation Configuration](./docs/post-install-recommended-configuration.md).
+
+## Upgrades
+
+When performing an upgrade, please review
+[Upgrading From Previous Versions](./docs/upgrading.md).
+
+## Known Issues
+
+For a list of common issues and their solutions, refer to the
+[Known Issues documentation](./docs/known-issues.md).
+
+If you encounter a new issue, please open a ticket on the
+[GitHub Issues page](https://github.com/voxel51/fiftyone-teams-app-deploy/issues).
+
+## Advanced Configuration
+
+For backup and recovery, secrets management, GPU workloads, high
+availability, plugins, proxies, snapshot archival, storage credentials,
+static banners, Terms of Service URLs, text similarity, and workload identity
+federation, see the chart's
+[Advanced Configuration](./fiftyone-teams-app/README.md#advanced-configuration)
+documentation.
+
+## Validating
+
+After deploying FiftyOne Enterprise and configuring authentication, please
+follow
+[Validating Your Deployment](../docs/validating-deployment.md).
+
+## Health Checks and Monitoring
+
+See the chart's
+[Health Checks And Monitoring](./fiftyone-teams-app/README.md#health-checks-and-monitoring)
+documentation for basic health assessment and troubleshooting unhealthy pods.
+
+## Values
+
+For the full list of configurable `values.yaml` settings, see the chart's
+generated [Values](./fiftyone-teams-app/README.md#values) reference table.

--- a/helm/README.md
+++ b/helm/README.md
@@ -31,27 +31,28 @@ FiftyOne Enterprise.
 
 <!-- toc -->
 
-- [:open_file_folder: Directory Contents](#open_file_folder-directory-contents)
 - [:green_book: Prerequisites Skills and Knowledge](#green_book-prerequisites-skills-and-knowledge)
 - [:white_check_mark: Technical Requirements](#white_check_mark-technical-requirements)
+  - [Kubernetes Cluster And Kubectl](#kubernetes-cluster-and-kubectl)
+  - [Helm](#helm)
 - [:clock10: Estimated Completion Time](#clock10-estimated-completion-time)
 - [:floppy_disk: Sizing](#floppy_disk-sizing)
 - [:wrench: Step 1: Set Up MongoDB Database](#wrench-step-1-set-up-mongodb-database)
 - [:closed_lock_with_key: Step 2: Prepare License File](#closed_lock_with_key-step-2-prepare-license-file)
 - [:file_folder: Step 3: Choose Authentication Mode](#file_folder-step-3-choose-authentication-mode)
 - [:gear: Step 4: Configure `values.yaml`](#gear-step-4-configure-valuesyaml)
-  - [Enable Dedicated Plugins (required)](#enable-dedicated-plugins-required)
-  - [Configure Delegated Operators (required)](#configure-delegated-operators-required)
+  - [Create a Persistent Volume Claim for Shared Storage](#create-a-persistent-volume-claim-for-shared-storage)
+  - [Enable Dedicated Plugins Mode](#enable-dedicated-plugins-mode)
+  - [Choose Delegated Operator Compute](#choose-delegated-operator-compute)
 - [:rocket: Step 5: Initial Deployment](#rocket-step-5-initial-deployment)
 - [:globe_with_meridians: Step 6: Configure Ingress & TLS](#globe_with_meridians-step-6-configure-ingress--tls)
   - [:compass: Routing Overview (Path-Based Ingress)](#compass-routing-overview-path-based-ingress)
   - [:memo: Notes](#memo-notes)
-- [:page_facing_up: Step 7: Configure Delegated Operation Logs](#page_facing_up-step-7-configure-delegated-operation-logs)
-- [Step 8: Identity Provider (IdP) and Authentication (CAS)](#step-8-identity-provider-idp-and-authentication-cas)
-- [Step 9: Initial CAS Setup](#step-9-initial-cas-setup)
+- [Step 7: Identity Provider (IdP) and Authentication (CAS)](#step-7-identity-provider-idp-and-authentication-cas)
+- [Step 8: Initial CAS Setup](#step-8-initial-cas-setup)
   - [Add First Admin User](#add-first-admin-user)
   - [Enable Auto Join](#enable-auto-join)
-- [Step 10: Test End User Login](#step-10-test-end-user-login)
+- [Step 9: Test End User Login](#step-9-test-end-user-login)
 - [:books: Full Worked Example](#books-full-worked-example)
 - [Recommended Enhancements](#recommended-enhancements)
 - [Upgrades](#upgrades)
@@ -63,25 +64,6 @@ FiftyOne Enterprise.
 
 <!-- tocstop -->
 
-## :open_file_folder: Directory Contents
-
-This directory contains resources and information related to Helm deployments.
-
-- Directories
-  - `docs` contains additional documentation, including cloud-specific
-    deployment guides and configuration references.
-  - `fiftyone-teams-app` contains the Helm chart `voxel51/fiftyone-teams-app`.
-    For the full chart documentation (prerequisites, sizing, advanced
-    configuration, and the complete values reference), see
-    [`fiftyone-teams-app/README.md`](./fiftyone-teams-app/README.md).
-  - `gke-example` contains example Kubernetes resources used in the
-    [GKE Deployment Guide](./docs/gke-deployment-guide.md).
-  - `local-self-signed-example` contains resources for a local, self-signed
-    development setup.
-- Files
-  - `values.yaml` is an example of overrides for the chart's defaults for a
-    deployment.
-
 ## :green_book: Prerequisites Skills and Knowledge
 
 A successful, properly secured deployment of FiftyOne Enterprise requires
@@ -92,24 +74,66 @@ for the full list.
 
 ## :white_check_mark: Technical Requirements
 
-See the chart's
-[Technical Requirements](./fiftyone-teams-app/README.md#technical-requirements)
-for the full list of required tooling and versions (Kubernetes, `kubectl`,
-Helm, MongoDB, DNS, TLS/SSL, and optionally NFS/`ReadWriteMany` storage).
+The following technical requirements are required for a successful and
+properly secured deployment of FiftyOne Enterprise.
+
+1. [Kubernetes Cluster And Kubectl](#kubernetes-cluster-and-kubectl)
+
+1. [Helm](#helm)
+
+1. A MongoDB Database that meets FiftyOne's
+   [version constraints](https://docs.voxel51.com/user_guide/config.html#using-a-different-mongodb-version).
+
+1. A DNS record or records for ingress.
+
+1. A TLS/SSL certificate or certificates for HTTPS ingress.
+
+1. (optional) An NFS server or `ReadWriteMany` compatible storage medium for
+   [delegated operators](./fiftyone-teams-app/README.md#builtin-delegated-operator-orchestrator),
+   [plugins](./fiftyone-teams-app/README.md#plugins),
+   and
+   [API high-availability](./fiftyone-teams-app/README.md#highly-available-fiftyone-teams-api-deployments)
+
+### Kubernetes Cluster And Kubectl
+
+A kubernetes cluster and `kubectl` installation are required.
+The following kubernetes/kubectl versions are required:
+
+Kubernetes: `>=1.31-0`
+
+However, it is recommended to use a
+[supported kubernetes version](https://kubernetes.io/releases/).
+Please refer to the
+[kubernetes installation documentation](https://kubernetes.io/docs/tasks/tools/)
+for steps on installing kubernetes and kubectl.
+
+### Helm
+
+Helm version >= 3.14 is required.
+
+Please refer to the
+[helm installation documentation](https://helm.sh/docs/intro/install/)
+for steps on installing helm.
 
 ## :clock10: Estimated Completion Time
 
 The estimated time to deploy FiftyOne Enterprise is approximately 2 hours.
-See the chart's
-[Estimated Completion Time](./fiftyone-teams-app/README.md#estimated-completion-time)
-section for details.
 
 ## :floppy_disk: Sizing
 
-See the chart's
-[Sizing](./fiftyone-teams-app/README.md#sizing)
-recommendations for MongoDB, `fiftyone-app`, `teams-api`, `teams-app`,
-`teams-cas`, dedicated plugins, and delegated operator pods.
+Voxel51 recommends the following resource sizing:
+
+- MongoDB: 4 CPU, 16GB RAM, 256GB Storage
+- FiftyOne App: 1 CPU, 6GB RAM, 1GB Storage per pod
+- Teams API: 1 CPU, 2GB RAM, 1GB Storage per pod
+- Teams App: 500 mCPU, 512MB RAM, 512MB Storage per pod
+- Teams CAS: 500 mCPU, 512MB RAM, 512MB Storage per pod
+- Delegated Operators: 8 CPU, 16GB RAM, 1GB Storage per pod
+
+Voxel51 also recommends monitoring resource consumption across
+the applications.
+Resource usage varies dramatically with operations, use cases,
+and dataset sizes.
 
 ## :wrench: Step 1: Set Up MongoDB Database
 
@@ -223,14 +247,53 @@ kubectl --namespace your-namespace-here create secret generic regcred \
 For the full list of available settings, see
 [Values](./fiftyone-teams-app/README.md#values).
 
-### Enable Dedicated Plugins (required)
+### Create a Persistent Volume Claim for Shared Storage
 
 Dedicated plugins and delegated operators (below) share a common plugin
 directory backed by a Kubernetes PersistentVolume (PV) and
-PersistentVolumeClaim (PVC). If you do not already have shared storage
-configured, see
-[Adding Shared Storage for FiftyOne Enterprise Plugins](./docs/plugins-storage.md)
-before continuing.
+PersistentVolumeClaim (PVC).
+
+```yaml
+# teams-plugins-pv-pvc.yaml
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: teams-plugins-pv
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteMany
+    - ReadOnlyMany
+  nfs:
+    server: nfs-server
+    path: "/fiftyone_teams_app/plugins"
+
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: teams-plugins-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+    - ReadOnlyMany
+  storageClassName: ""
+  resources:
+    requests:
+      storage: 10Gi
+```
+
+```shell
+kubectl apply -f teams-plugins-pv-pvc.yaml
+```
+
+For NFS export configuration and cloud-provider alternatives (Google
+Filestore, AWS EFS, Azure Files), see
+[Adding Shared Storage for FiftyOne Enterprise Plugins](./docs/plugins-storage.md).
+
+### Enable Dedicated Plugins Mode
 
 Add the following to your `values.yaml` to run plugins in a dedicated
 `teams-plugins` pod, isolated from `fiftyone-app`:
@@ -240,17 +303,32 @@ pluginsSettings:
   enabled: true
   env:
     FIFTYONE_PLUGINS_DIR: /opt/plugins
+  volumes:
+    - name: plugins-vol
+      persistentVolumeClaim:
+        claimName: teams-plugins-pvc
+        readOnly: true
+  volumeMounts:
+    - name: plugins-vol
+      mountPath: /opt/plugins
 
-# teams-api also requires access to the plugins directory
+# teams-api also requires read-write access to the plugins directory
 apiSettings:
   env:
     FIFTYONE_PLUGINS_DIR: /opt/plugins
+  volumes:
+    - name: plugins-vol
+      persistentVolumeClaim:
+        claimName: teams-plugins-pvc
+  volumeMounts:
+    - name: plugins-vol
+      mountPath: /opt/plugins
 ```
 
 For full configuration options, see
 [Configuring Plugins](./docs/configuring-plugins.md).
 
-### Configure Delegated Operators (required)
+### Choose Delegated Operator Compute
 
 Delegated operators allow long-running or compute-heavy tasks (computing
 embeddings, model evaluation, dataset import, annotation workflows) to be
@@ -274,7 +352,7 @@ delegatedOperatorDeployments:
       volumes:
         - name: plugins-vol
           persistentVolumeClaim:
-            claimName: plugins-pvc
+            claimName: teams-plugins-pvc
             readOnly: true
       volumeMounts:
         - name: plugins-vol
@@ -358,28 +436,7 @@ controller or load balancer.
   [GKE Deployment Guide](./docs/gke-deployment-guide.md) or the
   [AWS Deployment Guide](./docs/aws-deployment-guide.md).
 
-## :page_facing_up: Step 7: Configure Delegated Operation Logs
-
-Add the log path for delegated operation runs to your `values.yaml`:
-
-```yaml
-delegatedOperatorDeployments:
-  deployments:
-    teamsDoCpuDefault:
-      env:
-        FIFTYONE_DELEGATED_OPERATION_LOG_PATH: "gs://your-bucket/logs"
-```
-
-Logs are stored in the format:
-
-```text
-/mnt/shared/logs/do_logs/<YYYY>/<MM>/<DD>/<RUN_ID>.log
-```
-
-This is useful for auditing, debugging, or monitoring delegated operator
-executions in shared storage or cloud buckets.
-
-## Step 8: Identity Provider (IdP) and Authentication (CAS)
+## Step 7: Identity Provider (IdP) and Authentication (CAS)
 
 FiftyOne Enterprise uses a Central Authentication Service (CAS), introduced
 in v1.6, for centralized login, roles, and user management. You chose your
@@ -400,7 +457,7 @@ documentation and the
 [Pluggable Authentication](https://docs.voxel51.com/enterprise/pluggable_auth.html)
 docs.
 
-## Step 9: Initial CAS Setup
+## Step 8: Initial CAS Setup
 
 1. Navigate to the CAS Super Admin UI at
    `https://<ENVIRONMENT>.fiftyone.ai/cas/configurations`.
@@ -422,7 +479,7 @@ docs.
 1. Select **Allow auto join**.
 1. Select **Save**.
 
-## Step 10: Test End User Login
+## Step 9: Test End User Login
 
 Verify the deployment's IdP setup by logging in as a regular user.
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -328,35 +328,35 @@ embeddings, model evaluation, dataset import, annotation workflows) to be
 scheduled from the FiftyOne UI and executed in the background. Choose the
 mode that fits your workload:
 
-| Mode                    | Use when                                                                                | Configuration                                   |
-| ----------------------- | --------------------------------------------------------------------------------------- | ----------------------------------------------- |
-| **Always-On Workers**   | Steady or unpredictable delegated-operation volume; workers should be ready immediately | `delegatedOperatorDeployments` in `values.yaml` |
-| **On-Demand Executors** | Infrequent or GPU-heavy jobs; avoid paying for idle workers                             | Kubernetes Jobs spun up per run                 |
+| Mode                    | Use when                                                                                |
+| ----------------------- | --------------------------------------------------------------------------------------- |
+| **Always-On Workers**   | Steady or unpredictable delegated-operation volume; workers should be ready immediately |
+| **On-Demand Executors** | Infrequent or GPU-heavy jobs; avoid paying for idle workers                             |
 
-For **Always-On Workers**, add the following to your `values.yaml`:
+FiftyOne Enterprise 2.14+ pre-populates a `teams-do-cpu-default` delegated
+operator `Deployment` by default. Enable **Always-On Workers** by setting
+`delegatedOperatorDeployments.deployments.teamsDoCpuDefault.enabled` to
+`true` in your `values.yaml`:
 
 ```yaml
 delegatedOperatorDeployments:
   deployments:
     teamsDoCpuDefault:
       enabled: true
-      env:
-        FIFTYONE_PLUGINS_DIR: /opt/plugins
-      volumes:
-        - name: plugins-vol
-          persistentVolumeClaim:
-            claimName: teams-plugins-pvc
-            readOnly: true
-      volumeMounts:
-        - name: plugins-vol
-          mountPath: /opt/plugins
 ```
+
+To run always-on **GPU-enabled** workers instead of CPU workers, see
+[Leveraging GPU Workloads](./docs/configuring-gpu-workloads.md):
+
+- [AWS EKS](./docs/configuring-gpu-workloads.md#deploying-gpu-enabled-delegated-operator-pods-2)
+- [GKE](./docs/configuring-gpu-workloads.md#deploying-gpu-enabled-delegated-operator-pods)
+- [Azure AKS](./docs/configuring-gpu-workloads.md#deploying-gpu-enabled-delegated-operator-pods-1)
 
 For **On-Demand Executors**, see
 [Configuring On-Demand Orchestrator](../docs/configuring-on-demand-orchestrator.md)
 for setup instructions.
 
-For full always-on delegated operator configuration options, see
+For full delegated operator configuration options, see
 [Configuring Delegated Operators](./docs/configuring-delegated-operators.md).
 
 ## :rocket: Step 8: Initial Deployment

--- a/helm/README.md
+++ b/helm/README.md
@@ -52,11 +52,8 @@ FiftyOne Enterprise.
   - [Enable Auto Join](#enable-auto-join)
 - [Step 12: Test End User Login](#step-12-test-end-user-login)
 - [Recommended Enhancements](#recommended-enhancements)
-  - [:desktop_computer: GPU-Scheduled Workers](#desktop_computer-gpu-scheduled-workers)
   - [:label: Agentic Labeling](#label-agentic-labeling)
   - [:bricks: Custom Plugin Images](#bricks-custom-plugin-images)
-  - [:on: Multiple Orchestrators](#on-multiple-orchestrators)
-  - [:clipboard: Custom Job Priorities](#clipboard-custom-job-priorities)
 - [Upgrades](#upgrades)
 - [Known Issues](#known-issues)
 - [Advanced Configuration](#advanced-configuration)
@@ -491,17 +488,11 @@ With dedicated plugins and delegated operators configured in
 [Step 7](#robot-step-7-configure-delegated-operators), consider these
 additional enhancements for a production-ready deployment.
 
-### :desktop_computer: GPU-Scheduled Workers
-
-*(Optional)* Schedule delegated operator pods on GPU-enabled nodes for
-compute-heavy tasks like embeddings or model evaluation. See
-[Leveraging GPU Workloads](./docs/configuring-gpu-workloads.md).
-
 ### :label: Agentic Labeling
 
 Run the builtin Agentic Labeler service (few-shot VLM inference via vLLM) on
 a dedicated GPU delegated-operator worker (see
-[GPU-Scheduled Workers](#desktop_computer-gpu-scheduled-workers) above), then
+[Leveraging GPU Workloads](./docs/configuring-gpu-workloads.md)), then
 start it from the FiftyOne Enterprise UI under `Settings -> Services`. For an
 overview of builtin services and the service orchestrator, see the
 [service orchestrator documentation](../docs/configuring-service-orchestrator.md).
@@ -526,18 +517,6 @@ delegatedOperatorDeployments:
         repository: fiftyone-cv-full-custom
         tag: v2.19.0
 ```
-
-### :on: Multiple Orchestrators
-
-*(Optional)* Register separate CPU- and GPU-targeted delegated operator
-orchestrators for mixed workloads. See
-[Configuring Delegated Operators](./docs/configuring-delegated-operators.md).
-
-### :clipboard: Custom Job Priorities
-
-*(Advanced)* Use Kubernetes PriorityClasses with on-demand delegated operator
-Jobs. See
-[Configuring the Kubernetes On-Demand Orchestrator](../docs/orchestrators/configuring-kubernetes-orchestrator.md).
 
 For step-by-step configuration instructions, see
 [Recommended Post-Installation Configuration](./docs/post-install-recommended-configuration.md).

--- a/helm/README.md
+++ b/helm/README.md
@@ -52,6 +52,11 @@ FiftyOne Enterprise.
   - [Enable Auto Join](#enable-auto-join)
 - [Step 12: Test End User Login](#step-12-test-end-user-login)
 - [Recommended Enhancements](#recommended-enhancements)
+  - [:desktop_computer: GPU-Scheduled Workers](#desktop_computer-gpu-scheduled-workers)
+  - [:label: Agentic Labeling](#label-agentic-labeling)
+  - [:bricks: Custom Plugin Images](#bricks-custom-plugin-images)
+  - [:on: Multiple Orchestrators](#on-multiple-orchestrators)
+  - [:clipboard: Custom Job Priorities](#clipboard-custom-job-priorities)
 - [Upgrades](#upgrades)
 - [Known Issues](#known-issues)
 - [Advanced Configuration](#advanced-configuration)
@@ -484,13 +489,55 @@ Verify the deployment's IdP setup by logging in as a regular user.
 With dedicated plugins and delegated operators configured in
 [Step 6](#jigsaw-step-6-enable-dedicated-plugins-mode) and
 [Step 7](#robot-step-7-configure-delegated-operators), consider these
-additional enhancements for a production-ready deployment:
+additional enhancements for a production-ready deployment.
 
-| Enhancement | What it enables |
-| --- | --- |
-| **GPU-Scheduled Workers** | *(Optional)* Schedule delegated operator pods on GPU-enabled nodes for compute-heavy tasks like embeddings or model evaluation |
-| **Multiple Orchestrators** | *(Optional)* Register separate CPU- and GPU-targeted delegated operator orchestrators for mixed workloads |
-| **Custom Job Priorities** | *(Advanced)* Use Kubernetes PriorityClasses with on-demand delegated operator Jobs |
+### :desktop_computer: GPU-Scheduled Workers
+
+*(Optional)* Schedule delegated operator pods on GPU-enabled nodes for
+compute-heavy tasks like embeddings or model evaluation. See
+[Leveraging GPU Workloads](./docs/configuring-gpu-workloads.md).
+
+### :label: Agentic Labeling
+
+Run the builtin Agentic Labeler service (few-shot VLM inference via vLLM) on
+a dedicated GPU delegated-operator worker (see
+[GPU-Scheduled Workers](#desktop_computer-gpu-scheduled-workers) above), then
+start it from the FiftyOne Enterprise UI under `Settings -> Services`. For an
+overview of builtin services and the service orchestrator, see the
+[service orchestrator documentation](../docs/configuring-service-orchestrator.md).
+
+### :bricks: Custom Plugin Images
+
+If your delegated operators or plugins require **custom dependencies**, build
+and deploy **custom plugin images**.
+Use `voxel51/fiftyone-teams-cv-full` as the base image
+(that includes a full CV/ML environment), and extend with:
+
+- Custom Python packages
+- Internal SDKs or models
+
+Once built, reference your custom image in `values.yaml`:
+
+```yaml
+delegatedOperatorDeployments:
+  deployments:
+    teamsDoCpuDefault:
+      image:
+        repository: fiftyone-cv-full-custom
+        tag: v2.19.0
+```
+
+### :on: Multiple Orchestrators
+
+*(Optional)* Register separate CPU- and GPU-targeted delegated operator
+orchestrators for mixed workloads. See
+[Configuring Delegated Operators](./docs/configuring-delegated-operators.md).
+
+### :clipboard: Custom Job Priorities
+
+*(Advanced)* Use Kubernetes PriorityClasses with on-demand delegated operator
+Jobs. See
+[Configuring the Kubernetes On-Demand Orchestrator](../docs/orchestrators/configuring-kubernetes-orchestrator.md).
 
 For step-by-step configuration instructions, see
 [Recommended Post-Installation Configuration](./docs/post-install-recommended-configuration.md).

--- a/helm/README.md
+++ b/helm/README.md
@@ -41,19 +41,18 @@ FiftyOne Enterprise.
 - [:closed_lock_with_key: Step 2: Prepare License File](#closed_lock_with_key-step-2-prepare-license-file)
 - [:file_folder: Step 3: Choose Authentication Mode](#file_folder-step-3-choose-authentication-mode)
 - [:gear: Step 4: Configure `values.yaml`](#gear-step-4-configure-valuesyaml)
-  - [Create a Persistent Volume Claim for Shared Storage](#create-a-persistent-volume-claim-for-shared-storage)
-  - [Enable Dedicated Plugins Mode](#enable-dedicated-plugins-mode)
-  - [Choose Delegated Operator Compute](#choose-delegated-operator-compute)
-- [:rocket: Step 5: Initial Deployment](#rocket-step-5-initial-deployment)
-- [:globe_with_meridians: Step 6: Configure Ingress & TLS](#globe_with_meridians-step-6-configure-ingress--tls)
+- [:file_cabinet: Step 5: Enable Shared Storage](#file_cabinet-step-5-enable-shared-storage)
+- [:jigsaw: Step 6: Enable Dedicated Plugins Mode](#jigsaw-step-6-enable-dedicated-plugins-mode)
+- [:robot: Step 7: Configure Delegated Operators](#robot-step-7-configure-delegated-operators)
+- [:rocket: Step 8: Initial Deployment](#rocket-step-8-initial-deployment)
+- [:globe_with_meridians: Step 9: Configure Ingress & TLS](#globe_with_meridians-step-9-configure-ingress--tls)
   - [:compass: Routing Overview (Path-Based Ingress)](#compass-routing-overview-path-based-ingress)
   - [:memo: Notes](#memo-notes)
-- [Step 7: Identity Provider (IdP) and Authentication (CAS)](#step-7-identity-provider-idp-and-authentication-cas)
-- [Step 8: Initial CAS Setup](#step-8-initial-cas-setup)
+- [Step 10: Identity Provider (IdP) and Authentication (CAS)](#step-10-identity-provider-idp-and-authentication-cas)
+- [Step 11: Initial CAS Setup](#step-11-initial-cas-setup)
   - [Add First Admin User](#add-first-admin-user)
   - [Enable Auto Join](#enable-auto-join)
-- [Step 9: Test End User Login](#step-9-test-end-user-login)
-- [:books: Full Worked Example](#books-full-worked-example)
+- [Step 12: Test End User Login](#step-12-test-end-user-login)
 - [Recommended Enhancements](#recommended-enhancements)
 - [Upgrades](#upgrades)
 - [Known Issues](#known-issues)
@@ -247,7 +246,7 @@ kubectl --namespace your-namespace-here create secret generic regcred \
 For the full list of available settings, see
 [Values](./fiftyone-teams-app/README.md#values).
 
-### Create a Persistent Volume Claim for Shared Storage
+## :file_cabinet: Step 5: Enable Shared Storage
 
 Dedicated plugins and delegated operators (below) share a common plugin
 directory backed by a Kubernetes PersistentVolume (PV) and
@@ -293,7 +292,7 @@ For NFS export configuration and cloud-provider alternatives (Google
 Filestore, AWS EFS, Azure Files), see
 [Adding Shared Storage for FiftyOne Enterprise Plugins](./docs/plugins-storage.md).
 
-### Enable Dedicated Plugins Mode
+## :jigsaw: Step 6: Enable Dedicated Plugins Mode
 
 Add the following to your `values.yaml` to run plugins in a dedicated
 `teams-plugins` pod, isolated from `fiftyone-app`:
@@ -328,7 +327,7 @@ apiSettings:
 For full configuration options, see
 [Configuring Plugins](./docs/configuring-plugins.md).
 
-### Choose Delegated Operator Compute
+## :robot: Step 7: Configure Delegated Operators
 
 Delegated operators allow long-running or compute-heavy tasks (computing
 embeddings, model evaluation, dataset import, annotation workflows) to be
@@ -366,7 +365,7 @@ for setup instructions.
 For full always-on delegated operator configuration options, see
 [Configuring Delegated Operators](./docs/configuring-delegated-operators.md).
 
-## :rocket: Step 5: Initial Deployment
+## :rocket: Step 8: Initial Deployment
 
 Add the Voxel51 Helm repository and install FiftyOne Enterprise:
 
@@ -396,15 +395,16 @@ helm upgrade fiftyone-teams-app voxel51/fiftyone-teams-app \
 > helm diff --context 1 upgrade fiftyone-teams-app voxel51/fiftyone-teams-app -f values.yaml
 > ```
 
-Confirm all pods are running, including `teams-plugins` and your chosen
-delegated operator workers, both configured in
-[Step 4](#gear-step-4-configure-valuesyaml):
+Confirm all pods are running, including `teams-plugins` (from
+[Step 6](#jigsaw-step-6-enable-dedicated-plugins-mode)) and your chosen
+delegated operator workers (from
+[Step 7](#robot-step-7-configure-delegated-operators)):
 
 ```shell
 kubectl get pods --namespace your-namespace-here
 ```
 
-## :globe_with_meridians: Step 6: Configure Ingress & TLS
+## :globe_with_meridians: Step 9: Configure Ingress & TLS
 
 Next, configure an **Ingress controller** and **TLS termination** in front of
 your FiftyOne Enterprise services — for example, using
@@ -436,7 +436,7 @@ controller or load balancer.
   [GKE Deployment Guide](./docs/gke-deployment-guide.md) or the
   [AWS Deployment Guide](./docs/aws-deployment-guide.md).
 
-## Step 7: Identity Provider (IdP) and Authentication (CAS)
+## Step 10: Identity Provider (IdP) and Authentication (CAS)
 
 FiftyOne Enterprise uses a Central Authentication Service (CAS), introduced
 in v1.6, for centralized login, roles, and user management. You chose your
@@ -449,7 +449,7 @@ The CAS service requires the following in your `values.yaml`:
   [Step 4](#gear-step-4-configure-valuesyaml))
 - When using path-based routing, an ingress rule for `/cas` routed to
   `teams-cas` (see
-  [Step 6](#globe_with_meridians-step-6-configure-ingress--tls))
+  [Step 9](#globe_with_meridians-step-9-configure-ingress--tls))
 
 For more detail, see the chart's
 [Central Authentication Service](./fiftyone-teams-app/README.md#central-authentication-service)
@@ -457,7 +457,7 @@ documentation and the
 [Pluggable Authentication](https://docs.voxel51.com/enterprise/pluggable_auth.html)
 docs.
 
-## Step 8: Initial CAS Setup
+## Step 11: Initial CAS Setup
 
 1. Navigate to the CAS Super Admin UI at
    `https://<ENVIRONMENT>.fiftyone.ai/cas/configurations`.
@@ -479,7 +479,7 @@ docs.
 1. Select **Allow auto join**.
 1. Select **Save**.
 
-## Step 9: Test End User Login
+## Step 12: Test End User Login
 
 Verify the deployment's IdP setup by logging in as a regular user.
 
@@ -488,19 +488,12 @@ Verify the deployment's IdP setup by logging in as a regular user.
    Super Admin UI.
 1. Confirm you are redirected to the FiftyOne Enterprise home page.
 
-## :books: Full Worked Example
-
-The generic steps above apply to any Kubernetes cluster. For a complete,
-cloud-specific walkthrough that combines all of the steps above, see:
-
-- [GKE Deployment Guide](./docs/gke-deployment-guide.md)
-- [AWS Deployment Guide](./docs/aws-deployment-guide.md)
-
 ## Recommended Enhancements
 
 With dedicated plugins and delegated operators configured in
-[Step 4](#gear-step-4-configure-valuesyaml), consider these additional
-enhancements for a production-ready deployment:
+[Step 6](#jigsaw-step-6-enable-dedicated-plugins-mode) and
+[Step 7](#robot-step-7-configure-delegated-operators), consider these
+additional enhancements for a production-ready deployment:
 
 | Enhancement | What it enables |
 | --- | --- |

--- a/helm/README.md
+++ b/helm/README.md
@@ -356,9 +356,6 @@ For **On-Demand Executors**, see
 [Configuring the Kubernetes On-Demand Orchestrator](../docs/orchestrators/configuring-kubernetes-orchestrator.md)
 for setup instructions.
 
-For full delegated operator configuration options, see
-[Configuring Delegated Operators](./docs/configuring-delegated-operators.md).
-
 ## :rocket: Step 8: Initial Deployment
 
 Add the Voxel51 Helm repository and install FiftyOne Enterprise:

--- a/helm/README.md
+++ b/helm/README.md
@@ -353,7 +353,7 @@ To run always-on **GPU-enabled** workers instead of CPU workers, see
 - [Azure AKS](./docs/configuring-gpu-workloads.md#deploying-gpu-enabled-delegated-operator-pods-1)
 
 For **On-Demand Executors**, see
-[Configuring On-Demand Orchestrator](../docs/configuring-on-demand-orchestrator.md)
+[Configuring the Kubernetes On-Demand Orchestrator](../docs/orchestrators/configuring-kubernetes-orchestrator.md)
 for setup instructions.
 
 For full delegated operator configuration options, see

--- a/helm/docs/gke-deployment-guide.md
+++ b/helm/docs/gke-deployment-guide.md
@@ -233,6 +233,6 @@ FiftyOne Enterprise installation at the DNS address you created
 
 Next, continue with the remaining steps in the
 [Helm README](../README.md), starting from
-[Step 7: Configure Delegated Operation Logs](../README.md#page_facing_up-step-7-configure-delegated-operation-logs)
+[Step 7: Identity Provider (IdP) and Authentication (CAS)](../README.md#step-7-identity-provider-idp-and-authentication-cas)
 (ingress/TLS is already handled by this guide),
 to finish setting up authentication and CAS.

--- a/helm/docs/gke-deployment-guide.md
+++ b/helm/docs/gke-deployment-guide.md
@@ -1,0 +1,238 @@
+<!-- markdownlint-disable no-inline-html line-length -->
+<!-- markdownlint-disable-next-line first-line-heading -->
+<div align="center">
+<p align="center">
+
+<img alt="Voxel51 Logo" src="https://user-images.githubusercontent.com/25985824/106288517-2422e000-6216-11eb-871d-26ad2e7b1e59.png" height="55px"> &nbsp;
+<img alt="Voxel51 FiftyOne" src="https://user-images.githubusercontent.com/25985824/106288518-24bb7680-6216-11eb-8f10-60052c519586.png" height="50px">
+
+</p>
+</div>
+<!-- markdownlint-enable no-inline-html line-length -->
+
+---
+
+# GKE Deployment Guide
+
+<!-- toc -->
+
+- [Introduction](#introduction)
+- [Prerequisites](#prerequisites)
+- [Download the Example Configuration Files](#download-the-example-configuration-files)
+- [Create the Necessary Helm Repos](#create-the-necessary-helm-repos)
+- [Install and Configure cert-manager](#install-and-configure-cert-manager)
+  - [Create a ClusterIssuer](#create-a-clusterissuer)
+- [Install and Configure MongoDB](#install-and-configure-mongodb)
+- [Obtain a Global Static IP Address and Configure a DNS Entry](#obtain-a-global-static-ip-address-and-configure-a-dns-entry)
+- [Set up HTTP to HTTPS Forwarding](#set-up-http-to-https-forwarding)
+- [Install FiftyOne Enterprise App](#install-fiftyone-enterprise-app)
+- [Installation Complete](#installation-complete)
+
+<!-- tocstop -->
+
+## Introduction
+
+This guide walks through a full Google Kubernetes Engine [GKE] deployment of
+FiftyOne Enterprise combining the following Helm charts:
+
+- [jetstack/cert-manager](https://github.com/cert-manager/cert-manager)
+  - For Let's Encrypt SSL certificates
+- [mongodb/community-operator](https://github.com/mongodb/helm-charts/tree/main/charts/community-operator)
+  - for MongoDB
+- voxel51/fiftyone-teams-app
+
+This guide is a complete, cloud-specific worked example of the generic steps
+in the [Helm README](../README.md). If you are deploying to AWS EKS instead,
+see the [AWS Deployment Guide](./aws-deployment-guide.md).
+
+## Prerequisites
+
+These instructions assume you have
+
+- These tools installed and operating
+  - [kubectl](https://kubernetes.io/docs/tasks/tools/)
+  - [Helm](https://helm.sh/docs/intro/install/)
+- An existing
+  [GKE Cluster available](https://cloud.google.com/kubernetes-engine/docs/concepts/kubernetes-engine-overview)
+- Received Docker Hub credentials from Voxel51
+  - Have `voxel51-docker.json` file in the current directory
+    - If `voxel51-docker.json` is not in the current directory,
+      please update the command line accordingly.
+- Your license file from the Voxel51 Customer Success Team
+  - If you have not received this information, please contact your
+    Voxel51 Support Team via your agreed-upon mechanism (Slack, email, etc.)
+
+> **NOTE**: Anytime a license file secret is updated, you
+> must restart the `teams-cas` and `teams-api` services.
+> You may delete the pods, or run
+>
+> ```shell
+> kubectl rollout restart deploy \
+>   -n your-namespace \
+>   teams-cas \
+>   teams-api
+> ```
+
+## Download the Example Configuration Files
+
+Download the example configuration files from the
+[voxel51/fiftyone-teams-app-deploy](https://github.com/voxel51/fiftyone-teams-app-deploy/tree/main/helm/gke-example)
+GitHub repository.
+
+For example
+
+```shell
+curl -o values.yaml \
+  https://raw.githubusercontent.com/voxel51/fiftyone-teams-app-deploy/main/helm/gke-example/values.yaml
+curl -o cluster-issuer.yaml \
+  https://raw.githubusercontent.com/voxel51/fiftyone-teams-app-deploy/main/helm/gke-example/cluster-issuer.yaml
+curl -o frontend-config.yaml \
+  https://github.com/voxel51/fiftyone-teams-app-deploy/blob/main/helm/gke-example/frontend-config.yaml
+```
+
+Update the `values.yaml` file with
+
+- In `secret.fiftyone`
+  - MongoDB
+    - Set `mongodbConnectionString` containing your MongoDB username and password
+  - Set `cookieSecret`
+  - Set `encryptionKey`
+  - Set `fiftyoneAuthSecret`
+- In `teamsAppSettings.dnsName`
+  - Set ingress `host` values
+
+Assuming you follow these directions your MongoDB host will be
+`fiftyone-teams-mongodb.fiftyone-teams-mongodb.svc.cluster.local`.
+<!-- Please modify this hostname if you modify these instructions. -->
+
+## Create the Necessary Helm Repos
+
+Add the Helm repositories
+
+```shell
+helm repo add mongodb https://mongodb.github.io/helm-charts
+helm repo add jetstack https://charts.jetstack.io
+helm repo add voxel51 https://helm.fiftyone.ai
+helm repo update
+```
+
+## Install and Configure cert-manager
+
+If you are using a GKE Autopilot cluster, please review the information
+[provided by cert-manager](https://github.com/cert-manager/cert-manager/issues/3717#issuecomment-919299192)
+and adjust your installation accordingly.
+
+```shell
+kubectl create namespace cert-manager
+kubectl config set-context --current --namespace cert-manager
+helm install cert-manager jetstack/cert-manager --set installCRDs=true
+```
+
+You can use the cert-manager instructions to
+[verify the cert-manager Installation](https://cert-manager.io/v1.4-docs/installation/verify/).
+
+### Create a ClusterIssuer
+
+`ClusterIssuers` are Kubernetes resources that represent certificate authorities
+that are able to generate signed certificates by honoring certificate signing requests.
+You must create either an `Issuer` in each namespace or a `ClusterIssuer`
+as part of your cert-manager configuration.
+Voxel51 has provided an example `ClusterIssuer` configuration (downloaded
+[earlier](#download-the-example-configuration-files)
+in this guide).
+
+```shell
+kubectl apply -f ./cluster-issuer.yaml
+```
+
+## Install and Configure MongoDB
+
+These
+[instructions](https://github.com/mongodb/helm-charts/tree/main/charts/community-operator#deploying-a-mongodb-replica-set)
+can be used to deploy a MongoDB replicaset in your GKE cluster.
+
+Wait until the MongoDB pods are in the `Ready` state before
+beginning the "Install FiftyOne Enterprise App" instructions.
+
+While waiting,
+[configure a DNS entry](#obtain-a-global-static-ip-address-and-configure-a-dns-entry).
+
+To determine the state of the `fiftyone-teams-mongodb` pods, run
+
+```shell
+kubectl get pods
+```
+
+## Obtain a Global Static IP Address and Configure a DNS Entry
+
+Reserve a global static IP address for use in your cluster:
+
+```shell
+gcloud compute addresses create \
+  fiftyone-teams-static-ip --global --ip-version IPV4
+gcloud compute addresses describe \
+  fiftyone-teams-static-ip --global
+```
+
+Record the IP address and either create a DNS entry or contact your Voxel51
+support team to have them create an appropriate `fiftyone.ai` DNS entry for you.
+
+## Set up HTTP to HTTPS Forwarding
+
+```shell
+kubectl apply -f frontend-config.yaml
+```
+
+For more information, see
+[HTTP to HTTPS redirects](https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-configuration#https_redirect).
+
+## Install FiftyOne Enterprise App
+
+```shell
+kubectl create namespace fiftyone-teams
+kubectl config set-context --current --namespace fiftyone-teams
+kubectl create secret generic regcred \
+  --from-file=.dockerconfigjson=./voxel51-docker.json \
+  --type kubernetes.io/dockerconfigjson
+helm install fiftyone-teams-app voxel51/fiftyone-teams-app \
+  --values ./values.yaml
+```
+
+Issuing SSL Certificates can take up to 15 minutes.
+Be patient while Let's Encrypt and GKE negotiate.
+
+You can verify that your SSL certificates have been
+properly issued with the following curl command:
+
+```shell
+curl -I https://replace.this.dns.name
+```
+
+Your SSL certificates have been correctly issued when
+you see `HTTP/2 200` at the top of the response.
+If, however, you encounter a
+`SSL certificate problem: unable to get local issuer certificate`
+message you should delete the certificate and allow it to recreate.
+
+```shell
+kubectl delete secret fiftyone-teams-cert-secret
+```
+
+Further instructions for debugging ACME certificates are on the
+[cert-manager docs site](https://cert-manager.io/docs/faq/acme/).
+
+Once your installation is complete, browse to
+`/settings/cloud_storage_credentials`
+and add your storage credentials to access sample data.
+
+## Installation Complete
+
+Congratulations! You should now be able to access your
+FiftyOne Enterprise installation at the DNS address you created
+[earlier](#obtain-a-global-static-ip-address-and-configure-a-dns-entry).
+
+Next, continue with the remaining steps in the
+[Helm README](../README.md), starting from
+[Step 7: Configure Delegated Operation Logs](../README.md#page_facing_up-step-7-configure-delegated-operation-logs)
+(ingress/TLS is already handled by this guide),
+to finish setting up authentication and CAS.

--- a/helm/docs/gke-deployment-guide.md
+++ b/helm/docs/gke-deployment-guide.md
@@ -233,6 +233,6 @@ FiftyOne Enterprise installation at the DNS address you created
 
 Next, continue with the remaining steps in the
 [Helm README](../README.md), starting from
-[Step 7: Identity Provider (IdP) and Authentication (CAS)](../README.md#step-7-identity-provider-idp-and-authentication-cas)
+[Step 10: Identity Provider (IdP) and Authentication (CAS)](../README.md#step-10-identity-provider-idp-and-authentication-cas)
 (ingress/TLS is already handled by this guide),
 to finish setting up authentication and CAS.


### PR DESCRIPTION
## Summary
- Rewrites `helm/README.md` as a step-by-step tutorial, mirroring the structure and tone of `docker/README.md`
- Promotes shared storage, plugins, and Delegated Operators to their own top-level steps; simplifies DO setup and links On-Demand Executors to the k8s orchestrator doc
- Adds `helm/docs/gke-deployment-guide.md` and wires it into pre-commit doc linting
- Incorporates review feedback (trims TOC subheadings, drops redundant lines, reformats Recommended Enhancements to match docker's Advanced DO Settings)

## Test plan
- [ ] Read through `helm/README.md` end-to-end for a fresh GKE deploy and confirm steps are accurate and in order
- [ ] Verify all internal links (k8s orchestrator doc, gke-deployment-guide.md, etc.) resolve
- [ ] Confirm pre-commit doc linting passes on the new gke-deployment-guide.md